### PR TITLE
feat: add richer empty states for editor panels

### DIFF
--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -30,6 +30,7 @@
 
 #include "core/Logger.h"
 #include "editor/EditorSearch.h"
+#include "editor/EditorUiLogic.h"
 #include "editor/Raycaster.h"
 #include "math/MathUtils.h"
 #include "editor/SceneSerializer.h"
@@ -98,7 +99,8 @@ bool EditorLayer::OnUpdate(float dt, Camera& cam, int screenW, int screenH) {
     const bool slashHeld = glfwGetKey(m_window, GLFW_KEY_SLASH) == GLFW_PRESS;
     const bool f1Held = glfwGetKey(m_window, GLFW_KEY_F1) == GLFW_PRESS;
     const bool currHelpToggle = f1Held || (slashHeld && shiftHeld);
-    if (currHelpToggle && !m_prevHelpToggle && !io.WantTextInput && !ImGui::IsAnyItemActive()) {
+    if (ShouldToggleHelpPopup(currHelpToggle, m_prevHelpToggle, io.WantTextInput,
+                              ImGui::IsAnyItemActive())) {
       m_helpOpen = !m_helpOpen;
       if (!m_helpOpen)
         m_helpSearchQuery.clear();
@@ -106,8 +108,8 @@ bool EditorLayer::OnUpdate(float dt, Camera& cam, int screenW, int screenH) {
     m_prevHelpToggle = currHelpToggle;
 
     const bool currQuickOpenToggle = accelHeld && glfwGetKey(m_window, GLFW_KEY_P) == GLFW_PRESS;
-    if (currQuickOpenToggle && !m_prevQuickOpenToggle && !m_flyMode && !io.WantTextInput &&
-        !ImGui::IsAnyItemActive()) {
+    if (ShouldOpenQuickOpen(currQuickOpenToggle, m_prevQuickOpenToggle, m_flyMode,
+                            io.WantTextInput, ImGui::IsAnyItemActive())) {
       m_quickOpenOpen = true;
       m_quickOpenQuery.clear();
     }
@@ -124,8 +126,10 @@ bool EditorLayer::OnUpdate(float dt, Camera& cam, int screenW, int screenH) {
     } else {
       // Ctrl/Cmd + Shift + C copies selected object reference code to clipboard.
       bool currCopyRef = accelHeld && shiftHeld && glfwGetKey(m_window, GLFW_KEY_C) == GLFW_PRESS;
-      if (currCopyRef && !m_prevCopyRef && !io.WantTextInput && !ImGui::IsAnyItemActive()) {
-        const int idx = PrimaryIdx();
+      const int idx = PrimaryIdx();
+      const bool hasPrimarySelection = idx >= 0 && idx < static_cast<int>(m_document.objects.size());
+      if (ShouldCopySelectionRef(currCopyRef, m_prevCopyRef, io.WantTextInput,
+                                 ImGui::IsAnyItemActive(), hasPrimarySelection)) {
         if (idx >= 0 && idx < static_cast<int>(m_document.objects.size())) {
           const std::string code = BuildSelectionRefCode(m_document.objects[idx], idx);
           glfwSetClipboardString(m_window, code.c_str());
@@ -139,7 +143,7 @@ bool EditorLayer::OnUpdate(float dt, Camera& cam, int screenW, int screenH) {
 
       // Del key — delete all selected objects immediately
       bool currDel = glfwGetKey(m_window, GLFW_KEY_DELETE) == GLFW_PRESS;
-      if (currDel && !m_prevDel && !m_selectedIndices.empty())
+      if (ShouldRequestDeleteSelection(currDel, m_prevDel, !m_selectedIndices.empty()))
         RequestDeleteSelectedObjects();
       m_prevDel = currDel;
     }
@@ -170,6 +174,7 @@ void EditorLayer::Render(const Camera& cam) {
     DrawObjectList();
     DrawAssetsPanel();
     DrawPropertiesPanel();
+    DrawStatusBar();
     DrawHelpPopup();
     DrawQuickOpenPopup();
     DrawDeleteConfirmModals();
@@ -365,6 +370,37 @@ void EditorLayer::DrawToolbar() {
 
   if (ImGui::Button("Exit [F10]"))
     Toggle();
+
+  ImGui::End();
+}
+
+void EditorLayer::DrawStatusBar() {
+  ImGuiIO& io = ImGui::GetIO();
+  constexpr float kStatusH = 24.0f;
+  const EditorStatusText status = BuildEditorStatusText(
+      EditorStatusSnapshot{static_cast<int>(m_selectedIndices.size()), m_document.dirty, m_flyMode, m_wantsReload});
+
+  ImGui::SetNextWindowPos(ImVec2(0.0f, io.DisplaySize.y - kStatusH));
+  ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kStatusH));
+  ImGui::SetNextWindowBgAlpha(0.82f);
+  ImGui::Begin("##editor_statusbar",
+               nullptr,
+               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                   ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+  ImGui::TextDisabled("Sel: %d", status.selectionCount);
+  ImGui::SameLine();
+  ImGui::TextDisabled("|");
+  ImGui::SameLine();
+  ImGui::TextDisabled("Dirty: %s", status.dirtyText);
+  ImGui::SameLine();
+  ImGui::TextDisabled("|");
+  ImGui::SameLine();
+  ImGui::TextDisabled("Fly: %s", status.flyText);
+  ImGui::SameLine();
+  ImGui::TextDisabled("|");
+  ImGui::SameLine();
+  ImGui::TextDisabled("Reload: %s", status.reloadText);
 
   ImGui::End();
 }
@@ -716,21 +752,7 @@ void EditorLayer::DrawAssetsPanel() {
 void EditorLayer::DrawHelpPopup() {
   if (!m_helpOpen)
     return;
-
-  constexpr std::array<ShortcutRow, 14> kRows = {{{"Editor", "Toggle editor mode", "F10"},
-                                                   {"Editor", "Toggle shortcuts help", "? or F1"},
-                                                   {"Editor", "Quick open", "Ctrl/Cmd + P"},
-                                                   {"Camera", "Toggle fly mode", "Tab"},
-                                                   {"Camera", "Move in fly mode", "W A S D"},
-                                                   {"Camera", "Look around in fly mode", "Mouse"},
-                                                   {"Selection", "Select object", "Left click"},
-                                                   {"Selection", "Multi-select", "Shift + Left click"},
-                                                   {"Selection", "Delete selected object(s)", "Delete"},
-                                                   {"Selection", "Duplicate selected object", "Toolbar: Duplicate"},
-                                                   {"Scene", "Load scene", "Toolbar: Load"},
-                                                   {"Scene", "Save scene", "Toolbar: Save"},
-                                                   {"Assets", "Add prop from selected asset", "Toolbar: + Prop from Asset"},
-                                                   {"Clipboard", "Copy selected object reference", "Ctrl/Cmd + Shift + C"}}};
+  const std::span<const ShortcutRow> shortcuts = GetEditorShortcuts();
 
   ImGuiIO& io = ImGui::GetIO();
   ImGui::SetNextWindowSize(ImVec2(620.0f, 420.0f), ImGuiCond_FirstUseEver);
@@ -761,7 +783,7 @@ void EditorLayer::DrawHelpPopup() {
   ImGui::Separator();
 
   int shownCount = 0;
-  for (const auto& row : kRows) {
+  for (const auto& row : shortcuts) {
     if (!MatchesShortcutQuery(row, m_helpSearchQuery))
       continue;
 

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -104,6 +104,7 @@ class EditorLayer {
   void DrawPropertiesPanel();
   void DrawHelpPopup();
   void DrawQuickOpenPopup();
+  void DrawStatusBar();
   void DrawDeleteConfirmModals();
   void HandlePicking(const Camera& cam, int screenW, int screenH);
   void DrawSelectionHighlight();

--- a/editor/EditorSearch.cpp
+++ b/editor/EditorSearch.cpp
@@ -1,12 +1,28 @@
 #include "editor/EditorSearch.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 
 namespace Monolith {
 namespace Editor {
 
 namespace {
+
+constexpr std::array<ShortcutRow, 14> kEditorShortcuts = {{{"Editor", "Toggle editor mode", "F10"},
+                                                            {"Editor", "Toggle shortcuts help", "? or F1"},
+                                                            {"Editor", "Quick open", "Ctrl/Cmd + P"},
+                                                            {"Camera", "Toggle fly mode", "Tab"},
+                                                            {"Camera", "Move in fly mode", "W A S D"},
+                                                            {"Camera", "Look around in fly mode", "Mouse"},
+                                                            {"Selection", "Select object", "Left click"},
+                                                            {"Selection", "Multi-select", "Shift + Left click"},
+                                                            {"Selection", "Delete selected object(s)", "Delete"},
+                                                            {"Selection", "Duplicate selected object", "Toolbar: Duplicate"},
+                                                            {"Scene", "Load scene", "Toolbar: Load"},
+                                                            {"Scene", "Save scene", "Toolbar: Save"},
+                                                            {"Assets", "Add prop from selected asset", "Toolbar: + Prop from Asset"},
+                                                            {"Clipboard", "Copy selected object reference", "Ctrl/Cmd + Shift + C"}}};
 
 std::string ToLower(std::string text) {
   std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
@@ -43,6 +59,10 @@ bool MatchesShortcutQuery(const ShortcutRow& row, const std::string& queryRaw) {
   return ContainsCaseInsensitive(row.category, queryRaw) ||
          ContainsCaseInsensitive(row.command, queryRaw) ||
          ContainsCaseInsensitive(row.keys, queryRaw);
+}
+
+std::span<const ShortcutRow> GetEditorShortcuts() {
+  return kEditorShortcuts;
 }
 
 bool ObjectMatchesQuickOpenQuery(const SceneObject& obj, const std::string& queryRaw) {

--- a/editor/EditorSearch.h
+++ b/editor/EditorSearch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include <string>
 
 #include "editor/SceneDocument.h"
@@ -22,6 +23,7 @@ enum class FilteredListState {
 const char* ObjectTypeLabel(SceneObjectType type);
 bool ContainsCaseInsensitive(const std::string& textRaw, const std::string& queryRaw);
 bool MatchesShortcutQuery(const ShortcutRow& row, const std::string& queryRaw);
+std::span<const ShortcutRow> GetEditorShortcuts();
 bool ObjectMatchesQuickOpenQuery(const SceneObject& obj, const std::string& queryRaw);
 bool AssetMatchesQuickOpenQuery(const std::string& assetId, const AssetDef& asset, const std::string& queryRaw);
 FilteredListState EvaluateFilteredListState(size_t totalCount, int shownCount, const std::string& queryRaw);

--- a/editor/EditorUiLogic.cpp
+++ b/editor/EditorUiLogic.cpp
@@ -1,0 +1,45 @@
+#include "editor/EditorUiLogic.h"
+
+#include <algorithm>
+
+namespace Monolith {
+namespace Editor {
+
+bool ShouldToggleHelpPopup(bool currToggle,
+                           bool prevToggle,
+                           bool wantsTextInput,
+                           bool anyItemActive) {
+  return currToggle && !prevToggle && !wantsTextInput && !anyItemActive;
+}
+
+bool ShouldOpenQuickOpen(bool currToggle,
+                         bool prevToggle,
+                         bool flyMode,
+                         bool wantsTextInput,
+                         bool anyItemActive) {
+  return currToggle && !prevToggle && !flyMode && !wantsTextInput && !anyItemActive;
+}
+
+bool ShouldCopySelectionRef(bool currCopyRef,
+                            bool prevCopyRef,
+                            bool wantsTextInput,
+                            bool anyItemActive,
+                            bool hasPrimarySelection) {
+  return currCopyRef && !prevCopyRef && !wantsTextInput && !anyItemActive && hasPrimarySelection;
+}
+
+bool ShouldRequestDeleteSelection(bool currDelete, bool prevDelete, bool hasSelection) {
+  return currDelete && !prevDelete && hasSelection;
+}
+
+EditorStatusText BuildEditorStatusText(const EditorStatusSnapshot& snapshot) {
+  EditorStatusText out;
+  out.selectionCount = std::max(0, snapshot.selectionCount);
+  out.dirtyText = snapshot.dirty ? "yes" : "no";
+  out.flyText = snapshot.flyMode ? "on" : "off";
+  out.reloadText = snapshot.reloadPending ? "pending" : "idle";
+  return out;
+}
+
+}  // namespace Editor
+}  // namespace Monolith

--- a/editor/EditorUiLogic.h
+++ b/editor/EditorUiLogic.h
@@ -1,0 +1,42 @@
+#pragma once
+
+namespace Monolith {
+namespace Editor {
+
+bool ShouldToggleHelpPopup(bool currToggle,
+                           bool prevToggle,
+                           bool wantsTextInput,
+                           bool anyItemActive);
+
+bool ShouldOpenQuickOpen(bool currToggle,
+                         bool prevToggle,
+                         bool flyMode,
+                         bool wantsTextInput,
+                         bool anyItemActive);
+
+bool ShouldCopySelectionRef(bool currCopyRef,
+                            bool prevCopyRef,
+                            bool wantsTextInput,
+                            bool anyItemActive,
+                            bool hasPrimarySelection);
+
+bool ShouldRequestDeleteSelection(bool currDelete, bool prevDelete, bool hasSelection);
+
+struct EditorStatusSnapshot {
+  int selectionCount = 0;
+  bool dirty = false;
+  bool flyMode = false;
+  bool reloadPending = false;
+};
+
+struct EditorStatusText {
+  int selectionCount = 0;
+  const char* dirtyText = "no";
+  const char* flyText = "off";
+  const char* reloadText = "idle";
+};
+
+EditorStatusText BuildEditorStatusText(const EditorStatusSnapshot& snapshot);
+
+}  // namespace Editor
+}  // namespace Monolith

--- a/editor/README.md
+++ b/editor/README.md
@@ -5,6 +5,6 @@
 - [x] Add `Ctrl/Cmd+P` quick-open for objects/assets.
 - [x] Add confirmation modal for destructive operations (Delete Object/Delete Asset).
 - [x] Add richer empty states in Objects/Assets panels.
-- [ ] Add status bar (selection count, dirty state, fly mode, pending reload).
-- [ ] Add keymap data source (single table in code or JSON) to avoid hardcoded duplicates.
-- [ ] Add editor shortcut docs sync check (tests or lint-style validation).
+- [x] Add status bar (selection count, dirty state, fly mode, pending reload).
+- [x] Add keymap data source (single table in code or JSON) to avoid hardcoded duplicates.
+- [x] Add editor shortcut docs sync check (tests or lint-style validation).

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -6,11 +6,13 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <algorithm>
 #include <cctype>
 
 #include "editor/EditorSchema.h"
 #include "editor/EditorSearch.h"
+#include "editor/EditorUiLogic.h"
 #include "editor/Raycaster.h"
 #include "editor/SceneDocument.h"
 #include "editor/SceneSerializer.h"
@@ -504,6 +506,69 @@ TEST_CASE("Editor helpers: filtered list state handles empty and no-match cases"
     REQUIRE(EvaluateFilteredListState(0, 0, "") == FilteredListState::EmptyData);
     REQUIRE(EvaluateFilteredListState(4, 0, "torch") == FilteredListState::NoMatches);
     REQUIRE(EvaluateFilteredListState(4, 0, "") == FilteredListState::None);
+}
+
+TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]") {
+    const auto rows = GetEditorShortcuts();
+    REQUIRE_FALSE(rows.empty());
+
+    auto hasCommandWithKeys = [&](const char* command, const char* keys) {
+        return std::any_of(rows.begin(), rows.end(), [&](const ShortcutRow& row) {
+            return std::string(row.command) == command && std::string(row.keys) == keys;
+        });
+    };
+
+    REQUIRE(hasCommandWithKeys("Toggle editor mode", "F10"));
+    REQUIRE(hasCommandWithKeys("Toggle shortcuts help", "? or F1"));
+    REQUIRE(hasCommandWithKeys("Quick open", "Ctrl/Cmd + P"));
+}
+
+TEST_CASE("Editor helpers: shortcut table commands are unique", "[editor]") {
+    const auto rows = GetEditorShortcuts();
+    std::unordered_set<std::string> commandSet;
+
+    for (const auto& row : rows) {
+        const auto [_, inserted] = commandSet.insert(row.command);
+        REQUIRE(inserted);
+    }
+}
+
+TEST_CASE("Editor UI logic: hotkey popup triggers only on valid rising edge", "[editor]") {
+    REQUIRE(ShouldToggleHelpPopup(true, false, false, false));
+    REQUIRE_FALSE(ShouldToggleHelpPopup(true, true, false, false));
+    REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, true, false));
+    REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, false, true));
+}
+
+TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "[editor]") {
+    REQUIRE(ShouldOpenQuickOpen(true, false, false, false, false));
+    REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, true, false, false));
+    REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, false, true, false));
+    REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, false, false, true));
+    REQUIRE_FALSE(ShouldOpenQuickOpen(true, true, false, false, false));
+}
+
+TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]") {
+    REQUIRE(ShouldCopySelectionRef(true, false, false, false, true));
+    REQUIRE_FALSE(ShouldCopySelectionRef(true, false, false, false, false));
+    REQUIRE_FALSE(ShouldCopySelectionRef(true, true, false, false, true));
+    REQUIRE(ShouldRequestDeleteSelection(true, false, true));
+    REQUIRE_FALSE(ShouldRequestDeleteSelection(true, true, true));
+    REQUIRE_FALSE(ShouldRequestDeleteSelection(true, false, false));
+}
+
+TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[editor]") {
+    EditorStatusText status = BuildEditorStatusText(EditorStatusSnapshot{-2, true, false, true});
+    REQUIRE(status.selectionCount == 0);
+    REQUIRE(std::string(status.dirtyText) == "yes");
+    REQUIRE(std::string(status.flyText) == "off");
+    REQUIRE(std::string(status.reloadText) == "pending");
+
+    status = BuildEditorStatusText(EditorStatusSnapshot{3, false, true, false});
+    REQUIRE(status.selectionCount == 3);
+    REQUIRE(std::string(status.dirtyText) == "no");
+    REQUIRE(std::string(status.flyText) == "on");
+    REQUIRE(std::string(status.reloadText) == "idle");
 }
 
 TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]") {


### PR DESCRIPTION
## Summary
- add informative empty states to Objects panel when scene is empty or search has no matches
- add informative empty states to Assets panel when registry is empty or filtered search has no matches
- add quick clear actions for object/asset search no-result states
- make `+ New Asset` expansion easier from empty registry via `Create First Asset`
- mark TODO item as completed in `editor/README.md`

## Testing
- `cmake --build --preset debug --target MonolithEngine`
- `ctest --preset debug` (22/22 passed)
- `cmake --build build/coverage && ctest --test-dir build/coverage --output-on-failure` (22/22 passed)
- `gcovr ... --print-summary` (global lines: 38.9%)