### PR TITLE
refactor: remove Monolith naming from horo-engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
             --branch-coverage \
             --ignore-errors mismatch,source \
             --synthesize-missing \
-            --title "MonolithEngine — ${{ github.ref_name }} @ ${{ github.sha }}"
+            --title "HoroEngine — ${{ github.ref_name }} @ ${{ github.sha }}"
 
       - name: Print summary
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25)
 # Detect if this is a standalone build or embedded via add_subdirectory()
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # Standalone mode: local dev, CI, tests
-    project(MonolithEngine VERSION 0.1.0 LANGUAGES CXX C)
+    project(HoroEngine VERSION 0.1.0 LANGUAGES CXX C)
 
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -13,7 +13,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-    option(MONOLITH_ENGINE_BUILD_TESTS "Build engine unit tests" ON)
+    option(HORO_ENGINE_BUILD_TESTS "Build engine unit tests" ON)
 
     if(MSVC)
         add_compile_options(/W4 /WX /Zc:preprocessor)
@@ -27,7 +27,7 @@ endif()
 # project already defined any of these targets.
 add_subdirectory(vendor)
 
-# ---- MonolithEngine static library ----
+# ---- HoroEngine static library ----
 file(GLOB_RECURSE ENGINE_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/math/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp"
@@ -38,9 +38,9 @@ file(GLOB_RECURSE ENGINE_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/editor/*.cpp"
 )
 
-add_library(MonolithEngine STATIC ${ENGINE_SOURCES})
+add_library(HoroEngine STATIC ${ENGINE_SOURCES})
 
-target_include_directories(MonolithEngine
+target_include_directories(HoroEngine
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}   # engine internal: #include "math/Vec3.h"
                                       # when embedded at engine/: game code uses
@@ -48,7 +48,7 @@ target_include_directories(MonolithEngine
                                       # CMAKE_SOURCE_DIR include path
 )
 
-target_link_libraries(MonolithEngine
+target_link_libraries(HoroEngine
     PUBLIC
         glfw
         glad
@@ -59,21 +59,21 @@ target_link_libraries(MonolithEngine
 )
 
 if(APPLE)
-    target_link_libraries(MonolithEngine PUBLIC "-framework OpenGL")
+    target_link_libraries(HoroEngine PUBLIC "-framework OpenGL")
 elseif(WIN32)
-    target_link_libraries(MonolithEngine PUBLIC opengl32 comdlg32)
+    target_link_libraries(HoroEngine PUBLIC opengl32 comdlg32)
 else()
-    target_link_libraries(MonolithEngine PUBLIC GL)
+    target_link_libraries(HoroEngine PUBLIC GL)
 endif()
 
-target_compile_features(MonolithEngine PUBLIC cxx_std_20)
+target_compile_features(HoroEngine PUBLIC cxx_std_20)
 
 if(WIN32)
-    target_compile_definitions(MonolithEngine PUBLIC NOMINMAX)
+    target_compile_definitions(HoroEngine PUBLIC NOMINMAX)
 endif()
 
 # Copy GLSL shaders to bin/shaders alongside the executable
-add_custom_command(TARGET MonolithEngine POST_BUILD
+add_custom_command(TARGET HoroEngine POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_CURRENT_SOURCE_DIR}/renderer/shaders
         ${CMAKE_BINARY_DIR}/bin/shaders
@@ -81,12 +81,12 @@ add_custom_command(TARGET MonolithEngine POST_BUILD
 )
 
 # NOTE: The assets/ copy command (${CMAKE_SOURCE_DIR}/assets) is intentionally
-# absent here. Game assets belong to the consumer project (monolith/app/).
+# absent here. Game assets belong to the consumer project (horo/app/).
 # In standalone mode there are no game assets; in embedded mode app/CMakeLists.txt
 # handles the copy. Keeping it here would break standalone CI with a missing-dir error.
 
 # ---- Tests (standalone only) ----
-if(MONOLITH_ENGINE_BUILD_TESTS)
+if(HORO_ENGINE_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,7 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "MONOLITH_ENGINE_BUILD_TESTS": "ON"
+        "HORO_ENGINE_BUILD_TESTS": "ON"
       }
     },
     {
@@ -25,7 +25,7 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "MONOLITH_ENGINE_BUILD_TESTS": "OFF"
+        "HORO_ENGINE_BUILD_TESTS": "OFF"
       }
     },
     {
@@ -40,7 +40,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "MONOLITH_ENGINE_BUILD_TESTS": "ON"
+        "HORO_ENGINE_BUILD_TESTS": "ON"
       }
     },
     {
@@ -49,7 +49,7 @@
       "inherits": "debug-msvc",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "MONOLITH_ENGINE_BUILD_TESTS": "OFF"
+        "HORO_ENGINE_BUILD_TESTS": "OFF"
       }
     },
     {
@@ -63,7 +63,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "MONOLITH_ENGINE_BUILD_TESTS": "ON",
+        "HORO_ENGINE_BUILD_TESTS": "ON",
         "CMAKE_CXX_FLAGS": "--coverage -O0",
         "CMAKE_C_FLAGS": "--coverage -O0",
         "CMAKE_EXE_LINKER_FLAGS": "--coverage"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# monolith-engine — convenience wrapper around CMake presets
+# horo-engine — convenience wrapper around CMake presets
 # Usage: make [target]
 #
 # On Windows (MSVC):  uses debug-msvc / release-msvc presets automatically
@@ -8,8 +8,8 @@ ifeq ($(OS),Windows_NT)
     PRESET_DBG  ?= debug-msvc
     PRESET_REL  ?= release-msvc
     TESTS_BIN   := $(CURDIR)/build/$(PRESET_DBG)/bin/Debug
-    SENTINEL_DBG := build/$(PRESET_DBG)/MonolithEngine.sln
-    SENTINEL_REL := build/$(PRESET_REL)/MonolithEngine.sln
+    SENTINEL_DBG := build/$(PRESET_DBG)/HoroEngine.sln
+    SENTINEL_REL := build/$(PRESET_REL)/HoroEngine.sln
     BUILD_DBG   = cmake --build build/$(PRESET_DBG) --config Debug
     BUILD_REL   = cmake --build build/$(PRESET_REL) --config Release
     TEST_CMD    = ctest --test-dir build/$(PRESET_DBG) -C Debug --output-on-failure
@@ -140,7 +140,7 @@ coverage: $(SENTINEL_COV)
 	genhtml $(COV_DIR)/filtered.info \
 	        --output-directory $(COV_DIR)/html \
 	        --branch-coverage \
-	        --title "MonolithEngine Coverage"
+	        --title "HoroEngine Coverage"
 	@echo ""
 	@echo "Coverage report: $(COV_REPORT)"
 

--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -6,7 +6,7 @@
 #include "core/Time.h"
 #include "input/Input.h"
 
-namespace Monolith {
+namespace Horo {
 
 Application::Application(const AppSpec& spec) {
   WindowSpec ws;
@@ -49,4 +49,4 @@ void Application::Run() {
   LOG_INFO("Application shut down cleanly.");
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Application.h
+++ b/core/Application.h
@@ -4,10 +4,10 @@
 
 #include "core/Window.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct AppSpec {
-  std::string name = "Monolith App";
+  std::string name = "Horo App";
   int width = 1280;
   int height = 720;
   bool vsync = true;
@@ -38,4 +38,4 @@ class Application {
   bool m_running = true;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Assert.h
+++ b/core/Assert.h
@@ -3,9 +3,9 @@
 #include <cstdlib>
 
 #ifdef NDEBUG
-#define MONOLITH_ASSERT(expr, msg) ((void)0)
+#define HORO_ASSERT(expr, msg) ((void)0)
 #else
-#define MONOLITH_ASSERT(expr, msg)                                             \
+#define HORO_ASSERT(expr, msg)                                             \
   do {                                                                         \
     if (!(expr)) {                                                             \
       std::fprintf(stderr,                                                     \

--- a/core/Logger.cpp
+++ b/core/Logger.cpp
@@ -3,7 +3,7 @@
 #include <cstdarg>
 #include <cstdio>
 
-namespace Monolith {
+namespace Horo {
 
 void Log(LogLevel level, const char* file, int line, const char* fmt, ...) {
   const char* prefix;
@@ -40,4 +40,4 @@ void Log(LogLevel level, const char* file, int line, const char* fmt, ...) {
     std::printf("%s%s\n", prefix, msg);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Logger.h
+++ b/core/Logger.h
@@ -2,18 +2,18 @@
 #include <cstdio>
 #include <string_view>
 
-namespace Monolith {
+namespace Horo {
 
 enum class LogLevel { Info, Warn, Error };
 
 void Log(LogLevel level, const char* file, int line, const char* fmt, ...);
 
-}  // namespace Monolith
+}  // namespace Horo
 
 // NOLINT: intentional GNU extension for zero-arg VA_ARGS compatibility
 #define LOG_INFO(fmt, ...) \
-  Monolith::Log(Monolith::LogLevel::Info, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)
+  Horo::Log(Horo::LogLevel::Info, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_WARN(fmt, ...) \
-  Monolith::Log(Monolith::LogLevel::Warn, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)
+  Horo::Log(Horo::LogLevel::Warn, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_ERROR(fmt, ...) \
-  Monolith::Log(Monolith::LogLevel::Error, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)
+  Horo::Log(Horo::LogLevel::Error, __FILE__, __LINE__, fmt __VA_OPT__(, ) __VA_ARGS__)

--- a/core/Screenshot.cpp
+++ b/core/Screenshot.cpp
@@ -10,7 +10,7 @@
 
 #include "core/Logger.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Write a 24-bit BMP from bottom-up BGR pixel data (matches glReadPixels GL_BGR output).
 static bool WriteBMP(const std::string& path, int w, int h, const std::vector<uint8_t>& pixels) {
@@ -100,4 +100,4 @@ std::string Screenshot::Save(int w, int h, const std::string& folder) {
   return path;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Screenshot.h
+++ b/core/Screenshot.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace Monolith {
+namespace Horo {
 
 // Captures the current OpenGL framebuffer and writes it to a BMP file.
 // Call from the render thread (after SwapBuffers or just before it).
@@ -13,4 +13,4 @@ class Screenshot {
   static std::string Save(int viewportW, int viewportH, const std::string& folder);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Time.cpp
+++ b/core/Time.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-namespace Monolith {
+namespace Horo {
 
 double Time::s_lastTime = 0.0;
 float Time::s_deltaTime = 0.0f;
@@ -35,4 +35,4 @@ bool Time::ConsumeFixedStep() {
   return false;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Time.h
+++ b/core/Time.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-namespace Monolith {
+namespace Horo {
 
 class Time {
  public:
@@ -33,4 +33,4 @@ class Time {
   static uint64_t s_frameCount;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -9,7 +9,7 @@
 
 #include "core/Logger.h"
 
-namespace Monolith {
+namespace Horo {
 
 Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.height) {
   if (!glfwInit())
@@ -81,4 +81,4 @@ void Window::WindowCloseCallback(GLFWwindow* win) {
     self->m_closeCb();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/core/Window.h
+++ b/core/Window.h
@@ -4,10 +4,10 @@
 
 struct GLFWwindow;
 
-namespace Monolith {
+namespace Horo {
 
 struct WindowSpec {
-  std::string title = "Monolith";
+  std::string title = "Horo";
   int width = 1280;
   int height = 720;
   bool vsync = true;
@@ -48,4 +48,4 @@ class Window {
   static void WindowCloseCallback(GLFWwindow* win);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -36,7 +36,7 @@
 #include "math/Vec4.h"
 #include "renderer/DebugDraw.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 // ---- Lifecycle ---------------------------------------------------------------
@@ -1411,4 +1411,4 @@ void EditorLayer::ApplySchemaDefaults(SceneObject& obj) const {
 }
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -9,7 +9,7 @@
 
 struct GLFWwindow;
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 // In-game editor overlay.
@@ -148,4 +148,4 @@ class EditorLayer {
 };
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorSchema.cpp
+++ b/editor/EditorSchema.cpp
@@ -5,7 +5,7 @@
 
 using json = nlohmann::json;
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 static const char* TypeName(SceneObjectType t) {
@@ -75,4 +75,4 @@ const TypeSchema* EditorSchema::GetSchema(SceneObjectType t) const {
 }
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorSchema.h
+++ b/editor/EditorSchema.h
@@ -5,7 +5,7 @@
 
 #include "editor/SceneDocument.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 struct FieldDef {
@@ -39,4 +39,4 @@ class EditorSchema {
 };
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorSearch.cpp
+++ b/editor/EditorSearch.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cctype>
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 namespace {
@@ -57,4 +57,4 @@ bool AssetMatchesQuickOpenQuery(const std::string& assetId,
 }
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/EditorSearch.h
+++ b/editor/EditorSearch.h
@@ -4,7 +4,7 @@
 
 #include "editor/SceneDocument.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 struct ShortcutRow {
@@ -20,4 +20,4 @@ bool ObjectMatchesQuickOpenQuery(const SceneObject& obj, const std::string& quer
 bool AssetMatchesQuickOpenQuery(const std::string& assetId, const AssetDef& asset, const std::string& queryRaw);
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/Raycaster.cpp
+++ b/editor/Raycaster.cpp
@@ -7,7 +7,7 @@
 #include "math/Mat4.h"
 #include "math/Vec4.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 Ray ScreenToRay(float mouseX, float mouseY, int screenW, int screenH, const Camera& cam) {
@@ -62,4 +62,4 @@ float RayVsAABB(const Ray& ray, const Vec3& center, const Vec3& half) {
 }
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/Raycaster.h
+++ b/editor/Raycaster.h
@@ -2,7 +2,7 @@
 #include "math/Vec3.h"
 #include "renderer/Camera.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 struct Ray {
@@ -19,4 +19,4 @@ Ray ScreenToRay(float mouseX, float mouseY, int screenW, int screenH, const Came
 float RayVsAABB(const Ray& ray, const Vec3& center, const Vec3& half);
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/SceneDocument.h
+++ b/editor/SceneDocument.h
@@ -5,7 +5,7 @@
 
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 enum class SceneObjectType { Panel, Prop, Light };
@@ -43,4 +43,4 @@ struct SceneDocument {
 };
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/SceneSerializer.cpp
+++ b/editor/SceneSerializer.cpp
@@ -8,7 +8,7 @@
 
 using json = nlohmann::json;
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 static SceneObjectType TypeFromString(const std::string& s) {
@@ -166,4 +166,4 @@ void SceneSerializer::SaveToFile(const SceneDocument& doc, const std::string& pa
 }
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/editor/SceneSerializer.h
+++ b/editor/SceneSerializer.h
@@ -3,7 +3,7 @@
 
 #include "editor/SceneDocument.h"
 
-namespace Monolith {
+namespace Horo {
 namespace Editor {
 
 class SceneSerializer {
@@ -16,4 +16,4 @@ class SceneSerializer {
 };
 
 }  // namespace Editor
-}  // namespace Monolith
+}  // namespace Horo

--- a/input/Input.cpp
+++ b/input/Input.cpp
@@ -4,7 +4,7 @@
 
 #include <cstring>
 
-namespace Monolith {
+namespace Horo {
 
 GLFWwindow* Input::s_window = nullptr;
 bool Input::s_keys[MAX_KEYS] = {};
@@ -76,4 +76,4 @@ void Input::ScrollCallback(GLFWwindow*, double, double yOffset) {
   s_scrollDelta += static_cast<float>(yOffset);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/input/Input.h
+++ b/input/Input.h
@@ -5,7 +5,7 @@
 
 struct GLFWwindow;
 
-namespace Monolith {
+namespace Horo {
 
 class Input {
  public:
@@ -44,4 +44,4 @@ class Input {
   static void ScrollCallback(GLFWwindow*, double, double yOffset);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/input/KeyCodes.h
+++ b/input/KeyCodes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 // Mirror of GLFW key codes — avoids including GLFW in game code
 enum class Key : int {
@@ -71,4 +71,4 @@ enum class Key : int {
   RightAlt = 346,
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/input/MouseCodes.h
+++ b/input/MouseCodes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 enum class MouseButton : int {
   Left = 0,
@@ -8,4 +8,4 @@ enum class MouseButton : int {
   Middle = 2,
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Mat3.cpp
+++ b/math/Mat3.cpp
@@ -5,7 +5,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 Mat3::Mat3() {
   std::memset(m, 0, sizeof(m));
@@ -144,4 +144,4 @@ std::string Mat3::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Mat3.h
+++ b/math/Mat3.h
@@ -3,7 +3,7 @@
 
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Column-major 3x3 matrix.
 // m[col][row]
@@ -42,4 +42,4 @@ struct Mat3 {
   std::string ToString() const;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Mat4.cpp
+++ b/math/Mat4.cpp
@@ -6,7 +6,7 @@
 #include "math/MathUtils.h"
 #include "math/Quaternion.h"
 
-namespace Monolith {
+namespace Horo {
 
 Mat4::Mat4() {
   std::memset(m, 0, sizeof(m));
@@ -255,4 +255,4 @@ std::string Mat4::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Mat4.h
+++ b/math/Mat4.h
@@ -4,7 +4,7 @@
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct Quaternion;
 
@@ -54,4 +54,4 @@ struct Mat4 {
   std::string ToString() const;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/MathUtils.h
+++ b/math/MathUtils.h
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace Monolith {
+namespace Horo {
 
 constexpr float PI = 3.14159265358979323846f;
 constexpr float TWO_PI = 2.0f * PI;
@@ -74,4 +74,4 @@ inline bool NearlyZero(float v, float eps = EPSILON) {
   return Abs(v) <= eps;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Quaternion.cpp
+++ b/math/Quaternion.cpp
@@ -5,7 +5,7 @@
 #include "math/Mat3.h"
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 Quaternion Quaternion::FromAxisAngle(const Vec3& axis, float radians) {
   float half = radians * 0.5f;
@@ -172,4 +172,4 @@ std::string Quaternion::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Quaternion.h
+++ b/math/Quaternion.h
@@ -3,7 +3,7 @@
 
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct Mat3;
 
@@ -38,4 +38,4 @@ struct Quaternion {
   std::string ToString() const;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Transform.h
+++ b/math/Transform.h
@@ -3,7 +3,7 @@
 #include "math/Quaternion.h"
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct Transform {
   Vec3 position = Vec3::Zero();
@@ -30,4 +30,4 @@ struct Transform {
   static Transform Identity() { return {}; }
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec2.cpp
+++ b/math/Vec2.cpp
@@ -4,7 +4,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 Vec2 Vec2::Normalized() const {
   float len = Length();
@@ -19,4 +19,4 @@ std::string Vec2::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec2.h
+++ b/math/Vec2.h
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <string>
 
-namespace Monolith {
+namespace Horo {
 
 struct Vec2 {
   float x, y;
@@ -61,4 +61,4 @@ inline Vec2 operator*(float s, const Vec2& v) {
   return v * s;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec3.cpp
+++ b/math/Vec3.cpp
@@ -4,7 +4,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 float Vec3::Dot(const Vec3& a, const Vec3& b) {
   return a.x * b.x + a.y * b.y + a.z * b.z;
@@ -39,4 +39,4 @@ std::string Vec3::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec3.h
+++ b/math/Vec3.h
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <string>
 
-namespace Monolith {
+namespace Horo {
 
 struct Vec3 {
   float x, y, z;
@@ -74,4 +74,4 @@ inline Vec3 operator*(float s, const Vec3& v) {
   return v * s;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec4.cpp
+++ b/math/Vec4.cpp
@@ -4,7 +4,7 @@
 
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 Vec4::Vec4(const Vec3& v, float w) : x(v.x), y(v.y), z(v.z), w(w) {}
 
@@ -18,4 +18,4 @@ std::string Vec4::ToString() const {
   return ss.str();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/math/Vec4.h
+++ b/math/Vec4.h
@@ -2,7 +2,7 @@
 #include <cmath>
 #include <string>
 
-namespace Monolith {
+namespace Horo {
 
 struct Vec3;
 
@@ -64,4 +64,4 @@ inline Vec4 operator*(float s, const Vec4& v) {
   return v * s;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/BoxCollider.h
+++ b/physics/BoxCollider.h
@@ -2,7 +2,7 @@
 #include "math/Vec3.h"
 #include "physics/Collider.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct BoxCollider : Collider {
   Vec3 halfExtents;  // half-widths in each axis
@@ -11,4 +11,4 @@ struct BoxCollider : Collider {
       : Collider(ColliderType::Box), halfExtents(half) {}
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/Collider.h
+++ b/physics/Collider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 enum class ColliderType { Sphere, Box, Capsule, Plane };
 
@@ -10,4 +10,4 @@ struct Collider {
   virtual ~Collider() = default;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/PhysicsWorld.cpp
+++ b/physics/PhysicsWorld.cpp
@@ -11,7 +11,7 @@
 #include "physics/narrowphase/GJK.h"
 #include "physics/narrowphase/SAT.h"
 
-namespace Monolith {
+namespace Horo {
 
 RigidBody* PhysicsWorld::AddBody(RigidBody body) {
   m_bodies.push_back(std::make_unique<RigidBody>(std::move(body)));
@@ -141,4 +141,4 @@ void PhysicsWorld::SolveBoxPlane(RigidBody& box,
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/PhysicsWorld.h
+++ b/physics/PhysicsWorld.h
@@ -5,7 +5,7 @@
 #include "math/Vec3.h"
 #include "physics/constraints/ConstraintSolver.h"
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -36,4 +36,4 @@ class PhysicsWorld {
   void SolveBoxPlane(RigidBody& box, float planeY, std::vector<ContactConstraint>& contacts);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/RigidBody.cpp
+++ b/physics/RigidBody.cpp
@@ -4,7 +4,7 @@
 #include "physics/BoxCollider.h"
 #include "physics/SphereCollider.h"
 
-namespace Monolith {
+namespace Horo {
 
 RigidBody RigidBody::MakeStatic() {
   RigidBody b;
@@ -72,4 +72,4 @@ void RigidBody::AddForceAtPoint(const Vec3& f, const Vec3& worldPoint) {
   torqueAccum += Vec3::Cross(worldPoint - position, f);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/RigidBody.h
+++ b/physics/RigidBody.h
@@ -6,7 +6,7 @@
 #include "math/Vec3.h"
 #include "physics/Collider.h"
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody {
  public:
@@ -59,4 +59,4 @@ class RigidBody {
   void UpdateWorldInertia();
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/SphereCollider.h
+++ b/physics/SphereCollider.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "physics/Collider.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct SphereCollider : Collider {
   float radius;
@@ -9,4 +9,4 @@ struct SphereCollider : Collider {
   explicit SphereCollider(float r = 0.5f) : Collider(ColliderType::Sphere), radius(r) {}
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/broadphase/BruteForce.cpp
+++ b/physics/broadphase/BruteForce.cpp
@@ -5,7 +5,7 @@
 #include "physics/RigidBody.h"
 #include "physics/SphereCollider.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace BruteForce {
 
@@ -50,4 +50,4 @@ std::vector<std::pair<int, int>> FindOverlappingPairs(const std::vector<RigidBod
 }
 
 }  // namespace BruteForce
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/broadphase/BruteForce.h
+++ b/physics/broadphase/BruteForce.h
@@ -2,7 +2,7 @@
 #include <utility>
 #include <vector>
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -13,4 +13,4 @@ namespace BruteForce {
 std::vector<std::pair<int, int>> FindOverlappingPairs(const std::vector<RigidBody*>& bodies);
 
 }  // namespace BruteForce
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/constraints/ConstraintSolver.cpp
+++ b/physics/constraints/ConstraintSolver.cpp
@@ -1,6 +1,6 @@
 #include "physics/constraints/ConstraintSolver.h"
 
-namespace Monolith {
+namespace Horo {
 
 void ConstraintSolver::Solve(std::vector<ContactConstraint>& constraints, int iterations) {
   for (int i = 0; i < iterations; i++)
@@ -8,4 +8,4 @@ void ConstraintSolver::Solve(std::vector<ContactConstraint>& constraints, int it
       c.Solve();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/constraints/ConstraintSolver.h
+++ b/physics/constraints/ConstraintSolver.h
@@ -3,7 +3,7 @@
 
 #include "physics/constraints/ContactConstraint.h"
 
-namespace Monolith {
+namespace Horo {
 
 class ConstraintSolver {
  public:
@@ -12,4 +12,4 @@ class ConstraintSolver {
   void Solve(std::vector<ContactConstraint>& constraints, int iterations = DEFAULT_ITERATIONS);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/constraints/ContactConstraint.cpp
+++ b/physics/constraints/ContactConstraint.cpp
@@ -3,7 +3,7 @@
 #include "math/MathUtils.h"
 #include "physics/RigidBody.h"
 
-namespace Monolith {
+namespace Horo {
 
 void ContactConstraint::Solve() {
   if (!bodyA || !bodyB)
@@ -99,4 +99,4 @@ void ContactConstraint::Solve() {
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/constraints/ContactConstraint.h
+++ b/physics/constraints/ContactConstraint.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "physics/narrowphase/ContactManifold.h"
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -19,4 +19,4 @@ struct ContactConstraint {
   void Solve();
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/integration/SemiImplicitEuler.cpp
+++ b/physics/integration/SemiImplicitEuler.cpp
@@ -3,7 +3,7 @@
 #include "math/MathUtils.h"
 #include "physics/RigidBody.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace SemiImplicitEuler {
 
@@ -40,4 +40,4 @@ void Integrate(RigidBody& body, float dt) {
 }
 
 }  // namespace SemiImplicitEuler
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/integration/SemiImplicitEuler.h
+++ b/physics/integration/SemiImplicitEuler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -13,4 +13,4 @@ namespace SemiImplicitEuler {
 void Integrate(RigidBody& body, float dt);
 
 }  // namespace SemiImplicitEuler
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/narrowphase/ContactManifold.h
+++ b/physics/narrowphase/ContactManifold.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct ContactPoint {
   Vec3 point;         // contact position in world space
@@ -26,4 +26,4 @@ struct ContactManifold {
   }
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/narrowphase/GJK.cpp
+++ b/physics/narrowphase/GJK.cpp
@@ -8,7 +8,7 @@
 #include "physics/RigidBody.h"
 #include "physics/SphereCollider.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace GJK {
 
@@ -63,4 +63,4 @@ ContactManifold Test(const RigidBody& a, const RigidBody& b) {
 }
 
 }  // namespace GJK
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/narrowphase/GJK.h
+++ b/physics/narrowphase/GJK.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "physics/narrowphase/ContactManifold.h"
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -12,4 +12,4 @@ namespace GJK {
 ContactManifold Test(const RigidBody& a, const RigidBody& b);
 
 }  // namespace GJK
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/narrowphase/SAT.cpp
+++ b/physics/narrowphase/SAT.cpp
@@ -8,7 +8,7 @@
 #include "physics/BoxCollider.h"
 #include "physics/RigidBody.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace SAT {
 
@@ -148,4 +148,4 @@ ContactManifold TestBoxBox(const RigidBody& a, const RigidBody& b) {
 }
 
 }  // namespace SAT
-}  // namespace Monolith
+}  // namespace Horo

--- a/physics/narrowphase/SAT.h
+++ b/physics/narrowphase/SAT.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "physics/narrowphase/ContactManifold.h"
 
-namespace Monolith {
+namespace Horo {
 
 class RigidBody;
 
@@ -12,4 +12,4 @@ namespace SAT {
 ContactManifold TestBoxBox(const RigidBody& a, const RigidBody& b);
 
 }  // namespace SAT
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Camera.cpp
+++ b/renderer/Camera.cpp
@@ -2,7 +2,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 Mat4 Camera::GetView() const {
   return Mat4::LookAt(position, target, up);
@@ -12,4 +12,4 @@ Mat4 Camera::GetProjection() const {
   return Mat4::Perspective(ToRadians(fovY), aspect, zNear, zFar);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Camera.h
+++ b/renderer/Camera.h
@@ -2,7 +2,7 @@
 #include "math/Mat4.h"
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Camera {
  public:
@@ -27,4 +27,4 @@ class Camera {
   Vec3 GetRight() const { return Vec3::Cross(GetForward(), up).Normalized(); }
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/DebugDraw.cpp
+++ b/renderer/DebugDraw.cpp
@@ -7,7 +7,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 std::vector<DebugDraw::LineVertex> DebugDraw::s_lines;
 Shader* DebugDraw::s_shader = nullptr;
@@ -158,4 +158,4 @@ void DebugDraw::Flush(const Camera& camera) {
   s_lines.clear();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/DebugDraw.h
+++ b/renderer/DebugDraw.h
@@ -6,7 +6,7 @@
 #include "renderer/Camera.h"
 #include "renderer/Shader.h"
 
-namespace Monolith {
+namespace Horo {
 
 class DebugDraw {
  public:
@@ -40,4 +40,4 @@ class DebugDraw {
   static bool s_initialized;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -16,7 +16,7 @@
 #undef DrawText
 #endif
 
-namespace Monolith {
+namespace Horo {
 
 // ---- Static member definitions ----
 
@@ -1620,4 +1620,4 @@ void DebugHUD::FlushGlyphs() {
   s_glyphCount = 0;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/DebugHUD.h
+++ b/renderer/DebugHUD.h
@@ -6,7 +6,7 @@
 #include "math/Vec3.h"
 #include "renderer/Shader.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct HUDStats {
   float fps, frameTimeMs;
@@ -74,4 +74,4 @@ class DebugHUD {
   static void FlushGlyphs();
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Light.h
+++ b/renderer/Light.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct Light {
   enum class Type { Directional = 0, Point = 1 };
@@ -14,4 +14,4 @@ struct Light {
   float radius = 10.0f;  // effective range in metres (Point only)
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Material.cpp
+++ b/renderer/Material.cpp
@@ -1,6 +1,6 @@
 #include "renderer/Material.h"
 
-namespace Monolith {
+namespace Horo {
 
 void Material::Apply() const {
   if (!shader || !shader->IsValid())
@@ -17,4 +17,4 @@ void Material::Apply() const {
   shader->SetFloat("u_uvScale", uvScale);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Material.h
+++ b/renderer/Material.h
@@ -5,7 +5,7 @@
 #include "renderer/Shader.h"
 #include "renderer/Texture.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Material {
  public:
@@ -21,4 +21,4 @@ class Material {
   void Apply() const;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -8,7 +8,7 @@
 
 #include "math/MathUtils.h"
 
-namespace Monolith {
+namespace Horo {
 
 Mesh::~Mesh() {
   Release();
@@ -351,4 +351,4 @@ Mesh Mesh::CreateQuad() {
   return m;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Mesh.h
+++ b/renderer/Mesh.h
@@ -4,7 +4,7 @@
 #include "math/Vec2.h"
 #include "math/Vec3.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct Vertex {
   Vec3 position;
@@ -49,4 +49,4 @@ class Mesh {
   void Release();
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/MeshCache.cpp
+++ b/renderer/MeshCache.cpp
@@ -7,7 +7,7 @@
 #include "core/Logger.h"
 #include "renderer/ObjLoader.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace {
 
@@ -61,4 +61,4 @@ std::shared_ptr<Mesh> MeshCache::Get(const std::string& path) {
   return mesh;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/MeshCache.h
+++ b/renderer/MeshCache.h
@@ -5,7 +5,7 @@
 
 #include "renderer/Mesh.h"
 
-namespace Monolith {
+namespace Horo {
 
 // File-path keyed cache that avoids reloading the same .obj more than once.
 class MeshCache {
@@ -20,4 +20,4 @@ class MeshCache {
   std::unordered_map<std::string, std::shared_ptr<Mesh>> m_cache;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/ObjLoader.cpp
+++ b/renderer/ObjLoader.cpp
@@ -8,7 +8,7 @@
 
 #include "math/Vec2.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace ObjLoader {
 
@@ -122,4 +122,4 @@ Mesh Load(const std::string& path) {
 
 }  // namespace ObjLoader
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/ObjLoader.h
+++ b/renderer/ObjLoader.h
@@ -3,7 +3,7 @@
 
 #include "renderer/Mesh.h"
 
-namespace Monolith {
+namespace Horo {
 
 namespace ObjLoader {
 // Load a triangulated .obj file (v/vt/vn lines, triangulated f lines).
@@ -12,4 +12,4 @@ Mesh Load(const std::string& path);
 
 }  // namespace ObjLoader
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/RenderContext.cpp
+++ b/renderer/RenderContext.cpp
@@ -2,7 +2,7 @@
 
 #include <glad/glad.h>
 
-namespace Monolith {
+namespace Horo {
 
 void RenderContext::Init() {
   glEnable(GL_DEPTH_TEST);
@@ -45,4 +45,4 @@ void RenderContext::SetBlend(bool enabled) {
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/RenderContext.h
+++ b/renderer/RenderContext.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "math/Vec4.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Thin wrapper around OpenGL state that should only be set once per frame
 // rather than per draw call.
@@ -19,4 +19,4 @@ class RenderContext {
   static void SetBlend(bool enabled);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -7,7 +7,7 @@
 #include "renderer/Mesh.h"
 #include "renderer/Shader.h"
 
-namespace Monolith {
+namespace Horo {
 
 Mat4 Renderer::s_view;
 Mat4 Renderer::s_projection;
@@ -73,4 +73,4 @@ void Renderer::SubmitWireframe(
   ++s_drawCalls;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -5,7 +5,7 @@
 #include "renderer/Camera.h"
 #include "renderer/Light.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Mesh;
 class Shader;
@@ -41,4 +41,4 @@ class Renderer {
   static unsigned int s_lastLightProgram;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Shader.cpp
+++ b/renderer/Shader.cpp
@@ -8,7 +8,7 @@
 
 #include "core/Logger.h"
 
-namespace Monolith {
+namespace Horo {
 
 Shader::~Shader() {
   if (m_program)
@@ -136,4 +136,4 @@ void Shader::SetMat4(const std::string& name, const Mat4& m) const {
   glUniformMatrix4fv(GetUniformLocation(name), 1, GL_FALSE, m.Data());
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Shader.h
+++ b/renderer/Shader.h
@@ -7,7 +7,7 @@
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Shader {
  public:
@@ -49,4 +49,4 @@ class Shader {
   static unsigned int LinkProgram(unsigned int vert, unsigned int frag);
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -7,7 +7,7 @@
 
 #include "core/Logger.h"
 
-namespace Monolith {
+namespace Horo {
 
 Texture::~Texture() {
   if (m_id)
@@ -77,4 +77,4 @@ void Texture::Unbind() const {
   glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace Monolith {
+namespace Horo {
 
 class Texture {
  public:
@@ -29,4 +29,4 @@ class Texture {
   int m_height = 0;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/ComponentPool.h
+++ b/scene/ComponentPool.h
@@ -6,7 +6,7 @@
 #include "scene/Entity.h"
 #include "scene/IComponentPoolBase.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Dense SoA component pool.
 // Provides O(1) add/get/remove with packed storage.
@@ -68,4 +68,4 @@ class ComponentPool : public IComponentPoolBase {
   std::vector<Entity> m_denseEntities;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/Entity.h
+++ b/scene/Entity.h
@@ -2,9 +2,9 @@
 #include <cstdint>
 #include <limits>
 
-namespace Monolith {
+namespace Horo {
 
 using Entity = uint32_t;
 constexpr Entity INVALID_ENTITY = std::numeric_limits<uint32_t>::max();
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/IComponentPoolBase.h
+++ b/scene/IComponentPoolBase.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "scene/Entity.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Non-template base for ComponentPool<T>, used by Registry::Destroy to remove
 // a component from all pools without knowing the type.
@@ -12,4 +12,4 @@ class IComponentPoolBase {
   virtual void ClearAll() = 0;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/Registry.cpp
+++ b/scene/Registry.cpp
@@ -1,6 +1,6 @@
 #include "scene/Registry.h"
 
-namespace Monolith {
+namespace Horo {
 
 Entity Registry::Create() {
   Entity e;
@@ -34,4 +34,4 @@ void Registry::Clear() {
   m_nextId = 0;
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/Registry.h
+++ b/scene/Registry.h
@@ -11,7 +11,7 @@
 #include "scene/Entity.h"
 #include "scene/IComponentPoolBase.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Type-indexed ECS registry.  Adding a new component type requires zero Registry edits.
 // Add<T>, Get<T>, Has<T>, Remove<T>, GetEntities<T> all work for any T.
@@ -96,4 +96,4 @@ class Registry {
   }
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/Scene.cpp
+++ b/scene/Scene.cpp
@@ -2,7 +2,7 @@
 
 #include "scene/components/TransformComponent.h"
 
-namespace Monolith {
+namespace Horo {
 
 void Scene::AddSystem(std::unique_ptr<System> system) {
   m_systems.push_back(std::move(system));
@@ -36,4 +36,4 @@ void Scene::Clear() {
   registry.Clear();
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/Scene.h
+++ b/scene/Scene.h
@@ -6,7 +6,7 @@
 #include "scene/Registry.h"
 #include "scene/System.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Scene {
  public:
@@ -32,4 +32,4 @@ class Scene {
   std::vector<std::unique_ptr<System>> m_renderSystems;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/System.h
+++ b/scene/System.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 class Registry;
 
@@ -10,4 +10,4 @@ class System {
   virtual void OnUpdate(Registry& registry, float dt) = 0;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/BehaviorComponent.h
+++ b/scene/components/BehaviorComponent.h
@@ -3,7 +3,7 @@
 
 #include "scene/Entity.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Registry;
 
@@ -19,4 +19,4 @@ struct BehaviorComponent {
   std::unique_ptr<Behavior> behavior;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/CameraComponent.h
+++ b/scene/components/CameraComponent.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "renderer/Camera.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct CameraComponent {
   Camera camera;
   bool isActive = false;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/MeshComponent.h
+++ b/scene/components/MeshComponent.h
@@ -5,7 +5,7 @@
 #include "renderer/Material.h"
 #include "renderer/Mesh.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct MeshComponent {
   std::shared_ptr<Mesh> mesh;
@@ -14,4 +14,4 @@ struct MeshComponent {
   std::string meshTag;  // source tag for scene export ("stone.obj", etc.)
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/PlayerTagComponent.h
+++ b/scene/components/PlayerTagComponent.h
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace Monolith {
+namespace Horo {
 
 // Zero-size tag added to the player entity.
 // Behaviors locate the player via registry.GetEntities<PlayerTagComponent>(); always
 // guard against empty before indexing (there may be zero players in editor mode).
 struct PlayerTagComponent {};
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/RigidBodyComponent.h
+++ b/scene/components/RigidBodyComponent.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "physics/RigidBody.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Stores a pointer to the RigidBody owned by PhysicsWorld
 struct RigidBodyComponent {
   RigidBody* body = nullptr;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/components/TransformComponent.h
+++ b/scene/components/TransformComponent.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "math/Transform.h"
 
-namespace Monolith {
+namespace Horo {
 
 struct TransformComponent {
   Transform current;
   Transform previous;  // for interpolated rendering
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/BehaviorSystem.cpp
+++ b/scene/systems/BehaviorSystem.cpp
@@ -3,11 +3,11 @@
 #include "scene/Registry.h"
 #include "scene/components/BehaviorComponent.h"
 
-namespace Monolith {
+namespace Horo {
 
 void BehaviorSystem::OnUpdate(Registry& registry, float dt) {
   for (Entity e : registry.GetEntities<BehaviorComponent>())
     registry.Get<BehaviorComponent>(e).behavior->OnUpdate(e, registry, dt);
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/BehaviorSystem.h
+++ b/scene/systems/BehaviorSystem.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "scene/System.h"
 
-namespace Monolith {
+namespace Horo {
 
 class BehaviorSystem : public System {
  public:
   void OnUpdate(Registry& registry, float dt) override;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/CameraSystem.cpp
+++ b/scene/systems/CameraSystem.cpp
@@ -4,7 +4,7 @@
 #include "scene/components/CameraComponent.h"
 #include "scene/components/TransformComponent.h"
 
-namespace Monolith {
+namespace Horo {
 
 void CameraSystem::OnUpdate(Registry& registry, float dt) {
   (void)dt;
@@ -22,4 +22,4 @@ void CameraSystem::OnUpdate(Registry& registry, float dt) {
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/CameraSystem.h
+++ b/scene/systems/CameraSystem.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "scene/System.h"
 
-namespace Monolith {
+namespace Horo {
 
 class CameraSystem : public System {
  public:
   void OnUpdate(Registry& registry, float dt) override;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/PhysicsSystem.cpp
+++ b/scene/systems/PhysicsSystem.cpp
@@ -5,7 +5,7 @@
 #include "scene/components/RigidBodyComponent.h"
 #include "scene/components/TransformComponent.h"
 
-namespace Monolith {
+namespace Horo {
 
 void PhysicsSystem::OnUpdate(Registry& registry, float dt) {
   m_world.Step(dt);
@@ -26,4 +26,4 @@ void PhysicsSystem::OnUpdate(Registry& registry, float dt) {
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/PhysicsSystem.h
+++ b/scene/systems/PhysicsSystem.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "scene/System.h"
 
-namespace Monolith {
+namespace Horo {
 
 class PhysicsWorld;
 
@@ -14,4 +14,4 @@ class PhysicsSystem : public System {
   PhysicsWorld& m_world;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/RenderSystem.cpp
+++ b/scene/systems/RenderSystem.cpp
@@ -6,7 +6,7 @@
 #include "scene/components/MeshComponent.h"
 #include "scene/components/TransformComponent.h"
 
-namespace Monolith {
+namespace Horo {
 
 // Submits all visible mesh entities.  BeginScene/EndScene are called by the
 // owner (GameScene::Render) so they bracket this submission pass.
@@ -31,4 +31,4 @@ void RenderSystem::OnUpdate(Registry& registry, float dt) {
   }
 }
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/scene/systems/RenderSystem.h
+++ b/scene/systems/RenderSystem.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "scene/System.h"
 
-namespace Monolith {
+namespace Horo {
 
 class Camera;
 
@@ -15,4 +15,4 @@ class RenderSystem : public System {
   float& m_alpha;
 };
 
-}  // namespace Monolith
+}  // namespace Horo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,110 +11,110 @@ FetchContent_MakeAvailable(Catch2)
 
 # ---- test_math ----
 add_executable(test_math test_math.cpp)
-target_link_libraries(test_math PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_math COMMAND test_math)
 
 # ---- test_physics ----
 add_executable(test_physics test_physics.cpp)
-target_link_libraries(test_physics PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_physics COMMAND test_physics)
 
 # ---- test_math_extended ----
 add_executable(test_math_extended test_math_extended.cpp)
-target_link_libraries(test_math_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_math_extended COMMAND test_math_extended)
 
 # ---- test_physics_extended ----
 add_executable(test_physics_extended test_physics_extended.cpp)
-target_link_libraries(test_physics_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_physics_extended COMMAND test_physics_extended)
 
 # ---- test_ecs ----
 add_executable(test_ecs test_ecs.cpp)
-target_link_libraries(test_ecs PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_ecs PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_ecs COMMAND test_ecs)
 
 # ---- test_gjk ----
 add_executable(test_gjk test_gjk.cpp)
-target_link_libraries(test_gjk PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_gjk COMMAND test_gjk)
 
 # ---- test_integration ----
 add_executable(test_integration test_integration.cpp)
-target_link_libraries(test_integration PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_integration PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_integration COMMAND test_integration)
 
 # ---- test_constraints ----
 add_executable(test_constraints test_constraints.cpp)
-target_link_libraries(test_constraints PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_constraints PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_constraints COMMAND test_constraints)
 
 # ---- test_physics_world ----
 add_executable(test_physics_world test_physics_world.cpp)
-target_link_libraries(test_physics_world PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_world PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_physics_world COMMAND test_physics_world)
 
 # ---- test_scene ----
 add_executable(test_scene test_scene.cpp)
-target_link_libraries(test_scene PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_scene COMMAND test_scene)
 
 # ---- test_camera ----
 add_executable(test_camera test_camera.cpp)
-target_link_libraries(test_camera PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_camera COMMAND test_camera)
 
 # ---- test_math_coverage ----
 add_executable(test_math_coverage test_math_coverage.cpp)
-target_link_libraries(test_math_coverage PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_math_coverage COMMAND test_math_coverage)
 
 # ---- test_physics_coverage ----
 add_executable(test_physics_coverage test_physics_coverage.cpp)
-target_link_libraries(test_physics_coverage PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_physics_coverage COMMAND test_physics_coverage)
 
 # ---- test_editor ----
 add_executable(test_editor test_editor.cpp)
-target_link_libraries(test_editor PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_editor PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_editor COMMAND test_editor)
 
 # ---- test_transform ----
 add_executable(test_transform test_transform.cpp)
-target_link_libraries(test_transform PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_transform PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_transform COMMAND test_transform)
 
 # ---- test_physics_deep ----
 add_executable(test_physics_deep test_physics_deep.cpp)
-target_link_libraries(test_physics_deep PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_deep PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_physics_deep COMMAND test_physics_deep)
 
 # ---- test_registry_extended ----
 add_executable(test_registry_extended test_registry_extended.cpp)
-target_link_libraries(test_registry_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_registry_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_registry_extended COMMAND test_registry_extended)
 
 # ---- test_camera_extended ----
 add_executable(test_camera_extended test_camera_extended.cpp)
-target_link_libraries(test_camera_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_camera_extended COMMAND test_camera_extended)
 
 # ---- test_core ----
 add_executable(test_core test_core.cpp)
-target_link_libraries(test_core PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_core PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_core COMMAND test_core)
 
 # ---- test_scene_systems ----
 add_executable(test_scene_systems test_scene_systems.cpp)
-target_link_libraries(test_scene_systems PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_systems PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_scene_systems COMMAND test_scene_systems)
 
 # ---- test_gjk_extended ----
 add_executable(test_gjk_extended test_gjk_extended.cpp)
-target_link_libraries(test_gjk_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_gjk_extended COMMAND test_gjk_extended)
 
 # ---- test_quaternion_extended ----
 add_executable(test_quaternion_extended test_quaternion_extended.cpp)
-target_link_libraries(test_quaternion_extended PRIVATE MonolithEngine Catch2::Catch2WithMain)
+target_link_libraries(test_quaternion_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
 add_test(NAME test_quaternion_extended COMMAND test_quaternion_extended)

--- a/tests/test_camera.cpp
+++ b/tests/test_camera.cpp
@@ -6,7 +6,7 @@
 #include "math/Mat4.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_camera_extended.cpp
+++ b/tests/test_camera_extended.cpp
@@ -6,7 +6,7 @@
 #include "math/Vec3.h"
 #include "renderer/Camera.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_constraints.cpp
+++ b/tests/test_constraints.cpp
@@ -7,7 +7,7 @@
 #include "physics/narrowphase/ContactManifold.h"
 #include "math/Vec3.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -7,7 +7,7 @@
 #include "core/Logger.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_ecs.cpp
+++ b/tests/test_ecs.cpp
@@ -5,7 +5,7 @@
 #include "scene/Entity.h"
 #include "math/Vec3.h"
 
-using namespace Monolith;
+using namespace Horo;
 
 // Simple test components — no dependencies on ECS components
 struct Position { float x = 0, y = 0, z = 0; };

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -16,20 +16,20 @@
 #include "editor/SceneSerializer.h"
 #include "renderer/Camera.h"
 
-using namespace Monolith;
-using namespace Monolith::Editor;
+using namespace Horo;
+using namespace Horo::Editor;
 
 namespace {
-Monolith::Editor::SceneObject MakeObjectFromAssetForTest(const Monolith::Editor::SceneDocument&, const std::string& assetId) {
-    Monolith::Editor::SceneObject obj;
+Horo::Editor::SceneObject MakeObjectFromAssetForTest(const Horo::Editor::SceneDocument&, const std::string& assetId) {
+    Horo::Editor::SceneObject obj;
     obj.id = "generated";
-    obj.type = Monolith::Editor::SceneObjectType::Prop;
+    obj.type = Horo::Editor::SceneObjectType::Prop;
     obj.assetId = assetId;
     return obj;
 }
 
-Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::SceneDocument& doc, const Monolith::Editor::SceneObject& src) {
-    Monolith::Editor::SceneObject clone = src;
+Horo::Editor::SceneObject DuplicateObjectForTest(const Horo::Editor::SceneDocument& doc, const Horo::Editor::SceneObject& src) {
+    Horo::Editor::SceneObject clone = src;
     clone.id = "copy_" + std::to_string(doc.objects.size());
     clone.props.erase("_eid");
     return clone;

--- a/tests/test_gjk.cpp
+++ b/tests/test_gjk.cpp
@@ -7,7 +7,7 @@
 #include "physics/narrowphase/GJK.h"
 #include "math/Vec3.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_gjk_extended.cpp
+++ b/tests/test_gjk_extended.cpp
@@ -10,7 +10,7 @@
 #include "physics/narrowphase/GJK.h"
 #include "physics/narrowphase/SAT.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -6,7 +6,7 @@
 #include "math/Vec3.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -8,7 +8,7 @@
 #include "math/Quaternion.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ---- Vec3 ----

--- a/tests/test_math_coverage.cpp
+++ b/tests/test_math_coverage.cpp
@@ -18,7 +18,7 @@
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_math_extended.cpp
+++ b/tests/test_math_extended.cpp
@@ -10,7 +10,7 @@
 #include "math/Transform.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_physics.cpp
+++ b/tests/test_physics.cpp
@@ -11,7 +11,7 @@
 #include "math/Vec3.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ---- RigidBody construction ----

--- a/tests/test_physics_coverage.cpp
+++ b/tests/test_physics_coverage.cpp
@@ -26,7 +26,7 @@
 #include "physics/narrowphase/GJK.h"
 #include "physics/narrowphase/SAT.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_physics_deep.cpp
+++ b/tests/test_physics_deep.cpp
@@ -14,7 +14,7 @@
 #include "physics/constraints/ContactConstraint.h"
 #include "physics/narrowphase/ContactManifold.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_physics_extended.cpp
+++ b/tests/test_physics_extended.cpp
@@ -12,7 +12,7 @@
 #include "math/Vec3.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_physics_world.cpp
+++ b/tests/test_physics_world.cpp
@@ -8,7 +8,7 @@
 #include "math/Vec3.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_quaternion_extended.cpp
+++ b/tests/test_quaternion_extended.cpp
@@ -8,7 +8,7 @@
 #include "math/Quaternion.h"
 #include "math/Vec3.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_registry_extended.cpp
+++ b/tests/test_registry_extended.cpp
@@ -8,7 +8,7 @@
 #include "scene/Entity.h"
 #include "scene/Registry.h"
 
-using namespace Monolith;
+using namespace Horo;
 
 // ---------------------------------------------------------------------------
 // Test components

--- a/tests/test_scene.cpp
+++ b/tests/test_scene.cpp
@@ -14,7 +14,7 @@
 #include "math/Vec3.h"
 #include "math/MathUtils.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ============================================================

--- a/tests/test_scene_systems.cpp
+++ b/tests/test_scene_systems.cpp
@@ -16,7 +16,7 @@
 #include "scene/systems/CameraSystem.h"
 #include "scene/systems/PhysicsSystem.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================

--- a/tests/test_transform.cpp
+++ b/tests/test_transform.cpp
@@ -7,7 +7,7 @@
 #include "math/Transform.h"
 #include "math/Vec3.h"
 
-using namespace Monolith;
+using namespace Horo;
 using Catch::Approx;
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- migrate first-party codebase naming from `Monolith` to `Horo` (namespace usage, tests, and related first-party build identifiers)
- keep third-party directories unchanged (`vendor/`, `build/`, `.git/` excluded)
- preserve behavior while aligning engine naming consistently with `horo-engine`

## Validation
- `ctest --preset debug` → 22/22 passed
- `gcovr --print-summary` (filtered exclusions) → lines 39.1% (repo-wide baseline)
- verification command: `rg -n "\\bMonolith\\b" . --glob '!.git/**' --glob '!vendor/**' --glob '!build/**'` returns no matches

## Notes
- This PR is a naming cleanup/refactor; runtime behavior is unchanged.