### PR TITLE
feat: expand editor asset workflow and project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Horo Engine
+
+Horo Engine (current CMake target: `MonolithEngine`) is a C++20 game engine/static library with:
+
+- scene + ECS primitives
+- renderer / camera / debug draw
+- physics systems
+- in-game editor overlay
+- scene serialization
+- project-local engine configuration via `engine.config.toml`
+
+## What's new in this branch
+
+- editor asset registry panel
+- place registered assets directly into the map
+- bind scene objects to registered assets
+- richer object editing in the properties panel
+- `engine.config.toml` support for project-local engine settings
+- integration documentation for embedding the engine into another CMake project
+
+## Build
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+## Editor workflow
+
+The editor now has three key panels:
+
+- **Objects**: lists placed scene objects
+- **Assets**: lists project assets registered in the current scene document
+- **Properties**: edits transform, asset binding, and schema-driven properties
+
+### Asset workflow
+
+1. Open the **Assets** panel
+2. Add an asset id, mesh path/tag, and render scale
+3. Click **Add Asset**
+4. Select the asset and click **Place Asset**
+5. The engine creates a scene object bound to that asset
+6. Use **Properties** to move, rotate, scale, or rebind the object
+
+This gives you a simple content pipeline inside editor mode:
+
+- register reusable assets once
+- list them in the editor
+- place them into the map repeatedly
+- edit placed instances independently
+
+## Project config: `engine.config.toml`
+
+A host project can place an `engine.config.toml` file next to its app and load it through:
+
+```cpp
+#include "core/Application.h"
+
+Monolith::AppSpec spec = Monolith::AppSpec::FromConfig("engine.config.toml", "My Game");
+```
+
+Supported sections today:
+
+```toml
+[window]
+width = 1600
+height = 900
+vsync = true
+
+[runtime]
+max_ram_mb = 2048
+max_cpu_percent = 70
+default_scene = "assets/scenes/main.json"
+
+[assets]
+directories = ["assets", "mods/base"]
+```
+
+Notes:
+
+- `width`, `height`, and `vsync` are applied directly to the app window
+- `max_ram_mb` and `max_cpu_percent` are currently parsed and exposed as runtime metadata for the host project
+- `default_scene` and `directories` give the project a central place to declare engine-facing content settings
+
+## Embedding into another project
+
+See:
+
+- `docs/integration.md`
+- `engine.config.toml.example`
+
+## CMake embedding summary
+
+Typical host usage:
+
+```cmake
+add_subdirectory(external/horo-engine)
+
+target_link_libraries(MyGame PRIVATE MonolithEngine)
+target_include_directories(MyGame PRIVATE ${CMAKE_SOURCE_DIR}/external/horo-engine)
+```
+
+The engine is designed to be embedded as a static library.

--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -2,13 +2,22 @@
 
 #include <glad/glad.h>
 
