### PR TITLE
[codex] fix MCP scene consistency

### DIFF
--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -395,6 +395,73 @@ static bool TryResolveObjectMeshPath(const SceneDocument& doc,
   return true;
 }
 
+bool IsObjectReferencePropKey(const std::string& key) {
+  return key == "parentId" || key == "followTargetId";
+}
+
+std::unordered_set<std::string> CollectReservedObjectIds(const SceneDocument& doc) {
+  std::unordered_set<std::string> reservedIds;
+  reservedIds.reserve(doc.objects.size() * 2);
+  for (const SceneObject& obj : doc.objects) {
+    if (!obj.id.empty())
+      reservedIds.insert(obj.id);
+    for (const auto& entry : obj.props) {
+      if (IsObjectReferencePropKey(entry.first) && !entry.second.empty())
+        reservedIds.insert(entry.second);
+    }
+  }
+  return reservedIds;
+}
+
+bool IsReservedObjectId(const SceneDocument& doc,
+                        const std::string& id,
+                        const std::string* ignoreConcreteObjectId = nullptr) {
+  if (id.empty())
+    return false;
+  for (const SceneObject& obj : doc.objects) {
+    if (!obj.id.empty() && (!ignoreConcreteObjectId || obj.id != *ignoreConcreteObjectId) && obj.id == id)
+      return true;
+    for (const auto& entry : obj.props) {
+      if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
+        continue;
+      if (ignoreConcreteObjectId && entry.second == *ignoreConcreteObjectId)
+        continue;
+      if (entry.second == id)
+        return true;
+    }
+  }
+  return false;
+}
+
+void RewriteObjectIdReferences(SceneDocument* doc, const std::string& oldId, const std::string& newId) {
+  if (!doc || oldId.empty() || oldId == newId)
+    return;
+  for (SceneObject& object : doc->objects) {
+    for (auto& entry : object.props) {
+      if (IsObjectReferencePropKey(entry.first) && entry.second == oldId)
+        entry.second = newId;
+    }
+  }
+}
+
+void LogDanglingObjectReferences(const SceneDocument& doc, const std::string& sourceLabel) {
+  std::unordered_set<std::string> objectIds;
+  objectIds.reserve(doc.objects.size() * 2);
+  for (const SceneObject& object : doc.objects) {
+    if (!object.id.empty())
+      objectIds.insert(object.id);
+  }
+  for (const SceneObject& object : doc.objects) {
+    for (const auto& entry : object.props) {
+      if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
+        continue;
+      if (objectIds.find(entry.second) == objectIds.end())
+        LOG_WARN("[Editor] Dangling object reference in %s: %s.%s -> %s",
+                 sourceLabel.c_str(), object.id.c_str(), entry.first.c_str(), entry.second.c_str());
+    }
+  }
+}
+
 static Mat4 BuildObjectModelMatrix(const SceneDocument& doc, const SceneObject& obj) {
   Vec3 assetRenderScale = Vec3::One();
   std::string ignoredMeshPath;
@@ -1080,6 +1147,7 @@ void EditorLayer::LoadDocument(SceneDocument doc) {
   }
 
   SyncAssetScaleMetadata(&doc);
+  LogDanglingObjectReferences(doc, doc.filePath);
 
   m_document = std::move(doc);
   m_lastSavedDocument = m_document;
@@ -4488,6 +4556,58 @@ void EditorLayer::TriggerReload() {
   m_wantsReload = true;
 }
 
+std::vector<std::string> EditorLayer::GetSelectedObjectIds() const {
+  std::vector<std::string> ids;
+  ids.reserve(m_selectedIndices.size());
+  for (int idx : m_selectedIndices) {
+    if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+      ids.push_back(m_document.objects[static_cast<size_t>(idx)].id);
+  }
+  return ids;
+}
+
+void EditorLayer::SetSelectedObjectIds(const std::vector<std::string>& ids) {
+  m_selectedIndices.clear();
+  std::unordered_set<std::string> seen;
+  seen.reserve(ids.size());
+  for (const std::string& id : ids) {
+    if (id.empty() || !seen.insert(id).second)
+      continue;
+    for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
+      if (m_document.objects[static_cast<size_t>(i)].id == id) {
+        m_selectedIndices.push_back(i);
+        break;
+      }
+    }
+  }
+}
+
+bool EditorLayer::ReloadDocumentFromDisk(std::string* outError,
+                                         const std::vector<std::string>* preferredSelectionIds,
+                                         const std::string* preferredAssetId) {
+  if (outError)
+    outError->clear();
+
+  const std::string path = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
+  try {
+    SceneDocument reloaded = SceneSerializer::LoadFromFile(path);
+    reloaded.dirty = false;
+    LoadDocument(std::move(reloaded));
+    m_document.filePath = path;
+    m_lastSavedDocument = m_document;
+    if (preferredSelectionIds)
+      SetSelectedObjectIds(*preferredSelectionIds);
+    if (preferredAssetId && m_document.assets.find(*preferredAssetId) != m_document.assets.end())
+      m_selectedAssetId = *preferredAssetId;
+    TriggerReload();
+    return true;
+  } catch (const std::exception& e) {
+    if (outError)
+      *outError = e.what();
+    return false;
+  }
+}
+
 void EditorLayer::ProcessMcpCommands() {
   m_mcpController.DrainCommands([this](const std::string& toolName, const nlohmann::json& arguments) {
     return ExecuteMcpCommand(toolName, arguments);
@@ -4652,7 +4772,9 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
         m_selectedIndices.push_back(idx);
     }
     m_selectedAssetId.clear();
-    return Mcp::McpCommandResult{true, json{{"selectedObjectIds", ids}}, std::string()};
+    return Mcp::McpCommandResult{true,
+                                 json{{"selectedObjectIds", GetSelectedObjectIds()}},
+                                 std::string()};
   }
 
   if (toolName == "editor.clear_selection") {
@@ -4672,7 +4794,7 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
     object.id = arguments.value("id", std::string());
     if (object.id.empty())
       object.id = type == SceneObjectType::Camera ? GenerateCameraId(m_document) : GenerateId(m_document);
-    if (findIndexById(object.id) >= 0)
+    if (IsReservedObjectId(m_document, object.id))
       return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
 
     if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
@@ -4688,8 +4810,11 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
     if (arguments.contains("components") && !parseComponents(arguments["components"], &object.components))
       return Mcp::McpCommandResult{false, json::object(), "components must be an array of objects."};
     const std::string parentId = arguments.value("parentId", std::string());
-    if (!parentId.empty())
+    if (!parentId.empty()) {
+      if (findIndexById(parentId) < 0)
+        return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
       object.props["parentId"] = parentId;
+    }
 
     m_document.objects.push_back(std::move(object));
     m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
@@ -4710,7 +4835,7 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
     object.id = arguments.value("id", std::string());
     if (object.id.empty())
       object.id = GenerateId(m_document);
-    if (findIndexById(object.id) >= 0)
+    if (IsReservedObjectId(m_document, object.id))
       return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
     if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
       return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
@@ -4718,8 +4843,11 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
     object.pitch = arguments.value("pitch", object.pitch);
     object.roll = arguments.value("roll", object.roll);
     const std::string parentId = arguments.value("parentId", std::string());
-    if (!parentId.empty())
+    if (!parentId.empty()) {
+      if (findIndexById(parentId) < 0)
+        return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
       object.props["parentId"] = parentId;
+    }
 
     m_document.objects.push_back(std::move(object));
     m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
@@ -4776,17 +4904,13 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
       return Mcp::McpCommandResult{false, json::object(), "Object not found."};
     if (newId.empty())
       return Mcp::McpCommandResult{false, json::object(), "newId is required."};
-    if (id != newId && findIndexById(newId) >= 0)
+    if (id != newId && IsReservedObjectId(m_document, newId, &id))
       return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
 
     SceneObject& object = m_document.objects[static_cast<size_t>(idx)];
     const std::string oldId = object.id;
     object.id = newId;
-    for (SceneObject& other : m_document.objects) {
-      auto parentIt = other.props.find("parentId");
-      if (parentIt != other.props.end() && parentIt->second == oldId)
-        parentIt->second = newId;
-    }
+    RewriteObjectIdReferences(&m_document, oldId, newId);
     m_document.dirty = true;
     TriggerReload();
     return Mcp::McpCommandResult{true,
@@ -4951,8 +5075,16 @@ Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName
   }
 
   if (toolName == "editor.reload_scene") {
-    TriggerReload();
-    return Mcp::McpCommandResult{true, json{{"reloadPending", true}}, std::string()};
+    const std::vector<std::string> previousSelectionIds = GetSelectedObjectIds();
+    const std::string previousAssetId = m_selectedAssetId;
+    std::string reloadError;
+    if (!ReloadDocumentFromDisk(&reloadError, &previousSelectionIds, &previousAssetId))
+      return Mcp::McpCommandResult{false, json::object(), reloadError};
+    return Mcp::McpCommandResult{true,
+                                 json{{"reloadPending", true},
+                                      {"filePath", m_document.filePath},
+                                      {"dirty", m_document.dirty}},
+                                 std::string()};
   }
 
   return Mcp::McpCommandResult{false, json::object(), "Unsupported MCP command."};
@@ -5139,10 +5271,7 @@ std::string EditorLayer::BuildSelectionRefCode(const SceneObject& obj, int idx) 
 }
 
 std::string EditorLayer::GenerateId(const SceneDocument& doc) {
-  std::unordered_set<std::string> existingIds;
-  existingIds.reserve(doc.objects.size() * 2);
-  for (const auto& obj : doc.objects)
-    existingIds.insert(obj.id);
+  const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
 
   for (int i = 0; i < 1000000; ++i) {
     char buf[32];
@@ -5154,10 +5283,7 @@ std::string EditorLayer::GenerateId(const SceneDocument& doc) {
 }
 
 std::string EditorLayer::GenerateCameraId(const SceneDocument& doc) {
-  std::unordered_set<std::string> existingIds;
-  existingIds.reserve(doc.objects.size() * 2);
-  for (const auto& obj : doc.objects)
-    existingIds.insert(obj.id);
+  const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
 
   for (int i = 0; i < 1000000; ++i) {
     char buf[32];

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -113,6 +113,11 @@ class EditorLayer {
   // The document queued for reload.  Valid only while WantsSceneReload() == true.
   const SceneDocument& GetPendingDocument() const { return m_pendingDoc; }
   void AcknowledgeReload() { m_wantsReload = false; }
+  const SceneDocument& GetDocument() const { return m_document; }
+  const std::string& GetSelectedAssetId() const { return m_selectedAssetId; }
+  std::vector<std::string> GetSelectedObjectIds() const;
+  Mcp::McpCommandResult ExecuteMcpCommand(const std::string& toolName,
+                                         const nlohmann::json& arguments);
 
  private:
   enum class ViewSnap { None, Top, Bottom, Left, Right, Front, Back };
@@ -210,10 +215,12 @@ class EditorLayer {
   void DuplicatePrimarySelection();
   void ProcessMcpCommands();
   void PublishMcpSnapshot();
-  Mcp::McpCommandResult ExecuteMcpCommand(const std::string& toolName,
-                                         const nlohmann::json& arguments);
   bool SaveDocument(std::string* outError);
   void DiscardUnsavedChanges();
+  void SetSelectedObjectIds(const std::vector<std::string>& ids);
+  bool ReloadDocumentFromDisk(std::string* outError,
+                              const std::vector<std::string>* preferredSelectionIds = nullptr,
+                              const std::string* preferredAssetId = nullptr);
 
   // Multi-scene helpers
   void AddNewScene();

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -14,6 +14,13 @@ namespace {
 
 const std::vector<McpCatalogEntry>& GetToolCatalog();
 
+json MakeVec3Schema() {
+  return json{{"type", "array"},
+              {"minItems", 3},
+              {"maxItems", 3},
+              {"items", {{"type", "number"}}}};
+}
+
 std::string ToLowerAscii(std::string value) {
   for (char& c : value)
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
@@ -209,8 +216,8 @@ json BuildToolList() {
                                            {"id", {{"type", "string"}}},
                                            {"assetId", {{"type", "string"}}},
                                            {"parentId", {{"type", "string"}}},
-                                           {"position", {{"type", "array"}}},
-                                           {"scale", {{"type", "array"}}},
+                                           {"position", MakeVec3Schema()},
+                                           {"scale", MakeVec3Schema()},
                                            {"yaw", {{"type", "number"}}},
                                            {"pitch", {{"type", "number"}}},
                                            {"roll", {{"type", "number"}}},
@@ -221,7 +228,7 @@ json BuildToolList() {
       tool["inputSchema"]["properties"] = {{"assetId", {{"type", "string"}}},
                                            {"parentId", {{"type", "string"}}},
                                            {"id", {{"type", "string"}}},
-                                           {"position", {{"type", "array"}}},
+                                           {"position", MakeVec3Schema()},
                                            {"yaw", {{"type", "number"}}},
                                            {"pitch", {{"type", "number"}}},
                                            {"roll", {{"type", "number"}}}};
@@ -229,8 +236,8 @@ json BuildToolList() {
       tool["inputSchema"]["required"] = json::array({"id"});
       tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
                                            {"assetId", {{"type", "string"}}},
-                                           {"position", {{"type", "array"}}},
-                                           {"scale", {{"type", "array"}}},
+                                           {"position", MakeVec3Schema()},
+                                           {"scale", MakeVec3Schema()},
                                            {"yaw", {{"type", "number"}}},
                                            {"pitch", {{"type", "number"}}},
                                            {"roll", {{"type", "number"}}},

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -12,6 +12,9 @@
 
 #include <nlohmann/json.hpp>
 
+#include "editor/EditorLayer.h"
+#include "editor/SceneSerializer.h"
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -29,6 +32,7 @@
 
 using json = nlohmann::json;
 using namespace Monolith::Mcp;
+using namespace Monolith::Editor;
 
 namespace {
 
@@ -207,6 +211,92 @@ McpEditorSnapshot MakeSnapshot() {
   return snapshot;
 }
 
+McpEditorSnapshot MakeSnapshotFromDocument(const SceneDocument& doc,
+                                          const std::vector<std::string>& selectedObjectIds,
+                                          const std::string& selectedAssetId = {}) {
+  McpEditorSnapshot snapshot;
+  snapshot.editorActive = true;
+  snapshot.sceneId = doc.sceneId;
+  snapshot.sceneName = doc.sceneName;
+  snapshot.sceneFilePath = doc.filePath;
+  snapshot.dirty = doc.dirty;
+  snapshot.selectedObjectIds = selectedObjectIds;
+  snapshot.selectedAssetId = selectedAssetId;
+  for (const SceneObject& object : doc.objects) {
+    McpObjectSnapshot entry;
+    entry.id = object.id;
+    switch (object.type) {
+      case SceneObjectType::Panel:
+        entry.type = "Panel";
+        break;
+      case SceneObjectType::Prop:
+        entry.type = "Prop";
+        break;
+      case SceneObjectType::Light:
+        entry.type = "Light";
+        break;
+      case SceneObjectType::Camera:
+        entry.type = "Camera";
+        break;
+    }
+    entry.position = object.position;
+    entry.scale = object.scale;
+    entry.yaw = object.yaw;
+    entry.pitch = object.pitch;
+    entry.roll = object.roll;
+    entry.assetId = object.assetId;
+    entry.props = object.props;
+    snapshot.objects.push_back(std::move(entry));
+  }
+  for (const auto& assetEntry : doc.assets)
+    snapshot.assets.push_back({assetEntry.first, assetEntry.second.mesh, assetEntry.second.renderScale,
+                               assetEntry.second.albedoMap});
+  return snapshot;
+}
+
+SceneDocument MakeEditorSceneDocument(const std::filesystem::path& filePath) {
+  SceneDocument doc;
+  doc.sceneId = "scene";
+  doc.sceneName = "Scene";
+  doc.filePath = filePath.string();
+  doc.dirty = false;
+  doc.assets["stone"] = AssetDef{"assets/models/stone/stone.obj", "1.0000,1.0000,1.0000", ""};
+
+  SceneObject panel;
+  panel.id = "panel_000";
+  panel.type = SceneObjectType::Panel;
+  doc.objects.push_back(panel);
+
+  SceneObject camera;
+  camera.id = "cam_000";
+  camera.type = SceneObjectType::Camera;
+  camera.props["followTargetId"] = "";
+  camera.props["parentId"] = "obj_000";
+  doc.objects.push_back(camera);
+
+  return doc;
+}
+
+SceneObject* FindSceneObject(SceneDocument* doc, const std::string& id) {
+  if (!doc)
+    return nullptr;
+  for (SceneObject& object : doc->objects) {
+    if (object.id == id)
+      return &object;
+  }
+  return nullptr;
+}
+
+const SceneObject* FindSceneObject(const SceneDocument* doc, const std::string& id) {
+  if (!doc)
+    return nullptr;
+  for (const SceneObject& object : doc->objects) {
+    if (object.id == id)
+      return &object;
+  }
+  return nullptr;
+}
+
 json ParseBody(const McpHttpResponse& response) {
   return json::parse(response.body);
 }
@@ -379,6 +469,16 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   const json toolList = ProtocolRequest(protocol, "tools/list", json::object(), 3);
   REQUIRE(toolList["result"]["tools"].size() == 31);
   REQUIRE(toolList["result"]["tools"][0]["name"] == "editor_search");
+  const json* createObjectTool = nullptr;
+  for (const json& tool : toolList["result"]["tools"]) {
+    if (tool.value("name", std::string()) == "editor_create_object") {
+      createObjectTool = &tool;
+      break;
+    }
+  }
+  REQUIRE(createObjectTool != nullptr);
+  REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["items"]["type"] == "number");
+  REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["minItems"] == 3);
 
   const json resourceList = ProtocolRequest(protocol, "resources/list", json::object(), 4);
   REQUIRE(resourceList["result"]["resources"].size() == 10);
@@ -451,6 +551,93 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   REQUIRE(activity.size() >= 20);
   REQUIRE(activity.back().target == "editor.search_console");
   REQUIRE(activity.back().ok);
+}
+
+TEST_CASE("Editor MCP commands preserve reserved ids and reload from disk", "[mcp][editor]") {
+  EnvGuard env("horo_editor_mcp_consistency");
+  const std::filesystem::path scenePath =
+      std::filesystem::temp_directory_path() / "horo_editor_mcp_consistency" / "world.json";
+  std::filesystem::create_directories(scenePath.parent_path());
+
+  const SceneDocument initialDoc = MakeEditorSceneDocument(scenePath);
+  SceneSerializer::SaveToFile(initialDoc, scenePath.string());
+
+  EditorLayer editor;
+  editor.LoadDocument(initialDoc);
+
+  const McpCommandResult stringVecFail = editor.ExecuteMcpCommand(
+      "editor.create_object",
+      json{{"id", "codex_probe_panel"},
+           {"type", "Panel"},
+           {"position", json::array({"12", "1", "12"})},
+           {"scale", json::array({"1", "1", "1"})},
+           {"props", json{{"material", "default"}}}});
+  REQUIRE_FALSE(stringVecFail.ok);
+  REQUIRE(stringVecFail.error == "position must be [x,y,z].");
+
+  const McpCommandResult createPanel = editor.ExecuteMcpCommand(
+      "editor.create_object",
+      json{{"id", "codex_probe_panel"},
+           {"type", "Panel"},
+           {"position", json::array({12, 1, 12})},
+           {"scale", json::array({1, 1, 1})},
+           {"props", json{{"material", "default"}}}});
+  REQUIRE(createPanel.ok);
+
+  const McpCommandResult createProp = editor.ExecuteMcpCommand(
+      "editor.create_object_from_asset",
+      json{{"id", "codex_probe_prop"}, {"assetId", "stone"}, {"position", json::array({13, 1, 13})}});
+  REQUIRE(createProp.ok);
+
+  const McpCommandResult reparent =
+      editor.ExecuteMcpCommand("editor.reparent_object",
+                               json{{"id", "codex_probe_prop"}, {"parentId", "codex_probe_panel"}});
+  REQUIRE(reparent.ok);
+
+  const McpCommandResult duplicate =
+      editor.ExecuteMcpCommand("editor.duplicate", json{{"id", "codex_probe_prop"}, {"count", 1}});
+  REQUIRE(duplicate.ok);
+  REQUIRE(duplicate.data["duplicates"].size() == 1);
+  REQUIRE(duplicate.data["duplicates"][0]["id"] != "obj_000");
+
+  const std::string duplicateId = duplicate.data["duplicates"][0]["id"].get<std::string>();
+
+  const McpCommandResult renameReserved =
+      editor.ExecuteMcpCommand("editor.rename_object", json{{"id", duplicateId}, {"newId", "obj_000"}});
+  REQUIRE_FALSE(renameReserved.ok);
+  REQUIRE(renameReserved.error == "Object id already exists.");
+
+  const McpCommandResult renameOk = editor.ExecuteMcpCommand(
+      "editor.rename_object", json{{"id", duplicateId}, {"newId", "codex_probe_dup"}});
+  REQUIRE(renameOk.ok);
+
+  const SceneDocument& afterRenameDoc = editor.GetDocument();
+  const SceneObject* camera = FindSceneObject(&afterRenameDoc, "cam_000");
+  REQUIRE(camera != nullptr);
+  REQUIRE(camera->props.at("parentId") == "obj_000");
+
+  const McpCommandResult select = editor.ExecuteMcpCommand(
+      "editor.select", json{{"ids", json::array({"codex_probe_panel", "codex_probe_prop"})}});
+  REQUIRE(select.ok);
+  REQUIRE(select.data["selectedObjectIds"].size() == 2);
+
+  const McpEditorSnapshot selectedSnapshot =
+      MakeSnapshotFromDocument(editor.GetDocument(), editor.GetSelectedObjectIds(), editor.GetSelectedAssetId());
+  const json selectedOnly = BuildObjectListJson(selectedSnapshot, 16, "", "", true);
+  REQUIRE(selectedOnly["matchedObjects"] == 2);
+
+  const McpCommandResult reload = editor.ExecuteMcpCommand("editor.reload_scene", json::object());
+  REQUIRE(reload.ok);
+  const SceneDocument& reloadedDoc = editor.GetDocument();
+  REQUIRE_FALSE(reloadedDoc.dirty);
+  REQUIRE(reloadedDoc.objects.size() == initialDoc.objects.size());
+  REQUIRE(FindSceneObject(&reloadedDoc, "codex_probe_panel") == nullptr);
+  REQUIRE(FindSceneObject(&reloadedDoc, "codex_probe_prop") == nullptr);
+  REQUIRE(FindSceneObject(&reloadedDoc, "codex_probe_dup") == nullptr);
+
+  camera = FindSceneObject(&reloadedDoc, "cam_000");
+  REQUIRE(camera != nullptr);
+  REQUIRE(camera->props.at("parentId") == "obj_000");
 }
 
 TEST_CASE("McpProtocol dispatches every write tool and serializes success and failure", "[mcp][protocol]") {


### PR DESCRIPTION
## What changed
- hardened MCP object id allocation so duplicate/create paths also reserve ids referenced by object relations like `parentId`
- prevented `rename_object` from reusing reserved ids and limited object-id rewrites to typed object reference fields
- changed `reload_scene` to reload the active scene document from disk instead of rebuilding from the current dirty in-memory snapshot
- aligned MCP vector tool schemas with runtime validation by declaring `position` and `scale` as numeric 3-element arrays
- added regression coverage for the full bug chain: string vec rejection, duplicate id collision prevention, rename isolation, selected-only stability, and real disk reload behavior

## Why
The observed MCP anomalies were all connected by weak scene invariants around ids and reload semantics:
- dangling parent references could reserve ids implicitly without the generator knowing
- duplicate could therefore create `obj_000`, colliding with an existing reference-only parent id
- renaming that duplicate rewrote unrelated parent references
- reload did not discard in-memory mutations because it never reloaded from disk

## Impact
- duplicate/create flows now preserve object id uniqueness across both concrete objects and typed object references
- rename only affects the target object and legitimate typed references
- reload_scene now behaves like a true discard-and-reload operation for the active scene file
- MCP clients now see a stricter and accurate schema for vector inputs

## Validation
- `cmake -S C:\Users\abdul\projects\fun\game\monolith -B C:\Users\abdul\projects\fun\game\monolith\build\debug-msvc -DMONOLITH_BUILD_ENGINE_TESTS=ON`
- `cmake --build C:\Users\abdul\projects\fun\game\monolith\build\debug-msvc --config Debug --target test_mcp`
- `C:\Users\abdul\projects\fun\game\monolith\build\debug-msvc\bin\tests\test_mcp.exe`
