### PR TITLE
feat: add object search to editor list

### DIFF
--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -401,15 +401,28 @@ void EditorLayer::DrawObjectList() {
   ImGui::Begin(
       "Objects", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
+  char searchBuf[256] = {};
+  std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_objectSearchQuery.c_str());
+  if (ImGui::InputTextWithHint("##object_search", "Search objects...", searchBuf, sizeof(searchBuf)))
+    m_objectSearchQuery = searchBuf;
+  ImGui::Separator();
+
   for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
     auto& obj = m_document.objects[i];
     const char* tag = (obj.type == SceneObjectType::Prop)    ? "P"
                       : (obj.type == SceneObjectType::Light) ? "L"
                                                              : "B";
 
+    std::string haystack = obj.id + " " + tag + " " + obj.assetId;
+    std::string query = m_objectSearchQuery;
+    std::transform(haystack.begin(), haystack.end(), haystack.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    std::transform(query.begin(), query.end(), query.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (!query.empty() && haystack.find(query) == std::string::npos)
+      continue;
+
     char label[192];
     if (!obj.assetId.empty())
-      std::snprintf(label, sizeof(label), "[%s] %s  {%s}##%d", tag, obj.id.c_str(), obj.assetId.c_str(), i);
+      std::snprintf(label, sizeof(label), "[%s] %s · %s##%d", tag, obj.id.c_str(), obj.assetId.c_str(), i);
     else
       std::snprintf(label, sizeof(label), "[%s] %s##%d", tag, obj.id.c_str(), i);
 

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -120,6 +120,7 @@ class EditorLayer {
   std::string m_selectedAssetId;
   bool m_assetSearchOpen = false;
   std::string m_assetSearchQuery;
+  std::string m_objectSearchQuery;
 
   static SceneObject MakeObjectFromAsset(const SceneDocument& doc,
                                          const std::string& assetId,

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <algorithm>
+#include <cctype>
 
 #include "editor/EditorSchema.h"
 #include "editor/Raycaster.h"
@@ -30,6 +32,14 @@ Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::Sce
     clone.id = "copy_" + std::to_string(doc.objects.size());
     clone.props.erase("_eid");
     return clone;
+}
+
+bool ObjectMatchesQueryForTest(const Monolith::Editor::SceneObject& obj, const std::string& query) {
+    std::string haystack = obj.id + " " + obj.assetId;
+    std::string q = query;
+    std::transform(haystack.begin(), haystack.end(), haystack.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    std::transform(q.begin(), q.end(), q.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return q.empty() || haystack.find(q) != std::string::npos;
 }
 }
 using Catch::Approx;
@@ -441,6 +451,17 @@ TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[edit
     SceneObject created = MakeObjectFromAssetForTest(doc, "torch");
     REQUIRE(created.type == SceneObjectType::Prop);
     REQUIRE(created.assetId == "torch");
+}
+
+TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]") {
+    SceneObject obj;
+    obj.id = "prop_007";
+    obj.assetId = "stone_obj";
+
+    REQUIRE(ObjectMatchesQueryForTest(obj, "prop"));
+    REQUIRE(ObjectMatchesQueryForTest(obj, "stone"));
+    REQUIRE(ObjectMatchesQueryForTest(obj, "STONE_OBJ"));
+    REQUIRE_FALSE(ObjectMatchesQueryForTest(obj, "torch"));
 }
 
 TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]") {


### PR DESCRIPTION
## Summary
- add a search field to the object list so large scenes are easier to navigate
- clean up asset-backed object labels to use a more readable inline asset tag
- add helper coverage for object search matching behavior

## Testing
- cmake --build build\\debug-msvc --config Debug --target test_editor --parallel
- ctest --test-dir build\\debug-msvc -C Debug --output-on-failure -R test_editor