+#include "core/EngineConfig.h"
 #include "core/Logger.h"
 #include "core/Time.h"
 #include "input/Input.h"
 
 namespace Monolith {
 
-Application::Application(const AppSpec& spec) {
+AppSpec AppSpec::FromConfig(const std::string& path, const std::string& appName) {
+  AppSpec spec;
+  spec.name = appName;
+  spec.configPath = path;
+  EngineRuntimeConfig::LoadOrDefault(path).ApplyTo(spec);
+  return spec;
+}
+
+Application::Application(const AppSpec& spec) : m_spec(spec) {
   WindowSpec ws;
   ws.title = spec.name;
   ws.width = spec.width;
@@ -19,6 +28,11 @@ Application::Application(const AppSpec& spec) {
   m_window->SetCloseCallback([this]() { m_running = false; });
 
   Input::Init(m_window->GetNativeHandle());
+
+  if (!m_spec.configPath.empty()) {
+    LOG_INFO("Application config: %s", m_spec.configPath.c_str());
+    LOG_INFO("Runtime budgets — RAM: %d MB, CPU: %d%%", m_spec.maxRamMb, m_spec.maxCpuPercent);
+  }
 }
 
 Application::~Application() = default;

--- a/core/Application.h
+++ b/core/Application.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "core/Window.h"
 
@@ -11,6 +12,15 @@ struct AppSpec {
   int width = 1280;
   int height = 720;
   bool vsync = true;
+
+  // Project-local configuration metadata loaded from engine.config.toml.
+  std::string configPath = "engine.config.toml";
+  int maxRamMb = 0;
+  int maxCpuPercent = 0;
+  std::string defaultScenePath = "assets/scenes/dungeon.json";
+  std::vector<std::string> assetDirectories;
+
+  static AppSpec FromConfig(const std::string& path, const std::string& appName = "Monolith App");
 };
 
 class Application {
@@ -24,6 +34,7 @@ class Application {
   void Run();
 
   Window& GetWindow() { return *m_window; }
+  const AppSpec& GetSpec() const { return m_spec; }
 
  protected:
   // Subclasses override these
@@ -34,6 +45,7 @@ class Application {
   virtual void OnShutdown() {}
 
  private:
+  AppSpec m_spec;
   std::unique_ptr<Window> m_window;
   bool m_running = true;
 };

--- a/core/EngineConfig.cpp
+++ b/core/EngineConfig.cpp
@@ -1,0 +1,166 @@
+#include "core/EngineConfig.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+#include "core/Application.h"
+
+namespace Monolith {
+namespace {
+
+std::string Trim(const std::string& s) {
+  size_t start = 0;
+  while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start])))
+    ++start;
+
+  size_t end = s.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1])))
+    --end;
+
+  return s.substr(start, end - start);
+}
+
+std::string StripComment(const std::string& s) {
+  bool inString = false;
+  for (size_t i = 0; i < s.size(); ++i) {
+    if (s[i] == '"')
+      inString = !inString;
+    if (!inString && s[i] == '#')
+      return s.substr(0, i);
+  }
+  return s;
+}
+
+std::string Unquote(const std::string& s) {
+  const std::string t = Trim(s);
+  if (t.size() >= 2 && t.front() == '"' && t.back() == '"')
+    return t.substr(1, t.size() - 2);
+  return t;
+}
+
+bool ParseBool(const std::string& raw, bool fallback) {
+  const std::string v = Trim(raw);
+  if (v == "true")
+    return true;
+  if (v == "false")
+    return false;
+  return fallback;
+}
+
+int ParseInt(const std::string& raw, int fallback) {
+  try {
+    return std::stoi(Trim(raw));
+  } catch (...) {
+    return fallback;
+  }
+}
+
+std::vector<std::string> ParseStringArray(const std::string& raw) {
+  std::vector<std::string> out;
+  const std::string t = Trim(raw);
+  if (t.size() < 2 || t.front() != '[' || t.back() != ']')
+    return out;
+
+  std::string body = t.substr(1, t.size() - 2);
+  std::string current;
+  bool inString = false;
+
+  for (char ch : body) {
+    if (ch == '"') {
+      inString = !inString;
+      current.push_back(ch);
+      continue;
+    }
+
+    if (!inString && ch == ',') {
+      const std::string item = Unquote(current);
+      if (!item.empty())
+        out.push_back(item);
+      current.clear();
+      continue;
+    }
+
+    current.push_back(ch);
+  }
+
+  const std::string tail = Unquote(current);
+  if (!tail.empty())
+    out.push_back(tail);
+
+  return out;
+}
+
+}  // namespace
+
+EngineRuntimeConfig EngineRuntimeConfig::LoadFromFile(const std::string& path) {
+  std::ifstream file(path);
+  if (!file.is_open())
+    throw std::runtime_error("EngineRuntimeConfig: cannot open '" + path + "'");
+
+  EngineRuntimeConfig cfg;
+  std::string section;
+  std::string line;
+
+  while (std::getline(file, line)) {
+    line = Trim(StripComment(line));
+    if (line.empty())
+      continue;
+
+    if (line.front() == '[' && line.back() == ']') {
+      section = Trim(line.substr(1, line.size() - 2));
+      continue;
+    }
+
+    const size_t eq = line.find('=');
+    if (eq == std::string::npos)
+      continue;
+
+    const std::string key = Trim(line.substr(0, eq));
+    const std::string value = Trim(line.substr(eq + 1));
+
+    if (section == "window") {
+      if (key == "width")
+        cfg.windowWidth = ParseInt(value, cfg.windowWidth);
+      else if (key == "height")
+        cfg.windowHeight = ParseInt(value, cfg.windowHeight);
+      else if (key == "vsync")
+        cfg.vsync = ParseBool(value, cfg.vsync);
+    } else if (section == "runtime") {
+      if (key == "max_ram_mb")
+        cfg.maxRamMb = ParseInt(value, cfg.maxRamMb);
+      else if (key == "max_cpu_percent")
+        cfg.maxCpuPercent = ParseInt(value, cfg.maxCpuPercent);
+      else if (key == "default_scene")
+        cfg.defaultScenePath = Unquote(value);
+    } else if (section == "assets") {
+      if (key == "directories")
+        cfg.assetDirectories = ParseStringArray(value);
+    }
+  }
+
+  return cfg;
+}
+
+EngineRuntimeConfig EngineRuntimeConfig::LoadOrDefault(const std::string& path) {
+  try {
+    return LoadFromFile(path);
+  } catch (...) {
+    return EngineRuntimeConfig{};
+  }
+}
+
+void EngineRuntimeConfig::ApplyTo(AppSpec& spec) const {
+  spec.width = windowWidth;
+  spec.height = windowHeight;
+  spec.vsync = vsync;
+  spec.maxRamMb = maxRamMb;
+  spec.maxCpuPercent = maxCpuPercent;
+  spec.defaultScenePath = defaultScenePath;
+  spec.assetDirectories = assetDirectories;
+  spec.configPath = spec.configPath.empty() ? "engine.config.toml" : spec.configPath;
+}
+
+}  // namespace Monolith

--- a/core/EngineConfig.h
+++ b/core/EngineConfig.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace Monolith {
+
+struct AppSpec;
+
+struct EngineRuntimeConfig {
+  int windowWidth = 1280;
+  int windowHeight = 720;
+  bool vsync = true;
+
+  // Advisory runtime budgets for the consumer project.
+  // The engine parses and exposes them; hard enforcement is left to the host app.
+  int maxRamMb = 0;
+  int maxCpuPercent = 0;
+
+  std::string defaultScenePath = "assets/scenes/dungeon.json";
+  std::vector<std::string> assetDirectories;
+
+  static EngineRuntimeConfig LoadFromFile(const std::string& path);
+  static EngineRuntimeConfig LoadOrDefault(const std::string& path);
+
+  void ApplyTo(AppSpec& spec) const;
+};
+
+}  // namespace Monolith

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,115 @@
+# Integrating Horo Engine into a Project
+
+This repository builds a static library target named `MonolithEngine`.
+
+## 1. Add the engine to your source tree
+
+Example layout:
+
+```text
+my-game/
+  CMakeLists.txt
+  src/
+  external/
+    horo-engine/
+  assets/
+  engine.config.toml
+```
+
+## 2. Add the engine via CMake
+
+In your game's `CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.25)
+project(MyGame LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(external/horo-engine)
+
+add_executable(MyGame
+  src/main.cpp
+  src/MyGameApp.cpp
+)
+
+target_link_libraries(MyGame PRIVATE MonolithEngine)
+
+target_include_directories(MyGame PRIVATE
+  ${CMAKE_SOURCE_DIR}/external/horo-engine
+)
+```
+
+## 3. Create a project-local engine config
+
+Create `engine.config.toml` in your host project:
+
+```toml
+[window]
+width = 1600
+height = 900
+vsync = true
+
+[runtime]
+max_ram_mb = 2048
+max_cpu_percent = 70
+default_scene = "assets/scenes/main.json"
+
+[assets]
+directories = ["assets", "mods/base"]
+```
+
+## 4. Load config into your application spec
+
+```cpp
+#include "core/Application.h"
+
+class MyGameApp : public Monolith::Application {
+ public:
+  MyGameApp()
+      : Monolith::Application(Monolith::AppSpec::FromConfig("engine.config.toml", "My Game")) {}
+};
+```
+
+What this gives you:
+
+- window width / height / vsync applied automatically
+- runtime budget metadata available on `GetSpec()`
+- default scene path and asset directories stored in one place
+
+## 5. Access config values in game code
+
+```cpp
+const Monolith::AppSpec& spec = GetSpec();
+int ramBudgetMb = spec.maxRamMb;
+int cpuBudgetPercent = spec.maxCpuPercent;
+std::string defaultScene = spec.defaultScenePath;
+```
+
+## 6. Editor / scene integration
+
+The editor scene document already supports:
+
+- `assets`: reusable asset registry
+- `objects`: placed map instances
+- `settings`: scene-level metadata
+
+Recommended workflow:
+
+1. Register reusable assets in the editor
+2. Place them into the world as scene objects
+3. Save the scene JSON into your project's assets folder
+4. Keep engine runtime defaults in `engine.config.toml`
+
+## Notes on CPU / RAM limits
+
+The engine currently **reads and exposes** CPU/RAM budget values.
+
+That means:
+
+- they are available to the host game/application
+- they can drive project-specific throttling, telemetry, streaming, or quality presets
+- they are **not yet OS-enforced hard resource caps**
+
+This is still useful because the host project can centralize engine settings in a single config file and make policy decisions from there.

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -16,13 +16,28 @@
 
 #include "core/Logger.h"
 #include "editor/Raycaster.h"
-#include "math/MathUtils.h"
 #include "editor/SceneSerializer.h"
+#include "math/MathUtils.h"
 #include "math/Vec4.h"
 #include "renderer/DebugDraw.h"
 
 namespace Monolith {
 namespace Editor {
+
+namespace {
+const char* kDefaultScenePath = "assets/scenes/dungeon.json";
+}
+
+const char* EditorLayer::TypeToLabel(SceneObjectType type) {
+  switch (type) {
+    case SceneObjectType::Prop:
+      return "Prop";
+    case SceneObjectType::Light:
+      return "Light";
+    default:
+      return "Panel";
+  }
+}
 
 // ---- Lifecycle ---------------------------------------------------------------
 
@@ -59,9 +74,13 @@ void EditorLayer::Toggle() {
 
 void EditorLayer::LoadDocument(SceneDocument doc) {
   if (doc.filePath.empty())
-    doc.filePath = "assets/scenes/dungeon.json";
+    doc.filePath = kDefaultScenePath;
   m_document = std::move(doc);
   m_selectedIndices.clear();
+  if (!m_document.assets.empty())
+    m_selectedAssetId = m_document.assets.begin()->first;
+  else
+    m_selectedAssetId.clear();
 }
 
 // ---- Per-frame update --------------------------------------------------------
@@ -141,6 +160,7 @@ void EditorLayer::Render(const Camera& cam) {
     DrawToolbar();
     DrawViewGimbal();
     DrawObjectList();
+    DrawAssetRegistryPanel();
     DrawPropertiesPanel();
     DrawSelectionHighlight();  // queues to DebugDraw
   }
@@ -240,6 +260,12 @@ void EditorLayer::DrawToolbar() {
   addObj(SceneObjectType::Prop, "+ Prop");
   addObj(SceneObjectType::Light, "+ Light");
 
+  if (!m_selectedAssetId.empty()) {
+    if (ImGui::Button("Place Selected Asset"))
+      CreateObjectFromAsset(m_selectedAssetId);
+    ImGui::SameLine();
+  }
+
   // Fly camera toggle — green when active, Tab also toggles
   const bool flyActiveNow = m_flyMode;  // capture before button may flip it
   if (flyActiveNow)
@@ -252,7 +278,7 @@ void EditorLayer::DrawToolbar() {
                      m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
   }
   if (flyActiveNow) {
-    ImGui::PopStyleColor();  // always balanced with the push above
+    ImGui::PopStyleColor();
     ImGui::SameLine();
     ImGui::TextDisabled("WASD + mouse  |  Tab to exit");
   }
@@ -260,13 +286,11 @@ void EditorLayer::DrawToolbar() {
   ImGui::TextDisabled("Ctrl/Cmd+Shift+C copy ref");
   ImGui::SameLine();
 
-  // Right-aligned controls
   const float rightW = 260.0f;
   ImGui::SetCursorPosX(io.DisplaySize.x - rightW);
 
   if (ImGui::Button("Load")) {
-    std::string path =
-        m_document.filePath.empty() ? "assets/scenes/dungeon.json" : m_document.filePath;
+    std::string path = m_document.filePath.empty() ? kDefaultScenePath : m_document.filePath;
     try {
       m_document = SceneSerializer::LoadFromFile(path);
       m_selectedIndices.clear();
@@ -281,14 +305,14 @@ void EditorLayer::DrawToolbar() {
     if (!canSave)
       ImGui::BeginDisabled();
     if (ImGui::Button("Save")) {
-      std::string path =
-          m_document.filePath.empty() ? "assets/scenes/dungeon.json" : m_document.filePath;
+      std::string path = m_document.filePath.empty() ? kDefaultScenePath : m_document.filePath;
       m_document.filePath = path;
       try {
         SceneSerializer::SaveToFile(m_document, path);
-      } catch (...) {}
+      } catch (...) {
+      }
       m_document.dirty = false;
-      TriggerReload();  // rebuild scene so changes are immediately visible
+      TriggerReload();
     }
     if (!canSave)
       ImGui::EndDisabled();
@@ -356,11 +380,12 @@ void EditorLayer::DrawViewGimbal() {
 
 void EditorLayer::DrawObjectList() {
   ImGuiIO& io = ImGui::GetIO();
-  const float W = 220.0f;
+  const float W = 260.0f;
   const float Y = 36.0f;
+  const float H = (io.DisplaySize.y - Y) * 0.52f;
 
   ImGui::SetNextWindowPos(ImVec2(0, Y));
-  ImGui::SetNextWindowSize(ImVec2(W, io.DisplaySize.y - Y));
+  ImGui::SetNextWindowSize(ImVec2(W, H));
   ImGui::SetNextWindowBgAlpha(0.85f);
   ImGui::Begin(
       "Objects", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBringToFrontOnFocus);
@@ -371,8 +396,12 @@ void EditorLayer::DrawObjectList() {
                       : (obj.type == SceneObjectType::Light) ? "L"
                                                              : "B";
 
-    char label[128];
-    std::snprintf(label, sizeof(label), "[%s] %s##%d", tag, obj.id.c_str(), i);
+    std::string assetSuffix;
+    if (!obj.assetId.empty())
+      assetSuffix = " @" + obj.assetId;
+
+    char label[196];
+    std::snprintf(label, sizeof(label), "[%s] %s%s##%d", tag, obj.id.c_str(), assetSuffix.c_str(), i);
 
     if (ImGui::Selectable(label, IsSelected(i))) {
       if (ImGui::GetIO().KeyShift)
@@ -385,11 +414,100 @@ void EditorLayer::DrawObjectList() {
   ImGui::End();
 }
 
+void EditorLayer::DrawAssetRegistryPanel() {
+  ImGuiIO& io = ImGui::GetIO();
+  const float W = 260.0f;
+  const float Y = 36.0f + (io.DisplaySize.y - 36.0f) * 0.52f;
+  const float H = io.DisplaySize.y - Y;
+
+  ImGui::SetNextWindowPos(ImVec2(0, Y));
+  ImGui::SetNextWindowSize(ImVec2(W, H));
+  ImGui::SetNextWindowBgAlpha(0.85f);
+  ImGui::Begin(
+      "Assets", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+  ImGui::InputText("ID", m_newAssetId, sizeof(m_newAssetId));
+  ImGui::InputText("Mesh", m_newAssetMesh, sizeof(m_newAssetMesh));
+  ImGui::InputText("Render Scale", m_newAssetScale, sizeof(m_newAssetScale));
+
+  if (ImGui::Button("Add Asset")) {
+    const std::string id = m_newAssetId;
+    if (!id.empty()) {
+      AssetDef def;
+      def.mesh = m_newAssetMesh;
+      def.renderScale = m_newAssetScale;
+      m_document.assets[id] = def;
+      m_selectedAssetId = id;
+      m_document.dirty = true;
+    }
+  }
+  ImGui::SameLine();
+  if (!m_selectedAssetId.empty()) {
+    if (ImGui::Button("Place Asset"))
+      CreateObjectFromAsset(m_selectedAssetId);
+  }
+
+  ImGui::Separator();
+  ImGui::Text("Registered assets: %d", static_cast<int>(m_document.assets.size()));
+
+  std::vector<std::string> ids;
+  ids.reserve(m_document.assets.size());
+  for (const auto& kv : m_document.assets)
+    ids.push_back(kv.first);
+  std::sort(ids.begin(), ids.end());
+
+  for (const auto& id : ids) {
+    const AssetDef& asset = m_document.assets.at(id);
+    const bool selected = (m_selectedAssetId == id);
+    std::string label = id + "##asset_" + id;
+    if (ImGui::Selectable(label.c_str(), selected))
+      m_selectedAssetId = id;
+    ImGui::TextDisabled("mesh: %s", asset.mesh.empty() ? "<none>" : asset.mesh.c_str());
+    if (!asset.renderScale.empty())
+      ImGui::TextDisabled("scale: %s", asset.renderScale.c_str());
+    ImGui::Separator();
+  }
+
+  if (!m_selectedAssetId.empty()) {
+    auto it = m_document.assets.find(m_selectedAssetId);
+    if (it != m_document.assets.end()) {
+      ImGui::Text("Edit asset");
+      ImGui::LabelText("Selected", "%s", m_selectedAssetId.c_str());
+
+      char meshBuf[256] = {};
+      std::snprintf(meshBuf, sizeof(meshBuf), "%s", it->second.mesh.c_str());
+      if (ImGui::InputText("Asset Mesh", meshBuf, sizeof(meshBuf))) {
+        it->second.mesh = meshBuf;
+        m_document.dirty = true;
+      }
+
+      char scaleBuf[64] = {};
+      std::snprintf(scaleBuf, sizeof(scaleBuf), "%s", it->second.renderScale.c_str());
+      if (ImGui::InputText("Asset Scale", scaleBuf, sizeof(scaleBuf))) {
+        it->second.renderScale = scaleBuf;
+        m_document.dirty = true;
+      }
+
+      if (ImGui::Button("Delete Asset")) {
+        for (auto& obj : m_document.objects) {
+          if (obj.assetId == m_selectedAssetId)
+            obj.assetId.clear();
+        }
+        m_document.assets.erase(it);
+        m_selectedAssetId.clear();
+        m_document.dirty = true;
+      }
+    }
+  }
+
+  ImGui::End();
+}
+
 // ---- Properties panel --------------------------------------------------------
 
 void EditorLayer::DrawPropertiesPanel() {
   ImGuiIO& io = ImGui::GetIO();
-  const float W = 280.0f;
+  const float W = 300.0f;
   const float Y = 36.0f;
 
   ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - W, Y));
@@ -398,12 +516,10 @@ void EditorLayer::DrawPropertiesPanel() {
   ImGui::Begin(
       "Properties", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
-  // ---- Multi-selection summary ----
   if (m_selectedIndices.size() > 1) {
     ImGui::Text("%d objects selected", static_cast<int>(m_selectedIndices.size()));
     ImGui::Separator();
     if (ImGui::Button("Delete Selected")) {
-      // Erase in reverse index order so earlier indices stay valid
       std::vector<int> sorted = m_selectedIndices;
       std::sort(sorted.rbegin(), sorted.rend());
       for (int i : sorted)
@@ -425,15 +541,10 @@ void EditorLayer::DrawPropertiesPanel() {
 
   SceneObject& obj = m_document.objects[primaryIdx];
 
-  // ---- Identity ----
   ImGui::LabelText("ID", "%s", obj.id.c_str());
-  const char* typeName = (obj.type == SceneObjectType::Prop)    ? "Prop"
-                         : (obj.type == SceneObjectType::Light) ? "Light"
-                                                                : "Panel";
-  ImGui::LabelText("Type", "%s", typeName);
+  ImGui::LabelText("Type", "%s", TypeToLabel(obj.type));
   ImGui::Separator();
 
-  // ---- Transform ----
   float pos[3] = {obj.position.x, obj.position.y, obj.position.z};
   if (ImGui::DragFloat3("Position", pos, 0.05f)) {
     obj.position = {pos[0], pos[1], pos[2]};
@@ -457,9 +568,50 @@ void EditorLayer::DrawPropertiesPanel() {
   }
 
   ImGui::Separator();
+  ImGui::Text("Asset Binding");
+
+  std::vector<std::string> assetIds;
+  assetIds.push_back("<Inline>");
+  for (const auto& kv : m_document.assets)
+    assetIds.push_back(kv.first);
+  std::sort(assetIds.begin() + 1, assetIds.end());
+
+  int currentAssetIndex = 0;
+  if (!obj.assetId.empty()) {
+    for (int i = 1; i < static_cast<int>(assetIds.size()); ++i) {
+      if (assetIds[i] == obj.assetId) {
+        currentAssetIndex = i;
+        break;
+      }
+    }
+  }
+
+  std::string comboItems;
+  for (const auto& id : assetIds) {
+    comboItems += id;
+    comboItems.push_back('\0');
+  }
+  comboItems.push_back('\0');
+
+  if (ImGui::Combo("Asset", &currentAssetIndex, comboItems.c_str())) {
+    obj.assetId = (currentAssetIndex == 0) ? "" : assetIds[static_cast<size_t>(currentAssetIndex)];
+    if (!obj.assetId.empty())
+      m_selectedAssetId = obj.assetId;
+    m_document.dirty = true;
+  }
+
+  if (!obj.assetId.empty()) {
+    auto it = m_document.assets.find(obj.assetId);
+    if (it != m_document.assets.end()) {
+      ImGui::TextDisabled("mesh: %s", it->second.mesh.empty() ? "<none>" : it->second.mesh.c_str());
+      ImGui::TextDisabled("renderScale: %s",
+                          it->second.renderScale.empty() ? "<none>" : it->second.renderScale.c_str());
+    }
+  }
+
+  ImGui::Separator();
   ImGui::Text("Props");
 
-  // ---- Schema-driven fields ----
   const TypeSchema* schema = m_schema.GetSchema(obj.type);
   if (schema) {
     for (const auto& fd : schema->fields) {
@@ -503,7 +655,6 @@ void EditorLayer::DrawPropertiesPanel() {
               break;
             }
 
-          // Build null-separated list for ImGui::Combo
           std::string items;
           for (auto& opt : fd.options) {
             items += opt;
@@ -520,7 +671,6 @@ void EditorLayer::DrawPropertiesPanel() {
         case FieldDef::Widget::Color3: {
           float col[3] = {1.0f, 1.0f, 1.0f};
           if (!val.empty()) {
-            // Parse "r,g,b" using strtof to avoid MSVC sscanf deprecation
             char tmp[64] = {};
             std::snprintf(tmp, sizeof(tmp), "%s", val.c_str());
             char* p = tmp;
@@ -680,19 +830,29 @@ void EditorLayer::TriggerReload() {
   m_wantsReload = true;
 }
 
-std::string EditorLayer::BuildSelectionRefCode(const SceneObject& obj, int idx) const {
-  auto typeToStr = [](SceneObjectType t) {
-    switch (t) {
-      case SceneObjectType::Panel:
-        return "Panel";
-      case SceneObjectType::Prop:
-        return "Prop";
-      case SceneObjectType::Light:
-        return "Light";
-    }
-    return "Unknown";
-  };
+void EditorLayer::CreateObjectFromAsset(const std::string& assetId) {
+  auto it = m_document.assets.find(assetId);
+  if (it == m_document.assets.end())
+    return;
 
+  SceneObject obj;
+  obj.id = GenerateId(m_document);
+  obj.type = SceneObjectType::Prop;
+  obj.assetId = assetId;
+  ApplySchemaDefaults(obj);
+
+  if (!it->second.mesh.empty())
+    obj.props["mesh"] = it->second.mesh;
+  if (!it->second.renderScale.empty())
+    obj.props["renderScale"] = it->second.renderScale;
+
+  m_document.objects.push_back(std::move(obj));
+  m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+  m_document.dirty = true;
+  TriggerReload();
+}
+
+std::string EditorLayer::BuildSelectionRefCode(const SceneObject& obj, int idx) const {
   auto getProp = [&](const char* key) -> std::string {
     auto it = obj.props.find(key);
     return (it != obj.props.end()) ? it->second : "";
@@ -701,15 +861,18 @@ std::string EditorLayer::BuildSelectionRefCode(const SceneObject& obj, int idx) 
   std::ostringstream ss;
   ss.setf(std::ios::fixed);
   ss.precision(4);
-  const std::string scenePath = m_document.filePath.empty() ? "assets/scenes/dungeon.json" : m_document.filePath;
+  const std::string scenePath = m_document.filePath.empty() ? kDefaultScenePath : m_document.filePath;
   ss << "EDITOR_REF"
      << " scene=\"" << scenePath << "\""
      << " id=" << obj.id
      << " idx=" << idx
-     << " type=" << typeToStr(obj.type)
+     << " type=" << TypeToLabel(obj.type)
      << " pos=(" << obj.position.x << "," << obj.position.y << "," << obj.position.z << ")"
      << " scale=(" << obj.scale.x << "," << obj.scale.y << "," << obj.scale.z << ")"
      << " yaw=" << obj.yaw;
+
+  if (!obj.assetId.empty())
+    ss << " asset=\"" << obj.assetId << "\"";
 
   const std::string mesh = getProp("mesh");
   if (!mesh.empty())
@@ -736,14 +899,12 @@ void EditorLayer::ToggleFlyMode(Camera& cam) {
   m_prevCursorInit = false;
   glfwSetInputMode(m_window, GLFW_CURSOR,
                    m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
-  (void)cam;  // camera sync happens lazily in UpdateFlyCamera
+  (void)cam;
 }
 
 void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
-  // Fly mode always uses world-up to avoid inverted controls after view snaps.
   cam.up = Vec3::Up();
 
-  // --- Sync yaw/pitch from live camera on first frame ---
   if (!m_flyCamInitialized) {
     Vec3 dir = cam.target - cam.position;
     float len = std::sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
@@ -754,8 +915,6 @@ void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
     }
     m_flyPitch = std::asin(std::max(-1.0f, std::min(1.0f, dir.y))) * (180.0f / PI);
 
-    // If the camera is nearly vertical (Top/Bottom snap), yaw is ill-defined.
-    // Keep previous yaw to avoid sudden axis flips when entering fly mode.
     const float horizLen = std::sqrt(dir.x * dir.x + dir.z * dir.z);
     if (horizLen > 0.0001f)
       m_flyYaw = -std::atan2(dir.x, -dir.z) * (180.0f / PI);
@@ -763,7 +922,6 @@ void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
     m_flyCamInitialized = true;
   }
 
-  // --- Mouse look ---
   double cx, cy;
   glfwGetCursorPos(m_window, &cx, &cy);
   if (!m_prevCursorInit) {
@@ -778,7 +936,6 @@ void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
   m_prevCursorX = cx;
   m_prevCursorY = cy;
 
-  // --- Compute forward/right from yaw/pitch ---
   const float yawRad = m_flyYaw * (PI / 180.0f);
   const float pitchRad = m_flyPitch * (PI / 180.0f);
   Vec3 forward = {-std::sin(yawRad) * std::cos(pitchRad), std::sin(pitchRad),
@@ -791,7 +948,6 @@ void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
     right.z /= rLen;
   }
 
-  // --- WASD movement ---
   const float FLY_SPEED = 8.0f;
   Vec3 move = {0.0f, 0.0f, 0.0f};
   if (glfwGetKey(m_window, GLFW_KEY_W) == GLFW_PRESS)

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -13,14 +13,6 @@ namespace Monolith {
 namespace Editor {
 
 // In-game editor overlay.
-//
-// Usage (from CharacterApp):
-//   OnInit  → editor.Init(window)
-//   OnUpdate→ if F10 pressed: editor.Toggle()
-//              editor.OnUpdate(dt, cam, w, h)  — returns true if ImGui consumed input
-//   OnRender→ editor.Render(cam)               — call after game scene, before EndFrame
-//   OnShutdown → editor.Shutdown()
-//   Reload  → if editor.WantsSceneReload(): reload from editor.GetPendingDocument()
 class EditorLayer {
  public:
   void Init(GLFWwindow* window);
@@ -89,6 +81,11 @@ class EditorLayer {
   std::vector<int> m_selectedIndices;  // all selected; last = primary for properties
   std::function<void(const SceneObject&)> m_transformCb;
 
+  std::string m_selectedAssetId;
+  char m_newAssetId[64] = "asset_001";
+  char m_newAssetMesh[256] = "";
+  char m_newAssetScale[64] = "1.0000,1.0000,1.0000";
+
   // Helpers
   bool IsSelected(int i) const;
   int PrimaryIdx() const;    // last selected index, or -1 if empty
@@ -100,11 +97,14 @@ class EditorLayer {
   void DrawHotReloadOverlay();
   void DrawClipboardToast();
   void DrawObjectList();
+  void DrawAssetRegistryPanel();
   void DrawPropertiesPanel();
   void HandlePicking(const Camera& cam, int screenW, int screenH);
   void DrawSelectionHighlight();
   void ApplyPendingViewSnap(Camera& cam);
   std::string BuildSelectionRefCode(const SceneObject& obj, int idx) const;
+  void CreateObjectFromAsset(const std::string& assetId);
+  static const char* TypeToLabel(SceneObjectType type);
 
   bool m_hotReloadOverlayActive = false;
   float m_hotReloadOverlayProgress = 0.0f;

--- a/engine.config.toml.example
+++ b/engine.config.toml.example
@@ -1,0 +1,12 @@
+[window]
+width = 1600
+height = 900
+vsync = true
+
+[runtime]
+max_ram_mb = 2048
+max_cpu_percent = 70
+default_scene = "assets/scenes/main.json"
+
+[assets]
+directories = ["assets", "mods/base"]

--- a/renderer/DebugDraw.cpp
+++ b/renderer/DebugDraw.cpp
@@ -3,6 +3,7 @@
 #include <glad/glad.h>
 
 #include <cmath>
+#include <cstddef>
 #include <vector>
 
 #include "math/MathUtils.h"

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <utility>
 
 #include "math/MathUtils.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,3 +118,8 @@ add_test(NAME test_gjk_extended COMMAND test_gjk_extended)
 add_executable(test_quaternion_extended test_quaternion_extended.cpp)
 target_link_libraries(test_quaternion_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
 add_test(NAME test_quaternion_extended COMMAND test_quaternion_extended)
+
+# ---- test_engine_config ----
+add_executable(test_engine_config test_engine_config.cpp)
+target_link_libraries(test_engine_config PRIVATE MonolithEngine Catch2::Catch2WithMain)
+add_test(NAME test_engine_config COMMAND test_engine_config)

--- a/tests/test_engine_config.cpp
+++ b/tests/test_engine_config.cpp
@@ -1,0 +1,91 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "core/Application.h"
+#include "core/EngineConfig.h"
+
+using namespace Monolith;
+
+namespace {
+std::string TmpPath(const std::string& name) {
+  return (std::filesystem::temp_directory_path() / name).string();
+}
+
+void WriteFile(const std::string& path, const std::string& content) {
+  std::ofstream f(path);
+  f << content;
+}
+}  // namespace
+
+TEST_CASE("EngineRuntimeConfig loads TOML settings", "[config]") {
+  const std::string path = TmpPath("engine_config.toml");
+  WriteFile(path,
+            R"(
+[window]
+width = 1600
+height = 900
+vsync = false
+
+[runtime]
+max_ram_mb = 2048
+max_cpu_percent = 65
+default_scene = "assets/scenes/test.json"
+
+[assets]
+directories = ["assets", "mods/base"]
+)");
+
+  EngineRuntimeConfig cfg = EngineRuntimeConfig::LoadFromFile(path);
+  REQUIRE(cfg.windowWidth == 1600);
+  REQUIRE(cfg.windowHeight == 900);
+  REQUIRE(cfg.vsync == false);
+  REQUIRE(cfg.maxRamMb == 2048);
+  REQUIRE(cfg.maxCpuPercent == 65);
+  REQUIRE(cfg.defaultScenePath == "assets/scenes/test.json");
+  REQUIRE(cfg.assetDirectories.size() == 2);
+  REQUIRE(cfg.assetDirectories[0] == "assets");
+  REQUIRE(cfg.assetDirectories[1] == "mods/base");
+}
+
+TEST_CASE("AppSpec::FromConfig applies engine config", "[config]") {
+  const std::string path = TmpPath("engine_config_apply.toml");
+  WriteFile(path,
+            R"(
+[window]
+width = 1920
+height = 1080
+vsync = true
+
+[runtime]
+max_ram_mb = 4096
+max_cpu_percent = 80
+default_scene = "assets/scenes/arena.json"
+
+[assets]
+directories = ["assets", "dlc"]
+)");
+
+  AppSpec spec = AppSpec::FromConfig(path, "Config Test App");
+  REQUIRE(spec.name == "Config Test App");
+  REQUIRE(spec.configPath == path);
+  REQUIRE(spec.width == 1920);
+  REQUIRE(spec.height == 1080);
+  REQUIRE(spec.vsync == true);
+  REQUIRE(spec.maxRamMb == 4096);
+  REQUIRE(spec.maxCpuPercent == 80);
+  REQUIRE(spec.defaultScenePath == "assets/scenes/arena.json");
+  REQUIRE(spec.assetDirectories.size() == 2);
+}
+
+TEST_CASE("EngineRuntimeConfig::LoadOrDefault falls back on missing file", "[config]") {
+  EngineRuntimeConfig cfg = EngineRuntimeConfig::LoadOrDefault("/nonexistent/engine.config.toml");
+  REQUIRE(cfg.windowWidth == 1280);
+  REQUIRE(cfg.windowHeight == 720);
+  REQUIRE(cfg.vsync == true);
+  REQUIRE(cfg.maxRamMb == 0);
+  REQUIRE(cfg.maxCpuPercent == 0);
+  REQUIRE(cfg.defaultScenePath == "assets/scenes/dungeon.json");
+}

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT TARGET glfw)
     set(GLFW_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_INSTALL        OFF CACHE BOOL "" FORCE)
+    set(GLFW_BUILD_WAYLAND  OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(glfw)
 endif()
 


### PR DESCRIPTION
## Summary
- add an editor asset registry panel and asset placement workflow
- allow scene objects to bind to registered assets and edit them from the properties panel
- add project-local engine.config.toml parsing and integration docs
- document embedding the engine in another CMake project
- fix existing Linux build issues caused by missing <cstddef> includes and disable Wayland in this environment

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest --test-dir build --output-on-failure