### PR TITLE
[55/#58] Normalize MCP resource paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ horo-engine/
 Horo Engine now ships with a built-in MCP server for the editor. Enable it from `File -> Settings...` in the editor and the server will auto-start on `http://127.0.0.1:39281/mcp` whenever the editor is open.
 
 User settings live in `~/.horo/settings.json` (Windows: `%USERPROFILE%\\.horo\\settings.json`). The MCP tab in the editor shows runtime status, recent requests, and copy-ready Claude/Codex configuration snippets.
+The recommended AI workflow is: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
+Apply-mode mutations also append audit records to `.horo/mcp-audit.jsonl` under the active project root
+when available.
 
 Integration details and token-minimal usage guidance live in [docs/mcp.md](/c:/Users/abdul/projects/fun/game/horo-engine/docs/mcp.md).
 

--- a/assets/editor_schema.json
+++ b/assets/editor_schema.json
@@ -23,6 +23,7 @@
       ]
     },
     "Light": {
+      "label": "Light",
       "fields": [
         {
           "key": "lightType",
@@ -52,6 +53,90 @@
           "label": "Color RGB",
           "type": "color3",
           "default": "1.0000,1.0000,1.0000"
+        }
+      ]
+    }
+  },
+  "components": {
+    "light": {
+      "label": "Light",
+      "appliesTo": ["Panel", "Prop"],
+      "fields": [
+        {
+          "key": "lightType",
+          "label": "Type",
+          "description": "Controls whether the attached light behaves as a point or directional light.",
+          "type": "enum",
+          "options": ["point", "directional"],
+          "default": "point"
+        },
+        {
+          "key": "radius",
+          "label": "Radius",
+          "description": "Fallback radius for point lights.",
+          "type": "float",
+          "min": 0.5,
+          "max": 50.0,
+          "default": "5.0"
+        },
+        {
+          "key": "intensity",
+          "label": "Intensity",
+          "description": "Brightness multiplier applied at runtime.",
+          "type": "float",
+          "min": 0.1,
+          "max": 20.0,
+          "default": "1.0"
+        },
+        {
+          "key": "color",
+          "label": "Color RGB",
+          "description": "Comma-separated linear RGB triple.",
+          "type": "color3",
+          "default": "1.0000,1.0000,1.0000"
+        }
+      ]
+    },
+    "rigidbody": {
+      "label": "RigidBody",
+      "appliesTo": ["Prop"],
+      "fields": [
+        {
+          "key": "mass",
+          "label": "Mass",
+          "description": "Zero creates a static rigid body.",
+          "type": "float",
+          "min": 0.0,
+          "max": 500.0,
+          "default": "1.0"
+        },
+        {
+          "key": "isKinematic",
+          "label": "Kinematic",
+          "description": "Disables physics simulation and uses authored transforms.",
+          "type": "bool",
+          "default": "false"
+        },
+        {
+          "key": "useGravity",
+          "label": "Use Gravity",
+          "description": "Applies world gravity during simulation.",
+          "type": "bool",
+          "default": "true"
+        }
+      ]
+    },
+    "script": {
+      "label": "Script",
+      "appliesTo": ["Panel", "Prop", "Light", "Camera"],
+      "fields": [
+        {
+          "key": "behaviorTag",
+          "label": "Behavior",
+          "description": "Runtime behavior id resolved by the game.",
+          "type": "string",
+          "default": "",
+          "allowEmpty": true
         }
       ]
     }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -87,6 +87,9 @@ List-style resources accept `limit` and `offset`, and query-driven reads such as
 
 `editor.list_schema_types` and `editor.get_schema` expose the same object and component metadata that
 drives `assets/editor_schema.json`, including defaults, enum options, and numeric bounds.
+Write tools accept `mode: "preview" | "apply"`. Preview requests never mutate editor state and return
+a `previewToken`; destructive applies for `editor.delete`, `editor.delete_asset`, `editor.new_scene`,
+and `editor.reload_scene` require the matching token.
 
 ## Claude Code
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -90,6 +90,8 @@ drives `assets/editor_schema.json`, including defaults, enum options, and numeri
 Write tools accept `mode: "preview" | "apply"`. Preview requests never mutate editor state and return
 a `previewToken`; destructive applies for `editor.delete`, `editor.delete_asset`, `editor.new_scene`,
 and `editor.reload_scene` require the matching token.
+Apply requests append audit records to `<project-root>/.horo/mcp-audit.jsonl`, or
+`~/.horo/mcp-audit.jsonl` when no project root is resolved.
 
 ## Claude Code
 
@@ -180,6 +182,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage guidance
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Prefer `scene.summary` before calling object-level tools.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -78,10 +78,15 @@ List-style resources accept `limit` and `offset`, and query-driven reads such as
 - `editor.delete_asset`
 - `editor.scene_status`
 - `editor.get_scene_file`
+- `editor.list_schema_types`
+- `editor.get_schema`
 - `editor.new_scene`
 - `editor.save_scene`
 - `editor.reload_scene`
 - `editor.search_console`
+
+`editor.list_schema_types` and `editor.get_schema` expose the same object and component metadata that
+drives `assets/editor_schema.json`, including defaults, enum options, and numeric bounds.
 
 ## Claude Code
 
@@ -177,5 +182,6 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.
 - Use `editor.search` with a narrow `query` and `limit`.
 - Use `editor.get_object` only for the specific object you need.
+- Use `editor.list_schema_types` and `editor.get_schema` before mutating typed props or components.
 - Prefer `console.recent` over asking for long log history.
 - Mutate with targeted tools instead of requesting broad state dumps first.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,6 +47,8 @@ User settings are stored in `~/.horo/settings.json` on macOS/Linux and `%USERPRO
 - `build.status`
 
 These resources are compact by default and intentionally avoid full-scene dumps.
+List-style resources accept `limit` and `offset`, and query-driven reads such as `scene.objects` and
+`assets.catalog` match case-insensitively.
 
 ## Tools
 
@@ -172,6 +174,7 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 ## Token-minimal usage guidance
 
 - Prefer `scene.summary` before calling object-level tools.
+- Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.
 - Use `editor.search` with a narrow `query` and `limit`.
 - Use `editor.get_object` only for the specific object you need.
 - Prefer `console.recent` over asking for long log history.

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -172,6 +172,7 @@ Mcp::McpSchemaFieldSnapshot BuildMcpSchemaFieldSnapshot(const FieldDef& field) {
   snapshot.label = field.label;
   snapshot.description = field.description;
   snapshot.widget = FieldWidgetToString(field.widget);
+  snapshot.hasDefault = field.hasDefault;
   snapshot.required = field.required;
   snapshot.allowEmpty = field.allowEmpty;
   snapshot.allowCustomValue = field.allowCustomValue;
@@ -6838,7 +6839,7 @@ void EditorLayer::ApplySchemaDefaults(SceneObject& obj) const {
   if (!schema)
     return;
   for (const auto& fd : schema->fields)
-    if (obj.props.find(fd.key) == obj.props.end())
+    if (fd.hasDefault && obj.props.find(fd.key) == obj.props.end())
       obj.props[fd.key] = fd.defaultValue;
 }
 
@@ -6847,7 +6848,7 @@ void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
   if (!schema)
     return;
   for (const FieldDef& field : schema->fields) {
-    if (component.props.find(field.key) == component.props.end())
+    if (field.hasDefault && component.props.find(field.key) == component.props.end())
       component.props[field.key] = field.defaultValue;
   }
 }

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -150,6 +150,118 @@ Mcp::McpBuildSnapshot BuildMcpBuildSnapshot(const SceneDocument& document) {
   return snapshot;
 }
 
+const char* FieldWidgetToString(FieldDef::Widget widget) {
+  switch (widget) {
+    case FieldDef::Widget::Float:
+      return "float";
+    case FieldDef::Widget::Bool:
+      return "bool";
+    case FieldDef::Widget::Enum:
+      return "enum";
+    case FieldDef::Widget::Color3:
+      return "color3";
+    case FieldDef::Widget::String:
+    default:
+      return "string";
+  }
+}
+
+Mcp::McpSchemaFieldSnapshot BuildMcpSchemaFieldSnapshot(const FieldDef& field) {
+  Mcp::McpSchemaFieldSnapshot snapshot;
+  snapshot.key = field.key;
+  snapshot.label = field.label;
+  snapshot.description = field.description;
+  snapshot.widget = FieldWidgetToString(field.widget);
+  snapshot.required = field.required;
+  snapshot.allowEmpty = field.allowEmpty;
+  snapshot.allowCustomValue = field.allowCustomValue;
+  snapshot.hasMin = field.hasMin;
+  snapshot.hasMax = field.hasMax;
+  snapshot.minVal = field.minVal;
+  snapshot.maxVal = field.maxVal;
+  snapshot.options = field.options;
+  snapshot.defaultValue = field.defaultValue;
+  return snapshot;
+}
+
+Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const TypeSchema& schema) {
+  Mcp::McpSchemaEntrySnapshot snapshot;
+  snapshot.kind = "object";
+  snapshot.name = schema.name;
+  snapshot.label = schema.label;
+  snapshot.appliesTo = schema.appliesTo;
+  snapshot.fields.reserve(schema.fields.size());
+  for (const FieldDef& field : schema.fields)
+    snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
+  return snapshot;
+}
+
+Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const ComponentSchema& schema) {
+  Mcp::McpSchemaEntrySnapshot snapshot;
+  snapshot.kind = "component";
+  snapshot.name = schema.name;
+  snapshot.label = schema.label;
+  snapshot.appliesTo = schema.appliesTo;
+  snapshot.fields.reserve(schema.fields.size());
+  for (const FieldDef& field : schema.fields)
+    snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
+  return snapshot;
+}
+
+Mcp::McpSchemaCatalogSnapshot BuildMcpSchemaCatalogSnapshot(const EditorSchema& schema) {
+  Mcp::McpSchemaCatalogSnapshot snapshot;
+
+  std::vector<std::string> typeNames;
+  typeNames.reserve(schema.TypeSchemas().size());
+  for (const auto& entry : schema.TypeSchemas())
+    typeNames.push_back(entry.first);
+  std::sort(typeNames.begin(), typeNames.end());
+  for (const std::string& typeName : typeNames)
+    snapshot.objectTypes.push_back(BuildMcpSchemaEntrySnapshot(schema.TypeSchemas().at(typeName)));
+
+  std::vector<std::string> componentTypes;
+  componentTypes.reserve(schema.ComponentSchemas().size());
+  for (const auto& entry : schema.ComponentSchemas())
+    componentTypes.push_back(entry.first);
+  std::sort(componentTypes.begin(), componentTypes.end());
+  for (const std::string& componentType : componentTypes)
+    snapshot.components.push_back(BuildMcpSchemaEntrySnapshot(schema.ComponentSchemas().at(componentType)));
+
+  return snapshot;
+}
+
+bool SchemaAppliesToObjectType(const std::vector<std::string>& appliesTo, SceneObjectType objectType) {
+  if (appliesTo.empty())
+    return true;
+  std::string typeName = "panel";
+  switch (objectType) {
+    case SceneObjectType::Prop:
+      typeName = "prop";
+      break;
+    case SceneObjectType::Light:
+      typeName = "light";
+      break;
+    case SceneObjectType::Camera:
+      typeName = "camera";
+      break;
+    case SceneObjectType::Panel:
+    default:
+      typeName = "panel";
+      break;
+  }
+  auto normalize = [](std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    return value;
+  };
+  for (const std::string& entry : appliesTo) {
+    if (normalize(entry) == typeName)
+      return true;
+  }
+  return false;
+}
+
 bool AssetDefsEqual(const AssetDef& lhs, const AssetDef& rhs) {
   return lhs.mesh == rhs.mesh &&
          lhs.renderScale == rhs.renderScale &&
@@ -5092,30 +5204,69 @@ void EditorLayer::DrawPropertiesPanel() {
     ImGui::OpenPopup("##add_component_popup");
   }
   if (ImGui::BeginPopup("##add_component_popup")) {
-    if (ImGui::MenuItem("Light")) {
-      ComponentDesc cd;
-      cd.type = "light";
-      cd.props["intensity"] = "1.0000";
-      cd.props["color"] = "1.0000,1.0000,1.0000";
-      cd.props["radius"] = "5.0000";
-      obj.components.push_back(std::move(cd));
-      m_document.dirty = true;
+    std::vector<const ComponentSchema*> componentSchemas;
+    componentSchemas.reserve(m_schema.ComponentSchemas().size());
+    for (const auto& entry : m_schema.ComponentSchemas()) {
+      if (SchemaAppliesToObjectType(entry.second.appliesTo, obj.type))
+        componentSchemas.push_back(&entry.second);
     }
-    if (ImGui::MenuItem("RigidBody")) {
-      ComponentDesc cd;
-      cd.type = "rigidbody";
-      cd.props["mass"] = "1.0000";
-      cd.props["isKinematic"] = "false";
-      cd.props["useGravity"] = "true";
-      obj.components.push_back(std::move(cd));
-      m_document.dirty = true;
-    }
-    if (ImGui::MenuItem("Script")) {
-      ComponentDesc cd;
-      cd.type = "script";
-      cd.props["behaviorTag"] = "";
-      obj.components.push_back(std::move(cd));
-      m_document.dirty = true;
+    std::sort(componentSchemas.begin(), componentSchemas.end(),
+              [](const ComponentSchema* lhs, const ComponentSchema* rhs) {
+                const std::string lhsLabel = lhs ? lhs->label : std::string();
+                const std::string rhsLabel = rhs ? rhs->label : std::string();
+                if (lhsLabel != rhsLabel)
+                  return lhsLabel < rhsLabel;
+                return lhs && rhs ? lhs->name < rhs->name : lhs < rhs;
+              });
+
+    if (!componentSchemas.empty()) {
+      for (const ComponentSchema* componentSchema : componentSchemas) {
+        if (!componentSchema)
+          continue;
+        const std::string menuLabel =
+            componentSchema->label.empty() ? componentSchema->name : componentSchema->label;
+        if (ImGui::MenuItem(menuLabel.c_str())) {
+          ComponentDesc component;
+          component.type = componentSchema->name;
+          ApplyComponentSchemaDefaults(component);
+          obj.components.push_back(std::move(component));
+          m_document.dirty = true;
+        }
+      }
+    } else {
+      if (ImGui::MenuItem("Light")) {
+        ComponentDesc component;
+        component.type = "light";
+        ApplyComponentSchemaDefaults(component);
+        if (component.props.empty()) {
+          component.props["intensity"] = "1.0000";
+          component.props["color"] = "1.0000,1.0000,1.0000";
+          component.props["radius"] = "5.0000";
+        }
+        obj.components.push_back(std::move(component));
+        m_document.dirty = true;
+      }
+      if (ImGui::MenuItem("RigidBody")) {
+        ComponentDesc component;
+        component.type = "rigidbody";
+        ApplyComponentSchemaDefaults(component);
+        if (component.props.empty()) {
+          component.props["mass"] = "1.0000";
+          component.props["isKinematic"] = "false";
+          component.props["useGravity"] = "true";
+        }
+        obj.components.push_back(std::move(component));
+        m_document.dirty = true;
+      }
+      if (ImGui::MenuItem("Script")) {
+        ComponentDesc component;
+        component.type = "script";
+        ApplyComponentSchemaDefaults(component);
+        if (component.props.empty())
+          component.props["behaviorTag"] = "";
+        obj.components.push_back(std::move(component));
+        m_document.dirty = true;
+      }
     }
     ImGui::EndPopup();
   }
@@ -5557,6 +5708,7 @@ void EditorLayer::PublishMcpSnapshot() {
   }
 
   snapshot.build = BuildMcpBuildSnapshot(m_document);
+  snapshot.schema = BuildMcpSchemaCatalogSnapshot(m_schema);
   m_mcpController.PublishSnapshot(snapshot);
 }
 
@@ -6688,6 +6840,16 @@ void EditorLayer::ApplySchemaDefaults(SceneObject& obj) const {
   for (const auto& fd : schema->fields)
     if (obj.props.find(fd.key) == obj.props.end())
       obj.props[fd.key] = fd.defaultValue;
+}
+
+void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
+  const ComponentSchema* schema = m_schema.GetComponentSchema(component.type);
+  if (!schema)
+    return;
+  for (const FieldDef& field : schema->fields) {
+    if (component.props.find(field.key) == component.props.end())
+      component.props[field.key] = field.defaultValue;
+  }
 }
 
 // ---- Wireframe overlay -------------------------------------------------------

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -419,6 +419,7 @@ class EditorLayer {
   static std::string GenerateId(const SceneDocument& doc);
   static std::string GenerateCameraId(const SceneDocument& doc);
   void ApplySchemaDefaults(SceneObject& obj) const;
+  void ApplyComponentSchemaDefaults(ComponentDesc& component) const;
 };
 
 }  // namespace Editor

--- a/editor/EditorSchema.cpp
+++ b/editor/EditorSchema.cpp
@@ -7,8 +7,9 @@ using json = nlohmann::json;
 
 namespace Monolith {
 namespace Editor {
+namespace {
 
-static const char* TypeName(SceneObjectType t) {
+const char* TypeName(SceneObjectType t) {
   switch (t) {
     case SceneObjectType::Prop:
       return "Prop";
@@ -20,6 +21,53 @@ static const char* TypeName(SceneObjectType t) {
       return "Panel";
   }
 }
+
+FieldDef ParseFieldDef(const json& fd) {
+  FieldDef field;
+  field.key = fd.value("key", "");
+  field.label = fd.value("label", field.key);
+  field.description = fd.value("description", "");
+  field.defaultValue = fd.value("default", "");
+  field.required = fd.value("required", false);
+  field.allowEmpty = fd.value("allowEmpty", true);
+  field.allowCustomValue = fd.value("allowCustomValue", false);
+
+  const std::string wtype = fd.value("type", "string");
+  if (wtype == "float") {
+    field.widget = FieldDef::Widget::Float;
+    field.hasMin = fd.contains("min");
+    field.hasMax = fd.contains("max");
+    field.minVal = fd.value("min", 0.0f);
+    field.maxVal = fd.value("max", 1.0f);
+  } else if (wtype == "bool") {
+    field.widget = FieldDef::Widget::Bool;
+  } else if (wtype == "enum") {
+    field.widget = FieldDef::Widget::Enum;
+    if (fd.contains("options"))
+      for (const auto& opt : fd["options"])
+        field.options.push_back(opt.get<std::string>());
+  } else if (wtype == "color3") {
+    field.widget = FieldDef::Widget::Color3;
+  } else {
+    field.widget = FieldDef::Widget::String;
+  }
+
+  return field;
+}
+
+void ParseAppliesTo(const json& definition, std::vector<std::string>* outAppliesTo) {
+  if (!outAppliesTo)
+    return;
+  outAppliesTo->clear();
+  if (!definition.contains("appliesTo") || !definition["appliesTo"].is_array())
+    return;
+  for (const auto& item : definition["appliesTo"]) {
+    if (item.is_string())
+      outAppliesTo->push_back(item.get<std::string>());
+  }
+}
+
+}  // namespace
 
 void EditorSchema::LoadFromFile(const std::string& path) {
   std::ifstream f(path);
@@ -33,62 +81,78 @@ void EditorSchema::LoadFromFile(const std::string& path) {
     return;
   }
 
-  if (!j.contains("types"))
-    return;
+  m_schemas.clear();
+  m_componentSchemas.clear();
 
-  for (auto& [typeName, typeDef] : j["types"].items()) {
-    if (!typeDef.contains("fields"))
-      continue;
-
-    TypeSchema schema;
-    for (auto& fd : typeDef["fields"]) {
-      FieldDef field;
-      field.key = fd.value("key", "");
-      field.label = fd.value("label", "");
-      field.defaultValue = fd.value("default", "");
-
-      // Legacy cleanup:
-      // - Prop.isLight is deprecated (use Light object/component instead)
-      // - Prop.mesh should always be an enum picker in editor UI
-      if (typeName == "Prop" && field.key == "isLight")
+  if (j.contains("types") && j["types"].is_object()) {
+    for (auto& [typeName, typeDef] : j["types"].items()) {
+      if (!typeDef.contains("fields") || !typeDef["fields"].is_array())
         continue;
 
-      std::string wtype = fd.value("type", "string");
-      if (wtype == "float") {
-        field.widget = FieldDef::Widget::Float;
-        field.minVal = fd.value("min", 0.0f);
-        field.maxVal = fd.value("max", 1.0f);
-      } else if (wtype == "bool") {
-        field.widget = FieldDef::Widget::Bool;
-      } else if (wtype == "enum") {
-        field.widget = FieldDef::Widget::Enum;
-        if (fd.contains("options"))
-          for (auto& opt : fd["options"])
-            field.options.push_back(opt.get<std::string>());
-      } else if (wtype == "color3") {
-        field.widget = FieldDef::Widget::Color3;
-      } else {
-        field.widget = FieldDef::Widget::String;
-      }
+      TypeSchema schema;
+      schema.name = typeName;
+      schema.label = typeDef.value("label", typeName);
+      ParseAppliesTo(typeDef, &schema.appliesTo);
+      for (const auto& fd : typeDef["fields"]) {
+        FieldDef field = ParseFieldDef(fd);
+        if (field.key.empty())
+          continue;
 
-      if (typeName == "Prop" && field.key == "mesh") {
-        field.widget = FieldDef::Widget::Enum;
-        if (field.options.empty()) {
-          field.options = {"box", "sphere", "cylinder", "pyramid", "plane", "quad"};
+        // Legacy cleanup:
+        // - Prop.isLight is deprecated (use Light object/component instead)
+        // - Prop.mesh should always be an enum picker in editor UI
+        if (typeName == "Prop" && field.key == "isLight")
+          continue;
+
+        if (typeName == "Prop" && field.key == "mesh") {
+          field.widget = FieldDef::Widget::Enum;
+          if (field.options.empty()) {
+            field.options = {"box", "sphere", "cylinder", "pyramid", "plane", "quad"};
+          }
+          if (field.defaultValue.empty())
+            field.defaultValue = "box";
         }
-        if (field.defaultValue.empty())
-          field.defaultValue = "box";
-      }
 
-      schema.fields.push_back(std::move(field));
+        schema.fields.push_back(std::move(field));
+      }
+      m_schemas[typeName] = std::move(schema);
     }
-    m_schemas[typeName] = std::move(schema);
+  }
+
+  if (j.contains("components") && j["components"].is_object()) {
+    for (auto& [componentType, componentDef] : j["components"].items()) {
+      if (!componentDef.contains("fields") || !componentDef["fields"].is_array())
+        continue;
+
+      ComponentSchema schema;
+      schema.name = componentType;
+      schema.label = componentDef.value("label", componentType);
+      ParseAppliesTo(componentDef, &schema.appliesTo);
+      for (const auto& fd : componentDef["fields"]) {
+        FieldDef field = ParseFieldDef(fd);
+        if (field.key.empty())
+          continue;
+        schema.fields.push_back(std::move(field));
+      }
+      if (!schema.fields.empty())
+        m_componentSchemas[componentType] = std::move(schema);
+    }
   }
 }
 
 const TypeSchema* EditorSchema::GetSchema(SceneObjectType t) const {
   auto it = m_schemas.find(TypeName(t));
   return (it != m_schemas.end()) ? &it->second : nullptr;
+}
+
+const TypeSchema* EditorSchema::GetSchemaByName(const std::string& typeName) const {
+  const auto it = m_schemas.find(typeName);
+  return (it != m_schemas.end()) ? &it->second : nullptr;
+}
+
+const ComponentSchema* EditorSchema::GetComponentSchema(const std::string& componentType) const {
+  const auto it = m_componentSchemas.find(componentType);
+  return (it != m_componentSchemas.end()) ? &it->second : nullptr;
 }
 
 }  // namespace Editor

--- a/editor/EditorSchema.cpp
+++ b/editor/EditorSchema.cpp
@@ -27,6 +27,7 @@ FieldDef ParseFieldDef(const json& fd) {
   field.key = fd.value("key", "");
   field.label = fd.value("label", field.key);
   field.description = fd.value("description", "");
+  field.hasDefault = fd.contains("default");
   field.defaultValue = fd.value("default", "");
   field.required = fd.value("required", false);
   field.allowEmpty = fd.value("allowEmpty", true);

--- a/editor/EditorSchema.h
+++ b/editor/EditorSchema.h
@@ -15,6 +15,7 @@ struct FieldDef {
   std::string label;
   std::string description;
   Widget widget = Widget::String;
+  bool hasDefault = false;
   bool required = false;
   bool allowEmpty = true;
   bool allowCustomValue = false;

--- a/editor/EditorSchema.h
+++ b/editor/EditorSchema.h
@@ -13,7 +13,13 @@ struct FieldDef {
 
   std::string key;
   std::string label;
+  std::string description;
   Widget widget = Widget::String;
+  bool required = false;
+  bool allowEmpty = true;
+  bool allowCustomValue = false;
+  bool hasMin = false;
+  bool hasMax = false;
   float minVal = 0.0f;
   float maxVal = 1.0f;
   std::vector<std::string> options;  // for Enum widget
@@ -21,6 +27,16 @@ struct FieldDef {
 };
 
 struct TypeSchema {
+  std::string name;
+  std::string label;
+  std::vector<std::string> appliesTo;
+  std::vector<FieldDef> fields;
+};
+
+struct ComponentSchema {
+  std::string name;
+  std::string label;
+  std::vector<std::string> appliesTo;
   std::vector<FieldDef> fields;
 };
 
@@ -33,9 +49,16 @@ class EditorSchema {
 
   // Returns nullptr if no schema registered for this type.
   const TypeSchema* GetSchema(SceneObjectType t) const;
+  const TypeSchema* GetSchemaByName(const std::string& typeName) const;
+  const ComponentSchema* GetComponentSchema(const std::string& componentType) const;
+  const std::unordered_map<std::string, TypeSchema>& TypeSchemas() const { return m_schemas; }
+  const std::unordered_map<std::string, ComponentSchema>& ComponentSchemas() const {
+    return m_componentSchemas;
+  }
 
  private:
   std::unordered_map<std::string, TypeSchema> m_schemas;
+  std::unordered_map<std::string, ComponentSchema> m_componentSchemas;
 };
 
 }  // namespace Editor

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -5,9 +5,15 @@
 #include <chrono>
 #include <cctype>
 #include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <unordered_set>
+
+#include "core/ProjectPath.h"
+#include "mcp/McpSettings.h"
 
 namespace Monolith {
 namespace Mcp {
@@ -191,6 +197,113 @@ std::string FormatFloatText(double value) {
   std::ostringstream out;
   out << std::fixed << std::setprecision(4) << value;
   return out.str();
+}
+
+std::string FormatAuditTimestamp() {
+  using clock = std::chrono::system_clock;
+  const std::time_t now = clock::to_time_t(clock::now());
+  std::tm tmBuf{};
+#ifdef _WIN32
+  gmtime_s(&tmBuf, &now);
+#else
+  gmtime_r(&now, &tmBuf);
+#endif
+  char buffer[48];
+  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &tmBuf);
+  return buffer;
+}
+
+std::filesystem::path ResolveMcpAuditPath() {
+  namespace fs = std::filesystem;
+  const fs::path projectRoot = Monolith::ProjectPath::Root();
+  if (!projectRoot.empty()) {
+    std::error_code ec;
+    if (fs::exists(projectRoot, ec) && !ec)
+      return projectRoot / ".horo" / "mcp-audit.jsonl";
+  }
+  return ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+}
+
+json BuildChangedIds(const std::string& toolName, const json& arguments, const json& summary) {
+  json changedIds = json::array();
+  auto pushUnique = [&](const std::string& value) {
+    if (value.empty())
+      return;
+    for (const json& item : changedIds) {
+      if (item.is_string() && item.get<std::string>() == value)
+        return;
+    }
+    changedIds.push_back(value);
+  };
+
+  if (arguments.contains("id") && arguments["id"].is_string())
+    pushUnique(arguments["id"].get<std::string>());
+  if (arguments.contains("ids") && arguments["ids"].is_array()) {
+    for (const json& item : arguments["ids"]) {
+      if (item.is_string())
+        pushUnique(item.get<std::string>());
+    }
+  }
+  if (toolName == "editor.new_scene" && arguments.contains("sceneId") && arguments["sceneId"].is_string())
+    pushUnique(arguments["sceneId"].get<std::string>());
+
+  const std::vector<std::string> summaryKeys = {"created", "updated", "asset", "renamed", "duplicates"};
+  for (const std::string& key : summaryKeys) {
+    if (!summary.contains(key))
+      continue;
+    const json& value = summary[key];
+    if (value.is_object() && value.contains("id") && value["id"].is_string())
+      pushUnique(value["id"].get<std::string>());
+    if (value.is_array()) {
+      for (const json& item : value) {
+        if (item.is_object() && item.contains("id") && item["id"].is_string())
+          pushUnique(item["id"].get<std::string>());
+      }
+    }
+  }
+  for (const char* key : {"newId", "deletedAssetId", "sceneId"}) {
+    if (summary.contains(key) && summary[key].is_string())
+      pushUnique(summary[key].get<std::string>());
+  }
+
+  return changedIds;
+}
+
+void AppendMutationAuditRecord(const json& requestId,
+                               const McpEditorSnapshot& snapshot,
+                               const std::string& toolName,
+                               const std::string& mode,
+                               const json& arguments,
+                               bool ok,
+                               const json& summary,
+                               const std::string& errorText) {
+  namespace fs = std::filesystem;
+
+  const fs::path auditPath = ResolveMcpAuditPath();
+  std::error_code ec;
+  fs::create_directories(auditPath.parent_path(), ec);
+  if (ec)
+    return;
+
+  std::ofstream out(auditPath, std::ios::app);
+  if (!out.is_open())
+    return;
+
+  json record = {
+      {"timestamp", FormatAuditTimestamp()},
+      {"requestId", requestId.is_null() ? std::string() : JsonToCompactString(requestId)},
+      {"tool", toolName},
+      {"mode", mode},
+      {"previewToken", arguments.value("previewToken", std::string())},
+      {"sceneId", snapshot.sceneId},
+      {"sceneFilePath", snapshot.sceneFilePath},
+      {"result", ok ? "success" : "error"},
+      {"error", ok ? std::string() : errorText},
+      {"changedIds", BuildChangedIds(toolName, arguments, summary)},
+      {"summary", summary},
+  };
+
+  out << record.dump() << "\n";
 }
 
 bool TryParseFloatText(const std::string& text, double* out) {
@@ -1669,11 +1782,21 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     json normalizedArguments = json::object();
     if (!NormalizeWriteArguments(*snapshot, name, StripMutationControls(arguments), &normalizedArguments,
                                  &validationError)) {
+      if (mode == "apply") {
+        AppendMutationAuditRecord(id, *snapshot, name, mode, StripMutationControls(arguments), false,
+                                  json{{"arguments", StripMutationControls(arguments)}}, validationError);
+      }
       const json result = MakeError(id, -32602, validationError);
       finish("tool", name, method, id, false, 200, validationError, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
     normalizedArguments["mode"] = mode;
+
+    auto appendApplyAudit = [&](bool ok, const json& summary, const std::string& errorText) {
+      if (mode != "apply")
+        return;
+      AppendMutationAuditRecord(id, *snapshot, name, mode, normalizedArguments, ok, summary, errorText);
+    };
 
     auto storePreviewToken = [&](const json& canonicalArguments) {
       std::scoped_lock lock(m_previewMutex);
@@ -1721,6 +1844,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     if (IsDestructiveToolName(name)) {
       if (!arguments.contains("previewToken") || !arguments["previewToken"].is_string()) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                         "previewToken is required for apply mode.");
         const json result = MakeError(id, -32602, "previewToken is required for apply mode.");
         finish("tool", name, method, id, false, 200, "previewToken is required for apply mode.",
                &result, {});
@@ -1730,6 +1855,7 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
       std::string previewError;
       const json canonicalArguments = StripMutationControls(normalizedArguments);
       if (!consumePreviewToken(previewToken, canonicalArguments, &previewError)) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, canonicalArguments), previewError);
         const json result = MakeError(id, -32602, previewError);
         finish("tool", name, method, id, false, 200, previewError, &result, {});
         return MakeJsonResponse(200, "OK", result);
@@ -1738,6 +1864,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     }
 
     if (!m_context.commandInvoker) {
+      appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                       "Command queue unavailable.");
       const json result = MakeError(id, -32002, "Command queue unavailable.");
       finish("tool", name, method, id, false, 503, "Command queue unavailable.", &result, {});
       return MakeJsonResponse(503, "Service Unavailable", result);
@@ -1745,10 +1873,16 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     const McpCommandResult commandResult = m_context.commandInvoker(name, normalizedArguments);
     if (!commandResult.ok) {
+      appendApplyAudit(false,
+                       commandResult.data.empty()
+                           ? BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments))
+                           : commandResult.data,
+                       commandResult.error);
       const json result = MakeError(id, -32010, commandResult.error);
       finish("tool", name, method, id, false, 200, commandResult.error, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
+    appendApplyAudit(true, commandResult.data, std::string());
     const json result = MakeSuccess(id, BuildTextToolResult(commandResult.data));
     finish("tool", name, method, id, true, 200, std::string(), &result, {});
     return MakeJsonResponse(200, "OK", result);

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -278,18 +278,20 @@ json BuildResourcePayload(const McpEditorSnapshot& snapshot, const std::string& 
   if (uri == "scene://assets")
     return BuildAssetsJson(snapshot, params.value("limit", 12));
   if (uri == "scene://hierarchy")
-    return BuildHierarchyJson(snapshot, params.value("limit", 32));
+    return BuildHierarchyJson(snapshot, params.value("limit", 32), params.value("offset", 0));
   if (uri == "scene://objects")
     return BuildObjectListJson(snapshot, params.value("limit", 12), params.value("type", std::string()),
-                               params.value("query", std::string()), params.value("selectedOnly", false));
+                               params.value("query", std::string()), params.value("selectedOnly", false),
+                               params.value("offset", 0));
   if (uri == "scene://scene_status")
     return BuildSceneStatusJson(snapshot);
   if (uri == "assets://selection")
     return BuildAssetsSelectionJson(snapshot);
   if (uri == "assets://catalog")
-    return BuildAssetsCatalogJson(snapshot, params.value("limit", 12), params.value("query", std::string()));
+    return BuildAssetsCatalogJson(snapshot, params.value("limit", 12), params.value("query", std::string()),
+                                  params.value("offset", 0));
   if (uri == "console://recent")
-    return BuildConsoleJson(snapshot, params.value("limit", 20));
+    return BuildConsoleJson(snapshot, params.value("limit", 20), params.value("offset", 0));
   if (uri == "console://summary")
     return BuildConsoleSummaryJson(snapshot, params.value("limit", 5));
   if (uri == "build://status")

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -1,8 +1,12 @@
 #include "mcp/McpProtocol.h"
 
 #include <algorithm>
+#include <cmath>
 #include <chrono>
 #include <cctype>
+#include <cstdlib>
+#include <iomanip>
+#include <sstream>
 #include <unordered_set>
 
 namespace Monolith {
@@ -167,6 +171,445 @@ bool IsKnownResourceUri(const std::string& uri) {
   return uris.find(uri) != uris.end();
 }
 
+bool IsWriteToolName(const std::string& name) {
+  return name == "editor.select" || name == "editor.clear_selection" ||
+         name == "editor.create_object" || name == "editor.create_object_from_asset" ||
+         name == "editor.update_object" || name == "editor.transform" ||
+         name == "editor.rename_object" || name == "editor.reparent_object" ||
+         name == "editor.duplicate" || name == "editor.delete" || name == "editor.select_asset" ||
+         name == "editor.update_asset" || name == "editor.delete_asset" ||
+         name == "editor.new_scene" || name == "editor.save_scene" ||
+         name == "editor.reload_scene";
+}
+
+bool IsDestructiveToolName(const std::string& name) {
+  return name == "editor.delete" || name == "editor.delete_asset" || name == "editor.new_scene" ||
+         name == "editor.reload_scene";
+}
+
+std::string FormatFloatText(double value) {
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(4) << value;
+  return out.str();
+}
+
+bool TryParseFloatText(const std::string& text, double* out) {
+  if (!out)
+    return false;
+  char* end = nullptr;
+  const double value = std::strtod(text.c_str(), &end);
+  if (end == text.c_str() || (end && *end != '\0') || !std::isfinite(value))
+    return false;
+  *out = value;
+  return true;
+}
+
+bool TryParseBoolText(const std::string& text, bool* out) {
+  if (!out)
+    return false;
+  const std::string lowered = ToLowerAscii(text);
+  if (lowered == "true" || lowered == "1") {
+    *out = true;
+    return true;
+  }
+  if (lowered == "false" || lowered == "0") {
+    *out = false;
+    return true;
+  }
+  return false;
+}
+
+bool NormalizeFreeformScalar(const json& value, std::string* out) {
+  if (!out)
+    return false;
+  if (value.is_string()) {
+    *out = value.get<std::string>();
+    return true;
+  }
+  if (value.is_number_integer() || value.is_number_unsigned() || value.is_number_float()) {
+    *out = value.dump();
+    return true;
+  }
+  if (value.is_boolean()) {
+    *out = value.get<bool>() ? "true" : "false";
+    return true;
+  }
+  if (value.is_null()) {
+    out->clear();
+    return true;
+  }
+  return false;
+}
+
+bool NormalizeVec3Argument(const json& value,
+                           const std::string& argumentName,
+                           json* out,
+                           std::string* error) {
+  if (!out)
+    return false;
+  if (!value.is_array() || value.size() != 3 || !value[0].is_number() || !value[1].is_number() ||
+      !value[2].is_number()) {
+    if (error)
+      *error = argumentName + " must be [x,y,z].";
+    return false;
+  }
+  *out = json::array({value[0].get<double>(), value[1].get<double>(), value[2].get<double>()});
+  return true;
+}
+
+bool NormalizeColor3Value(const json& value, std::string* out) {
+  if (!out)
+    return false;
+  if (value.is_string()) {
+    std::stringstream stream(value.get<std::string>());
+    std::string item;
+    std::vector<double> parts;
+    while (std::getline(stream, item, ',')) {
+      item.erase(std::remove_if(item.begin(), item.end(), [](unsigned char c) { return std::isspace(c); }),
+                 item.end());
+      double parsed = 0.0;
+      if (!TryParseFloatText(item, &parsed))
+        return false;
+      parts.push_back(parsed);
+    }
+    if (parts.size() != 3)
+      return false;
+    *out = FormatFloatText(parts[0]) + "," + FormatFloatText(parts[1]) + "," + FormatFloatText(parts[2]);
+    return true;
+  }
+  if (!value.is_array() || value.size() != 3 || !value[0].is_number() || !value[1].is_number() ||
+      !value[2].is_number()) {
+    return false;
+  }
+  *out = FormatFloatText(value[0].get<double>()) + "," + FormatFloatText(value[1].get<double>()) +
+         "," + FormatFloatText(value[2].get<double>());
+  return true;
+}
+
+const McpSchemaEntrySnapshot* FindSchemaEntryByName(const std::vector<McpSchemaEntrySnapshot>& entries,
+                                                    const std::string& name) {
+  const std::string loweredName = ToLowerAscii(name);
+  for (const McpSchemaEntrySnapshot& entry : entries) {
+    if (ToLowerAscii(entry.name) == loweredName)
+      return &entry;
+  }
+  return nullptr;
+}
+
+const McpSchemaFieldSnapshot* FindSchemaFieldByKey(const McpSchemaEntrySnapshot& schema,
+                                                   const std::string& key) {
+  const std::string loweredKey = ToLowerAscii(key);
+  for (const McpSchemaFieldSnapshot& field : schema.fields) {
+    if (ToLowerAscii(field.key) == loweredKey)
+      return &field;
+  }
+  return nullptr;
+}
+
+const McpSchemaEntrySnapshot* FindObjectSchema(const McpEditorSnapshot& snapshot, const std::string& typeName) {
+  return FindSchemaEntryByName(snapshot.schema.objectTypes, typeName);
+}
+
+const McpSchemaEntrySnapshot* FindComponentSchema(const McpEditorSnapshot& snapshot,
+                                                  const std::string& componentType) {
+  return FindSchemaEntryByName(snapshot.schema.components, componentType);
+}
+
+bool NormalizeFieldValue(const McpSchemaFieldSnapshot& field,
+                         const json& value,
+                         std::string* out,
+                         std::string* error) {
+  if (!out)
+    return false;
+
+  if (field.widget == "float") {
+    double numeric = 0.0;
+    if (value.is_number()) {
+      numeric = value.get<double>();
+    } else if (value.is_string()) {
+      if (!TryParseFloatText(value.get<std::string>(), &numeric)) {
+        if (error)
+          *error = "must be a number.";
+        return false;
+      }
+    } else {
+      if (error)
+        *error = "must be a number.";
+      return false;
+    }
+    if (!std::isfinite(numeric)) {
+      if (error)
+        *error = "must be finite.";
+      return false;
+    }
+    if (field.hasMin && numeric < static_cast<double>(field.minVal)) {
+      if (error)
+        *error = "must be >= " + FormatFloatText(field.minVal) + ".";
+      return false;
+    }
+    if (field.hasMax && numeric > static_cast<double>(field.maxVal)) {
+      if (error)
+        *error = "must be <= " + FormatFloatText(field.maxVal) + ".";
+      return false;
+    }
+    *out = FormatFloatText(numeric);
+    return true;
+  }
+
+  if (field.widget == "bool") {
+    bool boolValue = false;
+    if (value.is_boolean()) {
+      boolValue = value.get<bool>();
+    } else if (value.is_string()) {
+      if (!TryParseBoolText(value.get<std::string>(), &boolValue)) {
+        if (error)
+          *error = "must be true or false.";
+        return false;
+      }
+    } else {
+      if (error)
+        *error = "must be a boolean.";
+      return false;
+    }
+    *out = boolValue ? "true" : "false";
+    return true;
+  }
+
+  if (field.widget == "enum") {
+    if (!value.is_string()) {
+      if (error)
+        *error = "must be a string.";
+      return false;
+    }
+    const std::string text = value.get<std::string>();
+    const bool knownValue =
+        std::find(field.options.begin(), field.options.end(), text) != field.options.end();
+    if (!knownValue && !field.allowCustomValue) {
+      if (error) {
+        *error = "must be one of: ";
+        for (size_t i = 0; i < field.options.size(); ++i) {
+          if (i > 0)
+            *error += ", ";
+          *error += field.options[i];
+        }
+        *error += ".";
+      }
+      return false;
+    }
+    *out = text;
+    return true;
+  }
+
+  if (field.widget == "color3") {
+    if (!NormalizeColor3Value(value, out)) {
+      if (error)
+        *error = "must be a color3 string or [r,g,b] array.";
+      return false;
+    }
+    return true;
+  }
+
+  if (!value.is_string()) {
+    if (error)
+      *error = "must be a string.";
+    return false;
+  }
+  *out = value.get<std::string>();
+  if (!field.allowEmpty && out->empty()) {
+    if (error)
+      *error = "must not be empty.";
+    return false;
+  }
+  return true;
+}
+
+bool NormalizePropsObject(const json& input,
+                          const McpSchemaEntrySnapshot* schema,
+                          bool allowUnknown,
+                          bool applyDefaults,
+                          json* out,
+                          std::string* error,
+                          const std::string& prefix) {
+  if (!out)
+    return false;
+  if (!input.is_object()) {
+    if (error)
+      *error = prefix + " must be an object.";
+    return false;
+  }
+
+  json normalized = json::object();
+  if (applyDefaults && schema) {
+    for (const McpSchemaFieldSnapshot& field : schema->fields) {
+      if (field.hasDefault)
+        normalized[field.key] = field.defaultValue;
+    }
+  }
+
+  for (auto it = input.begin(); it != input.end(); ++it) {
+    const std::string key = it.key();
+    if (schema) {
+      if (const McpSchemaFieldSnapshot* field = FindSchemaFieldByKey(*schema, key)) {
+        std::string normalizedValue;
+        std::string fieldError;
+        if (!NormalizeFieldValue(*field, it.value(), &normalizedValue, &fieldError)) {
+          if (error)
+            *error = prefix + "." + key + " " + fieldError;
+          return false;
+        }
+        normalized[field->key] = normalizedValue;
+        continue;
+      }
+      if (!allowUnknown) {
+        if (error)
+          *error = "Unknown field in " + prefix + ": " + key + ".";
+        return false;
+      }
+    }
+
+    std::string scalar;
+    if (!NormalizeFreeformScalar(it.value(), &scalar)) {
+      if (error)
+        *error = prefix + "." + key + " must be a scalar value.";
+      return false;
+    }
+    normalized[key] = scalar;
+  }
+
+  if (schema) {
+    for (const McpSchemaFieldSnapshot& field : schema->fields) {
+      const bool hasField = normalized.contains(field.key);
+      if (field.required && (!hasField || normalized[field.key].get<std::string>().empty())) {
+        if (error)
+          *error = prefix + "." + field.key + " is required.";
+        return false;
+      }
+      if (hasField && !field.allowEmpty && normalized[field.key].get<std::string>().empty()) {
+        if (error)
+          *error = prefix + "." + field.key + " must not be empty.";
+        return false;
+      }
+    }
+  }
+
+  *out = std::move(normalized);
+  return true;
+}
+
+bool NormalizeComponentList(const json& input,
+                            const McpEditorSnapshot& snapshot,
+                            bool applyDefaults,
+                            json* out,
+                            std::string* error) {
+  if (!out)
+    return false;
+  if (!input.is_array()) {
+    if (error)
+      *error = "components must be an array of objects.";
+    return false;
+  }
+
+  json normalized = json::array();
+  for (size_t index = 0; index < input.size(); ++index) {
+    const json& item = input[index];
+    if (!item.is_object() || !item.contains("type") || !item["type"].is_string()) {
+      if (error)
+        *error = "components[" + std::to_string(index) + "] must include a string type.";
+      return false;
+    }
+    const std::string componentType = item["type"].get<std::string>();
+    const McpSchemaEntrySnapshot* schema = FindComponentSchema(snapshot, componentType);
+    if (!schema) {
+      if (error)
+        *error = "Unknown component type: " + componentType + ".";
+      return false;
+    }
+    json props = json::object();
+    if (!NormalizePropsObject(item.value("props", json::object()), schema, false, applyDefaults, &props,
+                              error, "components[" + std::to_string(index) + "].props")) {
+      return false;
+    }
+    normalized.push_back(json{{"type", schema->name}, {"props", std::move(props)}});
+  }
+
+  *out = std::move(normalized);
+  return true;
+}
+
+bool ParseMutationMode(const json& arguments, std::string* outMode, std::string* error) {
+  if (!outMode)
+    return false;
+  *outMode = "apply";
+  if (!arguments.contains("mode"))
+    return true;
+  if (!arguments["mode"].is_string()) {
+    if (error)
+      *error = "mode must be \"preview\" or \"apply\".";
+    return false;
+  }
+  const std::string mode = ToLowerAscii(arguments["mode"].get<std::string>());
+  if (mode != "preview" && mode != "apply") {
+    if (error)
+      *error = "mode must be \"preview\" or \"apply\".";
+    return false;
+  }
+  *outMode = mode;
+  return true;
+}
+
+json StripMutationControls(const json& arguments) {
+  json stripped = arguments.is_object() ? arguments : json::object();
+  stripped.erase("mode");
+  stripped.erase("previewToken");
+  return stripped;
+}
+
+bool ObjectExists(const McpEditorSnapshot& snapshot, const std::string& id) {
+  return FindObjectById(snapshot, id) != nullptr;
+}
+
+bool AssetExists(const McpEditorSnapshot& snapshot, const std::string& id) {
+  return FindAssetById(snapshot, id) != nullptr;
+}
+
+bool ParentWouldCreateCycle(const McpEditorSnapshot& snapshot,
+                            const std::string& childId,
+                            const std::string& parentId) {
+  std::string current = parentId;
+  while (!current.empty()) {
+    if (current == childId)
+      return true;
+    const McpObjectSnapshot* parent = FindObjectById(snapshot, current);
+    if (!parent)
+      return false;
+    current = GetParentId(*parent);
+  }
+  return false;
+}
+
+bool NormalizeObjectTypeName(const std::string& raw, std::string* outType) {
+  if (!outType)
+    return false;
+  const std::string lowered = ToLowerAscii(raw);
+  if (lowered == "panel") {
+    *outType = "Panel";
+    return true;
+  }
+  if (lowered == "prop") {
+    *outType = "Prop";
+    return true;
+  }
+  if (lowered == "light") {
+    *outType = "Light";
+    return true;
+  }
+  if (lowered == "camera") {
+    *outType = "Camera";
+    return true;
+  }
+  return false;
+}
+
 json BuildToolList() {
   json tools = json::array();
   for (const McpCatalogEntry& entry : GetToolCatalog()) {
@@ -197,6 +640,7 @@ json BuildToolList() {
         tool["inputSchema"]["properties"]["mesh"] = {{"type", "string"}};
         tool["inputSchema"]["properties"]["renderScale"] = {{"type", "string"}};
         tool["inputSchema"]["properties"]["albedoMap"] = {{"type", "string"}};
+        tool["inputSchema"]["properties"]["displayName"] = {{"type", "string"}};
       }
       if (entry.name == "editor.rename_object")
         tool["inputSchema"]["required"] = json::array({"id", "newId"});
@@ -235,7 +679,7 @@ json BuildToolList() {
                                            {"yaw", {{"type", "number"}}},
                                            {"pitch", {{"type", "number"}}},
                                            {"roll", {{"type", "number"}}}};
-    } else if (entry.name == "editor.update_object" || entry.name == "editor.transform") {
+    } else if (entry.name == "editor.update_object") {
       tool["inputSchema"]["required"] = json::array({"id"});
       tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
                                            {"assetId", {{"type", "string"}}},
@@ -246,6 +690,14 @@ json BuildToolList() {
                                            {"roll", {{"type", "number"}}},
                                            {"props", {{"type", "object"}}},
                                            {"components", {{"type", "array"}}}};
+    } else if (entry.name == "editor.transform") {
+      tool["inputSchema"]["required"] = json::array({"id"});
+      tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
+                                           {"position", MakeVec3Schema()},
+                                           {"scale", MakeVec3Schema()},
+                                           {"yaw", {{"type", "number"}}},
+                                           {"pitch", {{"type", "number"}}},
+                                           {"roll", {{"type", "number"}}}};
     } else if (entry.name == "editor.duplicate") {
       tool["inputSchema"]["required"] = json::array({"id"});
       tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
@@ -267,6 +719,14 @@ json BuildToolList() {
     } else if (entry.name == "editor.new_scene") {
       tool["inputSchema"]["properties"] = {{"sceneName", {{"type", "string"}}},
                                            {"sceneId", {{"type", "string"}}}};
+    }
+    if (IsWriteToolName(entry.name)) {
+      tool["inputSchema"]["properties"]["mode"] = {
+          {"type", "string"},
+          {"enum", json::array({"preview", "apply"})},
+      };
+      if (IsDestructiveToolName(entry.name))
+        tool["inputSchema"]["properties"]["previewToken"] = {{"type", "string"}};
     }
     tools.push_back(std::move(tool));
   }
@@ -312,6 +772,561 @@ json BuildResourcePayload(const McpEditorSnapshot& snapshot, const std::string& 
 json BuildResourceReadResult(const McpEditorSnapshot& snapshot, const std::string& uri, const json& params) {
   const json payload = BuildResourcePayload(snapshot, uri, params);
   return json{{"contents", json::array({{{"uri", uri}, {"mimeType", "application/json"}, {"text", payload.dump()}}})}};
+}
+
+Vec3 JsonArrayToVec3(const json& value) {
+  return Vec3(value[0].get<float>(), value[1].get<float>(), value[2].get<float>());
+}
+
+bool NormalizeWriteArguments(const McpEditorSnapshot& snapshot,
+                             const std::string& toolName,
+                             const json& arguments,
+                             json* out,
+                             std::string* error) {
+  if (!out)
+    return false;
+  if (!arguments.is_object()) {
+    if (error)
+      *error = "arguments must be an object.";
+    return false;
+  }
+
+  json normalized = json::object();
+
+  if (toolName == "editor.select" || toolName == "editor.delete" || toolName == "editor.duplicate") {
+    if (arguments.contains("id")) {
+      if (!arguments["id"].is_string()) {
+        if (error)
+          *error = "id must be a string.";
+        return false;
+      }
+      normalized["id"] = arguments["id"].get<std::string>();
+    }
+    if (arguments.contains("ids")) {
+      if (!arguments["ids"].is_array()) {
+        if (error)
+          *error = "ids must be an array of strings.";
+        return false;
+      }
+      json ids = json::array();
+      for (const json& item : arguments["ids"]) {
+        if (!item.is_string()) {
+          if (error)
+            *error = "ids must be an array of strings.";
+          return false;
+        }
+        ids.push_back(item.get<std::string>());
+      }
+      normalized["ids"] = std::move(ids);
+    }
+    if (toolName == "editor.duplicate" && arguments.contains("count")) {
+      if (!arguments["count"].is_number_integer()) {
+        if (error)
+          *error = "count must be an integer.";
+        return false;
+      }
+      const int count = arguments["count"].get<int>();
+      if (count < 1 || count > 8) {
+        if (error)
+          *error = "count must be between 1 and 8.";
+        return false;
+      }
+      normalized["count"] = count;
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.clear_selection" || toolName == "editor.save_scene") {
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.select_asset" || toolName == "editor.delete_asset") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string assetId = arguments["id"].get<std::string>();
+    if (!assetId.empty() && !AssetExists(snapshot, assetId)) {
+      if (error)
+        *error = "Asset not found.";
+      return false;
+    }
+    normalized["id"] = assetId;
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.update_asset") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string assetId = arguments["id"].get<std::string>();
+    if (!AssetExists(snapshot, assetId)) {
+      if (error)
+        *error = "Asset not found.";
+      return false;
+    }
+    normalized["id"] = assetId;
+    for (const char* key : {"mesh", "renderScale", "albedoMap", "displayName"}) {
+      if (!arguments.contains(key))
+        continue;
+      if (!arguments[key].is_string() && !arguments[key].is_null()) {
+        if (error)
+          *error = std::string(key) + " must be a string or null.";
+        return false;
+      }
+      normalized[key] = arguments[key];
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.rename_object") {
+    if (!arguments.contains("id") || !arguments["id"].is_string() || !arguments.contains("newId") ||
+        !arguments["newId"].is_string()) {
+      if (error)
+        *error = "id and newId are required.";
+      return false;
+    }
+    const std::string id = arguments["id"].get<std::string>();
+    const std::string newId = arguments["newId"].get<std::string>();
+    if (!ObjectExists(snapshot, id)) {
+      if (error)
+        *error = "Object not found.";
+      return false;
+    }
+    if (newId.empty()) {
+      if (error)
+        *error = "newId is required.";
+      return false;
+    }
+    if (const McpObjectSnapshot* existing = FindObjectById(snapshot, newId)) {
+      if (existing->id != id) {
+        if (error)
+          *error = "Object id already exists.";
+        return false;
+      }
+    }
+    normalized["id"] = id;
+    normalized["newId"] = newId;
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.reparent_object") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string id = arguments["id"].get<std::string>();
+    if (!ObjectExists(snapshot, id)) {
+      if (error)
+        *error = "Object not found.";
+      return false;
+    }
+    normalized["id"] = id;
+    if (arguments.contains("parentId")) {
+      if (!arguments["parentId"].is_string() && !arguments["parentId"].is_null()) {
+        if (error)
+          *error = "parentId must be a string or null.";
+        return false;
+      }
+      const std::string parentId =
+          arguments["parentId"].is_null() ? std::string() : arguments["parentId"].get<std::string>();
+      if (!parentId.empty()) {
+        if (!ObjectExists(snapshot, parentId)) {
+          if (error)
+            *error = "Parent object not found.";
+          return false;
+        }
+        if (parentId == id) {
+          if (error)
+            *error = "Object cannot parent itself.";
+          return false;
+        }
+        if (ParentWouldCreateCycle(snapshot, id, parentId)) {
+          if (error)
+            *error = "Parent would create a cycle.";
+          return false;
+        }
+        normalized["parentId"] = parentId;
+      } else {
+        normalized["parentId"] = nullptr;
+      }
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.new_scene") {
+    if (arguments.contains("sceneId") && !arguments["sceneId"].is_string()) {
+      if (error)
+        *error = "sceneId must be a string.";
+      return false;
+    }
+    if (arguments.contains("sceneName") && !arguments["sceneName"].is_string()) {
+      if (error)
+        *error = "sceneName must be a string.";
+      return false;
+    }
+    if (arguments.contains("sceneId"))
+      normalized["sceneId"] = arguments["sceneId"].get<std::string>();
+    if (arguments.contains("sceneName"))
+      normalized["sceneName"] = arguments["sceneName"].get<std::string>();
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.reload_scene") {
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.create_object" || toolName == "editor.create_object_from_asset" ||
+      toolName == "editor.update_object" || toolName == "editor.transform") {
+    const McpObjectSnapshot* existingObject = nullptr;
+    std::string objectTypeName;
+
+    if (toolName == "editor.create_object") {
+      if (!arguments.contains("type") || !arguments["type"].is_string()) {
+        if (error)
+          *error = "type is required.";
+        return false;
+      }
+      if (!NormalizeObjectTypeName(arguments["type"].get<std::string>(), &objectTypeName)) {
+        if (error)
+          *error = "Invalid object type.";
+        return false;
+      }
+      normalized["type"] = objectTypeName;
+    } else if (toolName == "editor.update_object" || toolName == "editor.transform") {
+      if (!arguments.contains("id") || !arguments["id"].is_string()) {
+        if (error)
+          *error = "id is required.";
+        return false;
+      }
+      const std::string objectId = arguments["id"].get<std::string>();
+      existingObject = FindObjectById(snapshot, objectId);
+      if (!existingObject) {
+        if (error)
+          *error = "Object not found.";
+        return false;
+      }
+      normalized["id"] = objectId;
+      objectTypeName = existingObject->type;
+    }
+
+    if (toolName == "editor.create_object_from_asset") {
+      if (!arguments.contains("assetId") || !arguments["assetId"].is_string()) {
+        if (error)
+          *error = "assetId is required.";
+        return false;
+      }
+      const std::string assetId = arguments["assetId"].get<std::string>();
+      if (!AssetExists(snapshot, assetId)) {
+        if (error)
+          *error = "Asset not found.";
+        return false;
+      }
+      normalized["assetId"] = assetId;
+      objectTypeName = "Prop";
+      if (arguments.contains("scale") || arguments.contains("props") || arguments.contains("components")) {
+        if (error)
+          *error = "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+    }
+
+    const McpSchemaEntrySnapshot* objectSchema =
+        objectTypeName.empty() ? nullptr : FindObjectSchema(snapshot, objectTypeName);
+
+    if (arguments.contains("id")) {
+      if (!arguments["id"].is_string()) {
+        if (error)
+          *error = "id must be a string.";
+        return false;
+      }
+      const std::string objectId = arguments["id"].get<std::string>();
+      if ((toolName == "editor.create_object" || toolName == "editor.create_object_from_asset") &&
+          ObjectExists(snapshot, objectId)) {
+        if (error)
+          *error = "Object id already exists.";
+        return false;
+      }
+      normalized["id"] = objectId;
+    }
+    if (arguments.contains("assetId")) {
+      if (toolName == "editor.transform") {
+        if (error)
+          *error = "transform only accepts id, position, scale, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!arguments["assetId"].is_string() && !arguments["assetId"].is_null()) {
+        if (error)
+          *error = "assetId must be a string or null.";
+        return false;
+      }
+      const std::string assetId =
+          arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
+      if (!assetId.empty() && !AssetExists(snapshot, assetId)) {
+        if (error)
+          *error = "Asset not found.";
+        return false;
+      }
+      normalized["assetId"] = arguments["assetId"];
+    }
+    if (arguments.contains("parentId")) {
+      if (toolName == "editor.update_object" || toolName == "editor.transform") {
+        if (error)
+          *error = "parentId must be changed with editor.reparent_object.";
+        return false;
+      }
+      if (!arguments["parentId"].is_string()) {
+        if (error)
+          *error = "parentId must be a string.";
+        return false;
+      }
+      const std::string parentId = arguments["parentId"].get<std::string>();
+      if (!ObjectExists(snapshot, parentId)) {
+        if (error)
+          *error = "Parent object not found.";
+        return false;
+      }
+      normalized["parentId"] = parentId;
+    }
+    if (arguments.contains("position") &&
+        !NormalizeVec3Argument(arguments["position"], "position", &normalized["position"], error)) {
+      return false;
+    }
+    if (arguments.contains("scale") &&
+        !NormalizeVec3Argument(arguments["scale"], "scale", &normalized["scale"], error)) {
+      return false;
+    }
+    for (const char* key : {"yaw", "pitch", "roll"}) {
+      if (!arguments.contains(key))
+        continue;
+      if (!arguments[key].is_number()) {
+        if (error)
+          *error = std::string(key) + " must be a number.";
+        return false;
+      }
+      normalized[key] = arguments[key].get<double>();
+    }
+    if (arguments.contains("props")) {
+      if (toolName == "editor.transform" || toolName == "editor.create_object_from_asset") {
+        if (error)
+          *error = toolName == "editor.transform"
+                       ? "transform only accepts id, position, scale, yaw, pitch, and roll."
+                       : "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!NormalizePropsObject(arguments["props"], objectSchema, true,
+                                toolName == "editor.create_object", &normalized["props"], error, "props")) {
+        return false;
+      }
+    } else if (toolName == "editor.create_object" && objectSchema) {
+      if (!NormalizePropsObject(json::object(), objectSchema, true, true, &normalized["props"], error, "props"))
+        return false;
+    }
+    if (arguments.contains("components")) {
+      if (toolName == "editor.transform" || toolName == "editor.create_object_from_asset") {
+        if (error)
+          *error = toolName == "editor.transform"
+                       ? "transform only accepts id, position, scale, yaw, pitch, and roll."
+                       : "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!NormalizeComponentList(arguments["components"], snapshot, true, &normalized["components"], error))
+        return false;
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  return false;
+}
+
+json BuildMutationPreviewPayload(const McpEditorSnapshot& snapshot,
+                                 const std::string& toolName,
+                                 const json& arguments) {
+  if (toolName == "editor.select") {
+    json ids = arguments.value("ids", json::array());
+    if (arguments.contains("id") && arguments["id"].is_string())
+      ids.push_back(arguments["id"].get<std::string>());
+    return json{{"tool", toolName}, {"selectedObjectIds", std::move(ids)}};
+  }
+  if (toolName == "editor.clear_selection") {
+    return json{{"tool", toolName}, {"cleared", true}};
+  }
+  if (toolName == "editor.create_object") {
+    McpObjectSnapshot object;
+    object.id = arguments.value("id", std::string("(auto-generated)"));
+    object.type = arguments.value("type", std::string("Panel"));
+    if (arguments.contains("position"))
+      object.position = JsonArrayToVec3(arguments["position"]);
+    if (arguments.contains("scale"))
+      object.scale = JsonArrayToVec3(arguments["scale"]);
+    object.yaw = arguments.value("yaw", 0.0f);
+    object.pitch = arguments.value("pitch", 0.0f);
+    object.roll = arguments.value("roll", 0.0f);
+    object.assetId = arguments.value("assetId", std::string());
+    if (arguments.contains("props")) {
+      for (auto it = arguments["props"].begin(); it != arguments["props"].end(); ++it)
+        object.props[it.key()] = it.value().get<std::string>();
+    }
+    if (arguments.contains("parentId"))
+      object.props["parentId"] = arguments["parentId"].get<std::string>();
+    if (arguments.contains("components")) {
+      for (const json& item : arguments["components"]) {
+        McpComponentSnapshot component;
+        component.type = item["type"].get<std::string>();
+        for (auto it = item["props"].begin(); it != item["props"].end(); ++it)
+          component.props[it.key()] = it.value().get<std::string>();
+        object.components.push_back(std::move(component));
+      }
+    }
+    return json{{"tool", toolName}, {"created", BuildObjectJson(object)}};
+  }
+  if (toolName == "editor.create_object_from_asset") {
+    json preview{{"tool", toolName},
+                 {"assetId", arguments.value("assetId", std::string())},
+                 {"id", arguments.value("id", std::string("(auto-generated)"))}};
+    if (const McpAssetSnapshot* asset =
+            FindAssetById(snapshot, arguments.value("assetId", std::string()))) {
+      preview["asset"] = BuildAssetJson(*asset);
+    }
+    if (arguments.contains("parentId"))
+      preview["parentId"] = arguments["parentId"];
+    if (arguments.contains("position"))
+      preview["position"] = arguments["position"];
+    preview["yaw"] = arguments.value("yaw", 0.0f);
+    preview["pitch"] = arguments.value("pitch", 0.0f);
+    preview["roll"] = arguments.value("roll", 0.0f);
+    return preview;
+  }
+  if (toolName == "editor.update_object" || toolName == "editor.transform") {
+    const McpObjectSnapshot* current = FindObjectById(snapshot, arguments.value("id", std::string()));
+    if (!current)
+      return json{{"tool", toolName}, {"id", arguments.value("id", std::string())}};
+    McpObjectSnapshot updated = *current;
+    if (arguments.contains("position"))
+      updated.position = JsonArrayToVec3(arguments["position"]);
+    if (arguments.contains("scale"))
+      updated.scale = JsonArrayToVec3(arguments["scale"]);
+    if (arguments.contains("yaw"))
+      updated.yaw = arguments["yaw"].get<float>();
+    if (arguments.contains("pitch"))
+      updated.pitch = arguments["pitch"].get<float>();
+    if (arguments.contains("roll"))
+      updated.roll = arguments["roll"].get<float>();
+    if (arguments.contains("assetId"))
+      updated.assetId = arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
+    if (arguments.contains("props")) {
+      for (auto it = arguments["props"].begin(); it != arguments["props"].end(); ++it)
+        updated.props[it.key()] = it.value().get<std::string>();
+    }
+    if (arguments.contains("components")) {
+      updated.components.clear();
+      for (const json& item : arguments["components"]) {
+        McpComponentSnapshot component;
+        component.type = item["type"].get<std::string>();
+        for (auto it = item["props"].begin(); it != item["props"].end(); ++it)
+          component.props[it.key()] = it.value().get<std::string>();
+        updated.components.push_back(std::move(component));
+      }
+    }
+    return json{{"tool", toolName}, {"before", BuildObjectJson(*current)}, {"after", BuildObjectJson(updated)}};
+  }
+  if (toolName == "editor.rename_object") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"newId", arguments.value("newId", std::string())}};
+  }
+  if (toolName == "editor.reparent_object") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"parentId", arguments.contains("parentId") ? arguments["parentId"] : json(nullptr)}};
+  }
+  if (toolName == "editor.duplicate") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"ids", arguments.value("ids", json::array())},
+                {"count", arguments.value("count", 1)}};
+  }
+  if (toolName == "editor.delete") {
+    json deleted = json::array();
+    std::vector<std::string> ids;
+    if (arguments.contains("id") && arguments["id"].is_string())
+      ids.push_back(arguments["id"].get<std::string>());
+    if (arguments.contains("ids")) {
+      for (const json& item : arguments["ids"])
+        ids.push_back(item.get<std::string>());
+    }
+    for (const std::string& id : ids) {
+      if (const McpObjectSnapshot* object = FindObjectById(snapshot, id))
+        deleted.push_back(BuildObjectJson(*object));
+    }
+    return json{{"tool", toolName},
+                {"deletedCount", deleted.size()},
+                {"objects", std::move(deleted)}};
+  }
+  if (toolName == "editor.select_asset") {
+    return json{{"tool", toolName}, {"selectedAssetId", arguments.value("id", std::string())}};
+  }
+  if (toolName == "editor.update_asset") {
+    const std::string assetId = arguments.value("id", std::string());
+    json preview{{"tool", toolName}, {"id", assetId}};
+    if (const McpAssetSnapshot* asset = FindAssetById(snapshot, assetId))
+      preview["before"] = BuildAssetJson(*asset);
+    json after = preview.value("before", json::object());
+    after["id"] = assetId;
+    for (const char* key : {"mesh", "renderScale", "albedoMap", "displayName"}) {
+      if (arguments.contains(key))
+        after[key] = arguments[key];
+    }
+    preview["after"] = std::move(after);
+    return preview;
+  }
+  if (toolName == "editor.delete_asset") {
+    const std::string assetId = arguments.value("id", std::string());
+    json preview{{"tool", toolName}, {"deletedAssetId", assetId}};
+    if (const McpAssetSnapshot* asset = FindAssetById(snapshot, assetId)) {
+      preview["asset"] = BuildAssetJson(*asset);
+      size_t referenceCount = 0;
+      for (const McpObjectSnapshot& object : snapshot.objects) {
+        if (object.assetId == assetId)
+          ++referenceCount;
+      }
+      preview["clearedObjectReferences"] = referenceCount;
+    }
+    return preview;
+  }
+  if (toolName == "editor.new_scene") {
+    return json{{"tool", toolName},
+                {"currentSceneId", snapshot.sceneId},
+                {"currentSceneName", snapshot.sceneName},
+                {"sceneId", arguments.value("sceneId", std::string("scene"))},
+                {"sceneName", arguments.value("sceneName", std::string("Scene"))}};
+  }
+  if (toolName == "editor.save_scene") {
+    return json{{"tool", toolName},
+                {"filePath", snapshot.sceneFilePath.empty() ? "assets/scenes/scene.json"
+                                                             : snapshot.sceneFilePath},
+                {"dirty", snapshot.dirty}};
+  }
+  if (toolName == "editor.reload_scene") {
+    return json{{"tool", toolName},
+                {"filePath", snapshot.sceneFilePath},
+                {"dirty", snapshot.dirty},
+                {"reloadPending", snapshot.reloadPending}};
+  }
+  return json{{"tool", toolName}};
 }
 
 }  // namespace
@@ -637,25 +1652,98 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
       return MakeJsonResponse(200, "OK", result);
     }
 
-    const bool isWriteTool =
-        name == "editor.select" || name == "editor.clear_selection" || name == "editor.create_object" ||
-        name == "editor.create_object_from_asset" || name == "editor.update_object" ||
-        name == "editor.transform" || name == "editor.rename_object" || name == "editor.reparent_object" ||
-        name == "editor.duplicate" || name == "editor.delete" || name == "editor.select_asset" ||
-        name == "editor.update_asset" || name == "editor.delete_asset" || name == "editor.new_scene" ||
-        name == "editor.save_scene" || name == "editor.reload_scene";
-    if (!isWriteTool) {
+    if (!IsWriteToolName(name)) {
       const json result = MakeError(id, -32601, "Unknown tool.");
       finish("tool", name, method, id, false, 200, "Unknown tool.", &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
+
+    std::string mode;
+    std::string validationError;
+    if (!ParseMutationMode(arguments, &mode, &validationError)) {
+      const json result = MakeError(id, -32602, validationError);
+      finish("tool", name, method, id, false, 200, validationError, &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+
+    json normalizedArguments = json::object();
+    if (!NormalizeWriteArguments(*snapshot, name, StripMutationControls(arguments), &normalizedArguments,
+                                 &validationError)) {
+      const json result = MakeError(id, -32602, validationError);
+      finish("tool", name, method, id, false, 200, validationError, &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+    normalizedArguments["mode"] = mode;
+
+    auto storePreviewToken = [&](const json& canonicalArguments) {
+      std::scoped_lock lock(m_previewMutex);
+      if (m_previewRecords.size() >= 128)
+        m_previewRecords.clear();
+      std::ostringstream token;
+      token << "preview_" << ++m_nextPreviewToken;
+      m_previewRecords[token.str()] = PreviewRecord{name, canonicalArguments, snapshot->sceneId,
+                                                    snapshot->sceneFilePath};
+      return token.str();
+    };
+
+    auto consumePreviewToken = [&](const std::string& previewToken,
+                                   const json& canonicalArguments,
+                                   std::string* outError) {
+      std::scoped_lock lock(m_previewMutex);
+      const auto it = m_previewRecords.find(previewToken);
+      if (it == m_previewRecords.end()) {
+        if (outError)
+          *outError = "previewToken is invalid or expired.";
+        return false;
+      }
+      const PreviewRecord& record = it->second;
+      if (record.toolName != name || record.arguments != canonicalArguments ||
+          record.sceneId != snapshot->sceneId || record.sceneFilePath != snapshot->sceneFilePath) {
+        if (outError)
+          *outError = "previewToken does not match the current scene state or arguments.";
+        return false;
+      }
+      m_previewRecords.erase(it);
+      return true;
+    };
+
+    if (mode == "preview") {
+      const json canonicalArguments = StripMutationControls(normalizedArguments);
+      const std::string previewToken = storePreviewToken(canonicalArguments);
+      json previewPayload = {{"tool", name},
+                             {"mode", "preview"},
+                             {"previewToken", previewToken},
+                             {"preview", BuildMutationPreviewPayload(*snapshot, name, canonicalArguments)}};
+      const json result = MakeSuccess(id, BuildTextToolResult(previewPayload));
+      finish("tool", name, method, id, true, 200, std::string(), &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+
+    if (IsDestructiveToolName(name)) {
+      if (!arguments.contains("previewToken") || !arguments["previewToken"].is_string()) {
+        const json result = MakeError(id, -32602, "previewToken is required for apply mode.");
+        finish("tool", name, method, id, false, 200, "previewToken is required for apply mode.",
+               &result, {});
+        return MakeJsonResponse(200, "OK", result);
+      }
+      const std::string previewToken = arguments["previewToken"].get<std::string>();
+      std::string previewError;
+      const json canonicalArguments = StripMutationControls(normalizedArguments);
+      if (!consumePreviewToken(previewToken, canonicalArguments, &previewError)) {
+        const json result = MakeError(id, -32602, previewError);
+        finish("tool", name, method, id, false, 200, previewError, &result, {});
+        return MakeJsonResponse(200, "OK", result);
+      }
+      normalizedArguments["previewToken"] = previewToken;
+    }
+
     if (!m_context.commandInvoker) {
       const json result = MakeError(id, -32002, "Command queue unavailable.");
       finish("tool", name, method, id, false, 503, "Command queue unavailable.", &result, {});
       return MakeJsonResponse(503, "Service Unavailable", result);
     }
 
-    const McpCommandResult commandResult = m_context.commandInvoker(name, arguments);
+    const McpCommandResult commandResult = m_context.commandInvoker(name, normalizedArguments);
     if (!commandResult.ok) {
       const json result = MakeError(id, -32010, commandResult.error);
       finish("tool", name, method, id, false, 200, commandResult.error, &result, {});

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -103,6 +103,8 @@ const std::vector<McpCatalogEntry>& GetToolCatalog() {
       {"editor.delete_asset", "tool", "Delete one asset definition."},
       {"editor.scene_status", "tool", "Return compact scene status."},
       {"editor.get_scene_file", "tool", "Return the active scene file path and save state."},
+      {"editor.list_schema_types", "tool", "List object and component schemas exposed to MCP."},
+      {"editor.get_schema", "tool", "Fetch one object or component schema by name."},
       {"editor.new_scene", "tool", "Create a new empty scene document."},
       {"editor.save_scene", "tool", "Save the active scene document."},
       {"editor.reload_scene", "tool", "Queue an in-editor scene reload."},
@@ -254,6 +256,14 @@ json BuildToolList() {
                                            {"limit", {{"type", "integer"}, {"minimum", 1}, {"maximum", 64}}}};
     } else if (entry.name == "editor.count_assets") {
       tool["inputSchema"]["properties"] = {{"query", {{"type", "string"}}}};
+    } else if (entry.name == "editor.list_schema_types") {
+      tool["inputSchema"]["properties"] = {
+          {"kind", {{"type", "string"}, {"enum", json::array({"all", "object", "component"})}}}};
+    } else if (entry.name == "editor.get_schema") {
+      tool["inputSchema"]["required"] = json::array({"name"});
+      tool["inputSchema"]["properties"] = {
+          {"name", {{"type", "string"}}},
+          {"kind", {{"type", "string"}, {"enum", json::array({"all", "object", "component"})}}}};
     } else if (entry.name == "editor.new_scene") {
       tool["inputSchema"]["properties"] = {{"sceneName", {{"type", "string"}}},
                                            {"sceneId", {{"type", "string"}}}};
@@ -603,6 +613,25 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     if (name == "editor.search_console") {
       const json payloadOut = SearchConsoleSnapshot(*snapshot, arguments.value("query", std::string()),
                                                     arguments.value("limit", 8));
+      const json result = MakeSuccess(id, BuildTextToolResult(payloadOut));
+      finish("tool", name, method, id, true, 200, std::string(), &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+    if (name == "editor.list_schema_types") {
+      const json payloadOut = BuildSchemaCatalogJson(*snapshot, arguments.value("kind", std::string()));
+      const json result = MakeSuccess(id, BuildTextToolResult(payloadOut));
+      finish("tool", name, method, id, true, 200, std::string(), &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+    if (name == "editor.get_schema") {
+      const std::string schemaName = arguments.value("name", std::string());
+      const json payloadOut =
+          BuildSchemaJson(*snapshot, schemaName, arguments.value("kind", std::string()));
+      if (payloadOut.empty()) {
+        const json result = MakeError(id, -32602, "Schema not found.");
+        finish("tool", name, method, id, false, 200, "Schema not found.", &result, {});
+        return MakeJsonResponse(200, "OK", result);
+      }
       const json result = MakeSuccess(id, BuildTextToolResult(payloadOut));
       finish("tool", name, method, id, true, 200, std::string(), &result, {});
       return MakeJsonResponse(200, "OK", result);

--- a/mcp/McpProtocol.h
+++ b/mcp/McpProtocol.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -70,7 +72,17 @@ class McpProtocol {
   const std::vector<McpCatalogEntry>& ResourceCatalog() const;
 
  private:
+  struct PreviewRecord {
+    std::string toolName;
+    nlohmann::json arguments = nlohmann::json::object();
+    std::string sceneId;
+    std::string sceneFilePath;
+  };
+
   McpProtocolContext m_context;
+  mutable std::mutex m_previewMutex;
+  mutable uint64_t m_nextPreviewToken = 0;
+  mutable std::unordered_map<std::string, PreviewRecord> m_previewRecords;
 };
 
 }  // namespace Mcp

--- a/mcp/McpSnapshot.cpp
+++ b/mcp/McpSnapshot.cpp
@@ -141,6 +141,7 @@ json BuildSchemaFieldJson(const McpSchemaFieldSnapshot& field) {
       {"label", field.label},
       {"description", field.description},
       {"widget", field.widget},
+      {"hasDefault", field.hasDefault},
       {"default", field.defaultValue},
       {"required", field.required},
       {"allowEmpty", field.allowEmpty},

--- a/mcp/McpSnapshot.cpp
+++ b/mcp/McpSnapshot.cpp
@@ -124,6 +124,73 @@ json BuildBuildIssueJson(const McpBuildIssueSnapshot& issue) {
   };
 }
 
+std::string NormalizeSchemaKind(std::string value) {
+  value = ToLowerAscii(std::move(value));
+  if (value.empty() || value == "all")
+    return "all";
+  if (value == "object" || value == "objects" || value == "type" || value == "types")
+    return "object";
+  if (value == "component" || value == "components")
+    return "component";
+  return value;
+}
+
+json BuildSchemaFieldJson(const McpSchemaFieldSnapshot& field) {
+  json out = json{
+      {"key", field.key},
+      {"label", field.label},
+      {"description", field.description},
+      {"widget", field.widget},
+      {"default", field.defaultValue},
+      {"required", field.required},
+      {"allowEmpty", field.allowEmpty},
+      {"allowCustomValue", field.allowCustomValue},
+  };
+  if (!field.options.empty())
+    out["options"] = field.options;
+  if (field.hasMin || field.hasMax) {
+    json numeric = json::object();
+    if (field.hasMin)
+      numeric["min"] = field.minVal;
+    if (field.hasMax)
+      numeric["max"] = field.maxVal;
+    out["numeric"] = std::move(numeric);
+  }
+  return out;
+}
+
+json BuildSchemaEntrySummaryJson(const McpSchemaEntrySnapshot& entry) {
+  json out = json{
+      {"kind", entry.kind},
+      {"name", entry.name},
+      {"label", entry.label},
+      {"fieldCount", entry.fields.size()},
+  };
+  if (!entry.appliesTo.empty())
+    out["appliesTo"] = entry.appliesTo;
+  return out;
+}
+
+json BuildSchemaEntryJson(const McpSchemaEntrySnapshot& entry) {
+  json fields = json::array();
+  for (const McpSchemaFieldSnapshot& field : entry.fields)
+    fields.push_back(BuildSchemaFieldJson(field));
+
+  json out = BuildSchemaEntrySummaryJson(entry);
+  out["fields"] = std::move(fields);
+  return out;
+}
+
+const McpSchemaEntrySnapshot* FindSchemaEntry(const std::vector<McpSchemaEntrySnapshot>& entries,
+                                              const std::string& name) {
+  const std::string normalizedName = ToLowerAscii(name);
+  for (const McpSchemaEntrySnapshot& entry : entries) {
+    if (ToLowerAscii(entry.name) == normalizedName)
+      return &entry;
+  }
+  return nullptr;
+}
+
 bool ObjectMatchesQuery(const McpObjectSnapshot& object, const std::string& query) {
   if (ContainsCaseInsensitive(object.id, query) || ContainsCaseInsensitive(object.type, query) ||
       ContainsCaseInsensitive(object.assetId, query) || ContainsCaseInsensitive(GetParentId(object), query)) {
@@ -363,6 +430,43 @@ json BuildBuildStatusJson(const McpEditorSnapshot& snapshot, size_t issueLimit) 
       {"issues", std::move(issues)},
       {"moreIssues", snapshot.build.issues.size() > count ? snapshot.build.issues.size() - count : 0},
   };
+}
+
+json BuildSchemaCatalogJson(const McpEditorSnapshot& snapshot, const std::string& kindFilter) {
+  const std::string normalizedKind = NormalizeSchemaKind(kindFilter);
+  json entries = json::array();
+
+  if (normalizedKind == "all" || normalizedKind == "object") {
+    for (const McpSchemaEntrySnapshot& entry : snapshot.schema.objectTypes)
+      entries.push_back(BuildSchemaEntrySummaryJson(entry));
+  }
+  if (normalizedKind == "all" || normalizedKind == "component") {
+    for (const McpSchemaEntrySnapshot& entry : snapshot.schema.components)
+      entries.push_back(BuildSchemaEntrySummaryJson(entry));
+  }
+
+  return json{
+      {"kind", normalizedKind},
+      {"objectTypeCount", snapshot.schema.objectTypes.size()},
+      {"componentCount", snapshot.schema.components.size()},
+      {"entryCount", entries.size()},
+      {"entries", std::move(entries)},
+  };
+}
+
+json BuildSchemaJson(const McpEditorSnapshot& snapshot,
+                     const std::string& name,
+                     const std::string& kindFilter) {
+  const std::string normalizedKind = NormalizeSchemaKind(kindFilter);
+  if (normalizedKind == "all" || normalizedKind == "object") {
+    if (const McpSchemaEntrySnapshot* entry = FindSchemaEntry(snapshot.schema.objectTypes, name))
+      return BuildSchemaEntryJson(*entry);
+  }
+  if (normalizedKind == "all" || normalizedKind == "component") {
+    if (const McpSchemaEntrySnapshot* entry = FindSchemaEntry(snapshot.schema.components, name))
+      return BuildSchemaEntryJson(*entry);
+  }
+  return json::object();
 }
 
 json BuildObjectListJson(const McpEditorSnapshot& snapshot,

--- a/mcp/McpSnapshot.cpp
+++ b/mcp/McpSnapshot.cpp
@@ -37,6 +37,10 @@ size_t ClampLimit(size_t requested, size_t fallback, size_t maximum) {
   return std::max<size_t>(1, std::min(requested, maximum));
 }
 
+size_t ClampOffset(size_t requested, size_t total) {
+  return std::min(requested, total);
+}
+
 json Vec3ToJson(const Vec3& value) {
   return json::array({value.x, value.y, value.z});
 }
@@ -252,41 +256,60 @@ json BuildAssetsSelectionJson(const McpEditorSnapshot& snapshot) {
 
 json BuildAssetsCatalogJson(const McpEditorSnapshot& snapshot,
                             size_t assetLimit,
-                            const std::string& query) {
+                            const std::string& query,
+                            size_t offset) {
   const size_t safeLimit = ClampLimit(assetLimit, 12, kMaxSummaryAssets);
-  json assets = json::array();
+  std::vector<json> matchedAssets;
+  matchedAssets.reserve(snapshot.assets.size());
   size_t totalMatches = 0;
   for (const McpAssetSnapshot& asset : snapshot.assets) {
     if (!AssetMatchesQuery(asset, query))
       continue;
     ++totalMatches;
-    if (assets.size() >= safeLimit)
-      continue;
-    assets.push_back(BuildAssetSummaryJson(asset, CountAssetReferences(snapshot, asset.id)));
+    matchedAssets.push_back(BuildAssetSummaryJson(asset, CountAssetReferences(snapshot, asset.id)));
   }
-  const size_t shownAssets = assets.size();
+
+  const size_t safeOffset = ClampOffset(offset, matchedAssets.size());
+  json assets = json::array();
+  const size_t end = std::min(safeOffset + safeLimit, matchedAssets.size());
+  for (size_t i = safeOffset; i < end; ++i)
+    assets.push_back(std::move(matchedAssets[i]));
+  const size_t returned = assets.size();
+  const bool hasMore = end < matchedAssets.size();
+
   return json{
       {"query", query},
+      {"offset", safeOffset},
+      {"limit", safeLimit},
+      {"returned", returned},
+      {"hasMore", hasMore},
       {"assetCount", snapshot.assets.size()},
       {"matchedAssets", totalMatches},
       {"assets", std::move(assets)},
-      {"moreAssets", totalMatches > shownAssets ? totalMatches - shownAssets : 0},
+      {"moreAssets", totalMatches > safeOffset + returned ? totalMatches - safeOffset - returned : 0},
   };
 }
 
-json BuildConsoleJson(const McpEditorSnapshot& snapshot, size_t lineLimit) {
-  json out = json::object();
-  out["lineCount"] = snapshot.consoleEntries.size();
+json BuildConsoleJson(const McpEditorSnapshot& snapshot, size_t lineLimit, size_t offset) {
+  const size_t safeLimit = ClampLimit(lineLimit, 20, kMaxSummaryConsoleLines);
+  const size_t safeOffset = ClampOffset(offset, snapshot.consoleEntries.size());
+  const size_t remaining = snapshot.consoleEntries.size() - safeOffset;
+  const size_t count = std::min(safeLimit, remaining);
 
   json lines = json::array();
-  const size_t count =
-      std::min(ClampLimit(lineLimit, 20, kMaxSummaryConsoleLines), snapshot.consoleEntries.size());
-  for (size_t i = 0; i < count; ++i) {
-    const McpConsoleEntry& entry = snapshot.consoleEntries[snapshot.consoleEntries.size() - count + i];
-    lines.push_back(BuildConsoleEntryJson(entry));
-  }
+  const size_t startIndex = snapshot.consoleEntries.size() - safeOffset - count;
+  for (size_t i = startIndex; i < startIndex + count; ++i)
+    lines.push_back(BuildConsoleEntryJson(snapshot.consoleEntries[i]));
+  const bool hasMore = safeOffset + count < snapshot.consoleEntries.size();
+
+  json out = json::object();
+  out["offset"] = safeOffset;
+  out["limit"] = safeLimit;
+  out["returned"] = count;
+  out["hasMore"] = hasMore;
+  out["lineCount"] = snapshot.consoleEntries.size();
   out["lines"] = std::move(lines);
-  out["truncated"] = snapshot.consoleEntries.size() > count;
+  out["truncated"] = hasMore;
   return out;
 }
 
@@ -346,10 +369,12 @@ json BuildObjectListJson(const McpEditorSnapshot& snapshot,
                          size_t objectLimit,
                          const std::string& typeFilter,
                          const std::string& query,
-                         bool selectedOnly) {
+                         bool selectedOnly,
+                         size_t offset) {
   const size_t safeLimit = ClampLimit(objectLimit, 12, kMaxSummaryObjects);
   const std::string normalizedType = ToLowerAscii(typeFilter);
-  json objects = json::array();
+  std::vector<json> matchedObjects;
+  matchedObjects.reserve(snapshot.objects.size());
   size_t totalMatches = 0;
 
   for (const McpObjectSnapshot& object : snapshot.objects) {
@@ -364,23 +389,30 @@ json BuildObjectListJson(const McpEditorSnapshot& snapshot,
       continue;
 
     ++totalMatches;
-    if (objects.size() >= safeLimit)
-      continue;
-    objects.push_back(BuildObjectSummaryJson(object));
+    matchedObjects.push_back(BuildObjectSummaryJson(object));
   }
-  const size_t shownObjects = objects.size();
+  const size_t safeOffset = ClampOffset(offset, matchedObjects.size());
+  json objects = json::array();
+  const size_t end = std::min(safeOffset + safeLimit, matchedObjects.size());
+  for (size_t i = safeOffset; i < end; ++i)
+    objects.push_back(std::move(matchedObjects[i]));
+  const size_t returned = objects.size();
 
   return json{
       {"query", query},
       {"type", typeFilter},
       {"selectedOnly", selectedOnly},
+      {"offset", safeOffset},
+      {"limit", safeLimit},
+      {"returned", returned},
+      {"hasMore", end < matchedObjects.size()},
       {"matchedObjects", totalMatches},
       {"objects", std::move(objects)},
-      {"moreObjects", totalMatches > shownObjects ? totalMatches - shownObjects : 0},
+      {"moreObjects", totalMatches > safeOffset + returned ? totalMatches - safeOffset - returned : 0},
   };
 }
 
-json BuildHierarchyJson(const McpEditorSnapshot& snapshot, size_t objectLimit) {
+json BuildHierarchyJson(const McpEditorSnapshot& snapshot, size_t objectLimit, size_t offset) {
   const size_t safeLimit = ClampLimit(objectLimit, 32, kMaxSummaryObjects);
   std::unordered_map<std::string, std::vector<const McpObjectSnapshot*>> children;
   std::vector<const McpObjectSnapshot*> roots;
@@ -394,33 +426,40 @@ json BuildHierarchyJson(const McpEditorSnapshot& snapshot, size_t objectLimit) {
       children[parentId].push_back(&object);
   }
 
-  json entries = json::array();
+  std::vector<json> flattenedEntries;
+  flattenedEntries.reserve(snapshot.objects.size());
   std::function<void(const McpObjectSnapshot*, int)> visit = [&](const McpObjectSnapshot* object, int depth) {
-    if (!object || entries.size() >= safeLimit)
+    if (!object)
       return;
     json item = BuildObjectSummaryJson(*object);
     item["depth"] = depth;
     item["childCount"] = children[object->id].size();
-    entries.push_back(std::move(item));
-    for (const McpObjectSnapshot* child : children[object->id]) {
-      if (entries.size() >= safeLimit)
-        break;
+    flattenedEntries.push_back(std::move(item));
+    for (const McpObjectSnapshot* child : children[object->id])
       visit(child, depth + 1);
-    }
   };
 
-  for (const McpObjectSnapshot* root : roots) {
-    if (entries.size() >= safeLimit)
-      break;
+  for (const McpObjectSnapshot* root : roots)
     visit(root, 0);
-  }
-  const size_t shownEntries = entries.size();
+
+  const size_t safeOffset = ClampOffset(offset, flattenedEntries.size());
+  json entries = json::array();
+  const size_t end = std::min(safeOffset + safeLimit, flattenedEntries.size());
+  for (size_t i = safeOffset; i < end; ++i)
+    entries.push_back(std::move(flattenedEntries[i]));
+  const size_t returned = entries.size();
 
   return json{
       {"objectCount", snapshot.objects.size()},
       {"roots", roots.size()},
+      {"offset", safeOffset},
+      {"limit", safeLimit},
+      {"returned", returned},
+      {"hasMore", end < flattenedEntries.size()},
       {"entries", std::move(entries)},
-      {"moreObjects", snapshot.objects.size() > shownEntries ? snapshot.objects.size() - shownEntries : 0},
+      {"moreObjects", snapshot.objects.size() > safeOffset + returned
+                          ? snapshot.objects.size() - safeOffset - returned
+                          : 0},
   };
 }
 

--- a/mcp/McpSnapshot.h
+++ b/mcp/McpSnapshot.h
@@ -94,16 +94,22 @@ nlohmann::json BuildAssetsJson(const McpEditorSnapshot& snapshot, size_t assetLi
 nlohmann::json BuildAssetsSelectionJson(const McpEditorSnapshot& snapshot);
 nlohmann::json BuildAssetsCatalogJson(const McpEditorSnapshot& snapshot,
                                       size_t assetLimit = 12,
-                                      const std::string& query = {});
-nlohmann::json BuildConsoleJson(const McpEditorSnapshot& snapshot, size_t lineLimit = 20);
+                                      const std::string& query = {},
+                                      size_t offset = 0);
+nlohmann::json BuildConsoleJson(const McpEditorSnapshot& snapshot,
+                                size_t lineLimit = 20,
+                                size_t offset = 0);
 nlohmann::json BuildConsoleSummaryJson(const McpEditorSnapshot& snapshot, size_t lineLimit = 5);
 nlohmann::json BuildBuildStatusJson(const McpEditorSnapshot& snapshot, size_t issueLimit = 5);
 nlohmann::json BuildObjectListJson(const McpEditorSnapshot& snapshot,
                                    size_t objectLimit = 12,
                                    const std::string& typeFilter = {},
                                    const std::string& query = {},
-                                   bool selectedOnly = false);
-nlohmann::json BuildHierarchyJson(const McpEditorSnapshot& snapshot, size_t objectLimit = 32);
+                                   bool selectedOnly = false,
+                                   size_t offset = 0);
+nlohmann::json BuildHierarchyJson(const McpEditorSnapshot& snapshot,
+                                  size_t objectLimit = 32,
+                                  size_t offset = 0);
 nlohmann::json BuildObjectJson(const McpObjectSnapshot& object);
 nlohmann::json BuildObjectEdgesJson(const McpObjectSnapshot& object);
 nlohmann::json BuildAssetJson(const McpAssetSnapshot& asset);

--- a/mcp/McpSnapshot.h
+++ b/mcp/McpSnapshot.h
@@ -68,6 +68,35 @@ struct McpBuildSnapshot {
   std::vector<McpBuildIssueSnapshot> issues;
 };
 
+struct McpSchemaFieldSnapshot {
+  std::string key;
+  std::string label;
+  std::string description;
+  std::string widget = "string";
+  bool required = false;
+  bool allowEmpty = true;
+  bool allowCustomValue = false;
+  bool hasMin = false;
+  bool hasMax = false;
+  float minVal = 0.0f;
+  float maxVal = 1.0f;
+  std::vector<std::string> options;
+  std::string defaultValue;
+};
+
+struct McpSchemaEntrySnapshot {
+  std::string kind;
+  std::string name;
+  std::string label;
+  std::vector<std::string> appliesTo;
+  std::vector<McpSchemaFieldSnapshot> fields;
+};
+
+struct McpSchemaCatalogSnapshot {
+  std::vector<McpSchemaEntrySnapshot> objectTypes;
+  std::vector<McpSchemaEntrySnapshot> components;
+};
+
 struct McpEditorSnapshot {
   bool editorActive = false;
   bool playMode = false;
@@ -82,6 +111,7 @@ struct McpEditorSnapshot {
   std::vector<McpAssetSnapshot> assets;
   std::vector<McpConsoleEntry> consoleEntries;
   McpBuildSnapshot build;
+  McpSchemaCatalogSnapshot schema;
 };
 
 std::shared_ptr<const McpEditorSnapshot> CloneSnapshot(const McpEditorSnapshot& snapshot);
@@ -101,6 +131,11 @@ nlohmann::json BuildConsoleJson(const McpEditorSnapshot& snapshot,
                                 size_t offset = 0);
 nlohmann::json BuildConsoleSummaryJson(const McpEditorSnapshot& snapshot, size_t lineLimit = 5);
 nlohmann::json BuildBuildStatusJson(const McpEditorSnapshot& snapshot, size_t issueLimit = 5);
+nlohmann::json BuildSchemaCatalogJson(const McpEditorSnapshot& snapshot,
+                                      const std::string& kindFilter = {});
+nlohmann::json BuildSchemaJson(const McpEditorSnapshot& snapshot,
+                               const std::string& name,
+                               const std::string& kindFilter = {});
 nlohmann::json BuildObjectListJson(const McpEditorSnapshot& snapshot,
                                    size_t objectLimit = 12,
                                    const std::string& typeFilter = {},

--- a/mcp/McpSnapshot.h
+++ b/mcp/McpSnapshot.h
@@ -73,6 +73,7 @@ struct McpSchemaFieldSnapshot {
   std::string label;
   std::string description;
   std::string widget = "string";
+  bool hasDefault = false;
   bool required = false;
   bool allowEmpty = true;
   bool allowCustomValue = false;

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,6 +44,9 @@ Resources:
 - `console.summary`
 - `build.status`
 
+List-style resources accept `limit` and `offset`, and query-driven reads such as `scene.objects` and
+`assets.catalog` match case-insensitively.
+
 Tools:
 
 - `editor.search`
@@ -241,6 +244,7 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 ## Token-minimal usage tips
 
 - Ask for `scene.summary` first instead of broad object dumps.
+- Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.
 - Use `editor.search` with a small `limit`.
 - Call `editor.get_object` only for the object you actually need.
 - Prefer `console.recent` over long log history.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -75,12 +75,16 @@ Tools:
 - `editor.delete_asset`
 - `editor.scene_status`
 - `editor.get_scene_file`
+- `editor.list_schema_types`
+- `editor.get_schema`
 - `editor.new_scene`
 - `editor.save_scene`
 - `editor.reload_scene`
 - `editor.search_console`
 
 The design is intentionally summary-first to keep token usage low.
+Schema tools expose the same `assets/editor_schema.json` metadata that powers editor defaults, enum
+choices, and numeric bounds for object and component fields.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.
@@ -247,6 +251,7 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.
 - Use `editor.search` with a small `limit`.
 - Call `editor.get_object` only for the object you actually need.
+- Use `editor.list_schema_types` and `editor.get_schema` before editing typed props or components.
 - Prefer `console.recent` over long log history.
 - Use targeted mutation tools directly instead of first requesting the whole scene.
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,6 +88,8 @@ choices, and numeric bounds for object and component fields.
 Every write tool accepts `mode: "preview" | "apply"`. Preview calls never mutate the editor and return
 a `previewToken`; destructive apply calls for delete/new-scene/reload flows must present the matching
 token from the latest preview.
+Apply calls append JSONL audit entries to `<project-root>/.horo/mcp-audit.jsonl`, or to
+`ResolveMcpSettingsDirectory()/mcp-audit.jsonl` when no project root is available.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.
@@ -249,6 +251,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage tips
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Ask for `scene.summary` first instead of broad object dumps.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -85,6 +85,9 @@ Tools:
 The design is intentionally summary-first to keep token usage low.
 Schema tools expose the same `assets/editor_schema.json` metadata that powers editor defaults, enum
 choices, and numeric bounds for object and component fields.
+Every write tool accepts `mode: "preview" | "apply"`. Preview calls never mutate the editor and return
+a `previewToken`; destructive apply calls for delete/new-scene/reload flows must present the matching
+token from the latest preview.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -451,6 +451,94 @@ TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]") {
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
+TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor][schema]") {
+    const std::string json = R"({
+        "types": {
+            "Prop": {
+                "label": "Prop",
+                "appliesTo": ["Prop"],
+                "fields": [
+                    {"key": "mesh", "label": "Mesh", "type": "enum", "options": ["box"], "default": "box"}
+                ]
+            }
+        },
+        "components": {
+            "light": {
+                "label": "Light",
+                "appliesTo": ["Prop", "Panel"],
+                "fields": [
+                    {
+                        "key": "intensity",
+                        "label": "Intensity",
+                        "description": "Brightness.",
+                        "type": "float",
+                        "min": 0.1,
+                        "max": 20.0,
+                        "default": "1.0"
+                    },
+                    {
+                        "key": "lightType",
+                        "label": "Type",
+                        "type": "enum",
+                        "options": ["point", "directional"],
+                        "default": "point"
+                    }
+                ]
+            }
+        }
+    })";
+    WriteFile(TmpPath("schema_components.json"), json);
+
+    EditorSchema schema;
+    schema.LoadFromFile(TmpPath("schema_components.json"));
+
+    const TypeSchema* propSchema = schema.GetSchemaByName("Prop");
+    REQUIRE(propSchema != nullptr);
+    REQUIRE(propSchema->name == "Prop");
+    REQUIRE(propSchema->label == "Prop");
+    REQUIRE(propSchema->appliesTo.size() == 1);
+    REQUIRE(propSchema->appliesTo[0] == "Prop");
+
+    const ComponentSchema* lightSchema = schema.GetComponentSchema("light");
+    REQUIRE(lightSchema != nullptr);
+    REQUIRE(lightSchema->name == "light");
+    REQUIRE(lightSchema->label == "Light");
+    REQUIRE(lightSchema->appliesTo.size() == 2);
+    REQUIRE(lightSchema->appliesTo[0] == "Prop");
+    REQUIRE(lightSchema->fields.size() == 2);
+    REQUIRE(lightSchema->fields[0].description == "Brightness.");
+    REQUIRE(lightSchema->fields[0].hasMin);
+    REQUIRE(lightSchema->fields[0].minVal == Approx(0.1f));
+    REQUIRE(lightSchema->fields[0].hasMax);
+    REQUIRE(lightSchema->fields[0].maxVal == Approx(20.0f));
+    REQUIRE(lightSchema->fields[1].widget == FieldDef::Widget::Enum);
+    REQUIRE(lightSchema->fields[1].options.size() == 2);
+}
+
+TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]") {
+    const std::filesystem::path schemaPath = Monolith::ProjectPath::Root() / "assets" / "editor_schema.json";
+    REQUIRE(std::filesystem::exists(schemaPath));
+
+    EditorSchema schema;
+    schema.LoadFromFile(schemaPath.string());
+
+    const ComponentSchema* rigidbody = schema.GetComponentSchema("rigidbody");
+    REQUIRE(rigidbody != nullptr);
+    REQUIRE(rigidbody->label == "RigidBody");
+    REQUIRE(rigidbody->appliesTo.size() == 1);
+    REQUIRE(rigidbody->appliesTo[0] == "Prop");
+    REQUIRE(rigidbody->fields.size() == 3);
+    REQUIRE(rigidbody->fields[0].key == "mass");
+    REQUIRE(rigidbody->fields[0].hasMin);
+    REQUIRE(rigidbody->fields[0].minVal == Approx(0.0f));
+
+    const ComponentSchema* script = schema.GetComponentSchema("script");
+    REQUIRE(script != nullptr);
+    REQUIRE(script->fields.size() == 1);
+    REQUIRE(script->fields[0].key == "behaviorTag");
+    REQUIRE(script->fields[0].allowEmpty);
+}
+
 // ===========================================================================
 // SceneSerializer
 // ===========================================================================

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -62,6 +62,10 @@ static std::string TmpPath(const std::string& name) {
     return (std::filesystem::temp_directory_path() / name).string();
 }
 
+static std::filesystem::path RepoRootFromTestSource() {
+    return std::filesystem::path(__FILE__).parent_path().parent_path().lexically_normal();
+}
+
 static void WriteFile(const std::string& path, const std::string& content) {
     std::ofstream f(path);
     f << content;
@@ -516,7 +520,7 @@ TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor]
 }
 
 TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]") {
-    const std::filesystem::path schemaPath = Monolith::ProjectPath::Root() / "assets" / "editor_schema.json";
+    const std::filesystem::path schemaPath = RepoRootFromTestSource() / "assets" / "editor_schema.json";
     REQUIRE(std::filesystem::exists(schemaPath));
 
     EditorSchema schema;

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -198,6 +198,7 @@ McpSchemaFieldSnapshot MakeSchemaField(std::string key,
   field.label = std::move(label);
   field.description = std::move(description);
   field.widget = std::move(widget);
+  field.hasDefault = true;
   field.defaultValue = std::move(defaultValue);
   field.options = std::move(options);
   field.hasMin = hasMin;
@@ -686,10 +687,20 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   REQUIRE(createObjectTool != nullptr);
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["items"]["type"] == "number");
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["minItems"] == 3);
+  REQUIRE((*createObjectTool)["inputSchema"]["properties"]["mode"]["enum"][0] == "preview");
   REQUIRE(listSchemaTool != nullptr);
   REQUIRE((*listSchemaTool)["inputSchema"]["properties"]["kind"]["enum"].size() == 3);
   REQUIRE(getSchemaTool != nullptr);
   REQUIRE((*getSchemaTool)["inputSchema"]["required"][0] == "name");
+  const json* deleteTool = nullptr;
+  for (const json& tool : toolList["result"]["tools"]) {
+    if (tool.value("name", std::string()) == "editor_delete") {
+      deleteTool = &tool;
+      break;
+    }
+  }
+  REQUIRE(deleteTool != nullptr);
+  REQUIRE((*deleteTool)["inputSchema"]["properties"]["previewToken"]["type"] == "string");
 
   const json resourceList = ProtocolRequest(protocol, "resources/list", json::object(), 4);
   REQUIRE(resourceList["result"]["resources"].size() == 11);
@@ -935,7 +946,7 @@ TEST_CASE("Editor MCP delete_asset reports managed file deletion details", "[mcp
   REQUIRE_FALSE(fs::exists(projectRoot / "assets" / "models" / "stone"));
 }
 
-TEST_CASE("McpProtocol dispatches every write tool and serializes success and failure", "[mcp][protocol]") {
+TEST_CASE("McpProtocol dispatches write tools and gates destructive apply behind previews", "[mcp][protocol]") {
   McpEditorSnapshot snapshot = MakeSnapshot();
   std::vector<std::string> invoked;
   McpProtocol protocol(McpProtocolContext{
@@ -949,7 +960,7 @@ TEST_CASE("McpProtocol dispatches every write tool and serializes success and fa
       {},
   });
 
-  const std::vector<std::pair<std::string, json>> writeTools = {
+  const std::vector<std::pair<std::string, json>> applyOnlyTools = {
       {"editor.select", json{{"id", "obj_root"}}},
       {"editor.clear_selection", json::object()},
       {"editor.create_object", json{{"type", "Prop"}, {"id", "spawned"}}},
@@ -959,28 +970,96 @@ TEST_CASE("McpProtocol dispatches every write tool and serializes success and fa
       {"editor.rename_object", json{{"id", "obj_root"}, {"newId", "obj_root_renamed"}}},
       {"editor.reparent_object", json{{"id", "obj_child"}, {"parentId", "obj_camera"}}},
       {"editor.duplicate", json{{"id", "obj_root"}, {"count", 2}}},
-      {"editor.delete", json{{"ids", json::array({"obj_light"})}}},
       {"editor.select_asset", json{{"id", "crate"}}},
       {"editor.update_asset", json{{"id", "crate"}, {"mesh", "assets/models/crate_v2.obj"}}},
+      {"editor.save_scene", json::object()},
+  };
+
+  for (size_t i = 0; i < applyOnlyTools.size(); ++i) {
+    const json response =
+        CallTool(protocol, applyOnlyTools[i].first, applyOnlyTools[i].second, 300 + static_cast<int>(i));
+    REQUIRE(response["result"]["structuredContent"]["handledTool"] == applyOnlyTools[i].first);
+    REQUIRE(response["result"]["structuredContent"]["echo"]["mode"] == "apply");
+  }
+
+  const std::vector<std::pair<std::string, json>> destructiveTools = {
+      {"editor.delete", json{{"ids", json::array({"obj_light"})}}},
       {"editor.delete_asset", json{{"id", "hero"}}},
       {"editor.new_scene", json{{"sceneId", "fresh"}, {"sceneName", "Fresh"}}},
-      {"editor.save_scene", json::object()},
       {"editor.reload_scene", json::object()},
   };
 
-  for (size_t i = 0; i < writeTools.size(); ++i) {
-    const json response = CallTool(protocol, writeTools[i].first, writeTools[i].second, 300 + static_cast<int>(i));
-    if (writeTools[i].first == "editor.delete_asset") {
+  for (size_t i = 0; i < destructiveTools.size(); ++i) {
+    json previewArguments = destructiveTools[i].second;
+    previewArguments["mode"] = "preview";
+    const json preview =
+        CallTool(protocol, destructiveTools[i].first, previewArguments, 400 + static_cast<int>(i));
+    REQUIRE(preview["result"]["structuredContent"]["mode"] == "preview");
+    REQUIRE(preview["result"]["structuredContent"]["previewToken"].is_string());
+
+    json applyArguments = destructiveTools[i].second;
+    applyArguments["mode"] = "apply";
+    applyArguments["previewToken"] = preview["result"]["structuredContent"]["previewToken"];
+    const json response =
+        CallTool(protocol, destructiveTools[i].first, applyArguments, 500 + static_cast<int>(i));
+    if (destructiveTools[i].first == "editor.delete_asset") {
       REQUIRE(response["error"]["message"] == "delete rejected");
       continue;
     }
-    REQUIRE(response["result"]["structuredContent"]["handledTool"] == writeTools[i].first);
-    REQUIRE(response["result"]["structuredContent"]["echo"] == writeTools[i].second);
+    REQUIRE(response["result"]["structuredContent"]["handledTool"] == destructiveTools[i].first);
+    REQUIRE(response["result"]["structuredContent"]["echo"]["mode"] == "apply");
+    REQUIRE(response["result"]["structuredContent"]["echo"]["previewToken"].is_string());
   }
 
-  REQUIRE(invoked.size() == writeTools.size());
+  REQUIRE(invoked.size() == applyOnlyTools.size() + destructiveTools.size());
   REQUIRE(invoked.front() == "editor.select");
   REQUIRE(invoked.back() == "editor.reload_scene");
+}
+
+TEST_CASE("McpProtocol validates schema-backed mutations and preview tokens before queueing",
+          "[mcp][protocol]") {
+  McpEditorSnapshot snapshot = MakeSnapshot();
+  std::vector<std::string> invoked;
+  McpProtocol protocol(McpProtocolContext{
+      [&snapshot]() { return CloneSnapshot(snapshot); },
+      [&invoked](const std::string& toolName, const json&) {
+        invoked.push_back(toolName);
+        return McpCommandResult{true, json{{"handledTool", toolName}}, {}};
+      },
+      {},
+  });
+
+  const json invalidEnum = CallTool(
+      protocol, "editor.create_object",
+      json{{"type", "Light"}, {"props", json{{"lightType", "spot"}}}}, 600);
+  REQUIRE(invalidEnum["error"]["message"] == "props.lightType must be one of: point, directional.");
+
+  const json invalidComponentRange =
+      CallTool(protocol, "editor.update_object",
+               json{{"id", "obj_root"},
+                    {"components", json::array({json{{"type", "light"},
+                                                     {"props", json{{"radius", 0.1}}}}})}},
+               601);
+  REQUIRE(invalidComponentRange["error"]["message"] ==
+          "components[0].props.radius must be >= 0.5000.");
+
+  const json deleteWithoutPreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}}, 602);
+  REQUIRE(deleteWithoutPreview["error"]["message"] == "previewToken is required for apply mode.");
+
+  const json deletePreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}, {"mode", "preview"}}, 603);
+  REQUIRE(deletePreview["result"]["structuredContent"]["preview"]["deletedCount"] == 1);
+  const std::string previewToken =
+      deletePreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+
+  const json deleteMismatchedApply = CallTool(
+      protocol, "editor.delete",
+      json{{"ids", json::array({"obj_root"})}, {"mode", "apply"}, {"previewToken", previewToken}}, 604);
+  REQUIRE(deleteMismatchedApply["error"]["message"] ==
+          "previewToken does not match the current scene state or arguments.");
+
+  REQUIRE(invoked.empty());
 }
 
 TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable paths", "[mcp][protocol]") {

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -183,6 +183,100 @@ bool NearlyEqualJsonFloat(const json& value, float expected, float eps = 0.001f)
   return std::fabs(value.get<float>() - expected) <= eps;
 }
 
+McpSchemaFieldSnapshot MakeSchemaField(std::string key,
+                                       std::string label,
+                                       std::string widget,
+                                       std::string defaultValue,
+                                       std::vector<std::string> options = {},
+                                       bool hasMin = false,
+                                       float minVal = 0.0f,
+                                       bool hasMax = false,
+                                       float maxVal = 0.0f,
+                                       std::string description = {}) {
+  McpSchemaFieldSnapshot field;
+  field.key = std::move(key);
+  field.label = std::move(label);
+  field.description = std::move(description);
+  field.widget = std::move(widget);
+  field.defaultValue = std::move(defaultValue);
+  field.options = std::move(options);
+  field.hasMin = hasMin;
+  field.minVal = minVal;
+  field.hasMax = hasMax;
+  field.maxVal = maxVal;
+  return field;
+}
+
+void PopulateSchemaSnapshot(McpEditorSnapshot* snapshot) {
+  REQUIRE(snapshot != nullptr);
+
+  McpSchemaEntrySnapshot panel;
+  panel.kind = "object";
+  panel.name = "Panel";
+  panel.label = "Panel";
+  panel.fields.push_back(MakeSchemaField("material", "Material", "enum", "stone",
+                                         {"stone", "metal", "wood"}));
+  snapshot->schema.objectTypes.push_back(std::move(panel));
+
+  McpSchemaEntrySnapshot prop;
+  prop.kind = "object";
+  prop.name = "Prop";
+  prop.label = "Prop";
+  prop.fields.push_back(
+      MakeSchemaField("mesh", "Mesh", "enum", "box", {"box", "sphere", "cylinder", "pyramid"}));
+  snapshot->schema.objectTypes.push_back(std::move(prop));
+
+  McpSchemaEntrySnapshot lightObject;
+  lightObject.kind = "object";
+  lightObject.name = "Light";
+  lightObject.label = "Light";
+  lightObject.fields.push_back(MakeSchemaField("lightType", "Type", "enum", "point",
+                                               {"point", "directional"}));
+  lightObject.fields.push_back(
+      MakeSchemaField("radius", "Radius", "float", "10.0", {}, true, 0.5f, true, 50.0f));
+  lightObject.fields.push_back(
+      MakeSchemaField("intensity", "Intensity", "float", "1.0", {}, true, 0.1f, true, 20.0f));
+  lightObject.fields.push_back(
+      MakeSchemaField("color", "Color RGB", "color3", "1.0000,1.0000,1.0000"));
+  snapshot->schema.objectTypes.push_back(std::move(lightObject));
+
+  McpSchemaEntrySnapshot lightComponent;
+  lightComponent.kind = "component";
+  lightComponent.name = "light";
+  lightComponent.label = "Light";
+  lightComponent.appliesTo = {"Panel", "Prop"};
+  lightComponent.fields.push_back(MakeSchemaField("lightType", "Type", "enum", "point",
+                                                  {"point", "directional"}));
+  lightComponent.fields.push_back(
+      MakeSchemaField("radius", "Radius", "float", "5.0", {}, true, 0.5f, true, 50.0f));
+  lightComponent.fields.push_back(
+      MakeSchemaField("intensity", "Intensity", "float", "1.0", {}, true, 0.1f, true, 20.0f));
+  lightComponent.fields.push_back(
+      MakeSchemaField("color", "Color RGB", "color3", "1.0000,1.0000,1.0000"));
+  snapshot->schema.components.push_back(std::move(lightComponent));
+
+  McpSchemaEntrySnapshot rigidbody;
+  rigidbody.kind = "component";
+  rigidbody.name = "rigidbody";
+  rigidbody.label = "RigidBody";
+  rigidbody.appliesTo = {"Prop"};
+  rigidbody.fields.push_back(
+      MakeSchemaField("mass", "Mass", "float", "1.0", {}, true, 0.0f, true, 500.0f));
+  rigidbody.fields.push_back(MakeSchemaField("isKinematic", "Kinematic", "bool", "false"));
+  rigidbody.fields.push_back(MakeSchemaField("useGravity", "Use Gravity", "bool", "true"));
+  snapshot->schema.components.push_back(std::move(rigidbody));
+
+  McpSchemaEntrySnapshot script;
+  script.kind = "component";
+  script.name = "script";
+  script.label = "Script";
+  script.appliesTo = {"Panel", "Prop", "Light", "Camera"};
+  script.fields.push_back(MakeSchemaField("behaviorTag", "Behavior", "string", "",
+                                          {}, false, 0.0f, false, 0.0f,
+                                          "Runtime behavior id resolved by the game."));
+  snapshot->schema.components.push_back(std::move(script));
+}
+
 McpEditorSnapshot MakeSnapshot() {
   McpEditorSnapshot snapshot;
   snapshot.editorActive = true;
@@ -253,6 +347,7 @@ McpEditorSnapshot MakeSnapshot() {
                                    "parentId does not resolve to a declared scene node."});
   snapshot.build.issues.push_back({"runtime", "warning", "scene.nodes[3].light",
                                    "Light node is missing typed light properties; using defaults."});
+  PopulateSchemaSnapshot(&snapshot);
   return snapshot;
 }
 
@@ -468,6 +563,28 @@ TEST_CASE("McpSnapshot builders cover compact MCP resources", "[mcp][snapshot]")
   REQUIRE(buildStatus["issues"].size() == 1);
   REQUIRE(buildStatus["moreIssues"] == 1);
 
+  const json schemaCatalog = BuildSchemaCatalogJson(snapshot);
+  REQUIRE(schemaCatalog["objectTypeCount"] == 3);
+  REQUIRE(schemaCatalog["componentCount"] == 3);
+  REQUIRE(schemaCatalog["entryCount"] == 6);
+
+  const json componentCatalog = BuildSchemaCatalogJson(snapshot, "component");
+  REQUIRE(componentCatalog["kind"] == "component");
+  REQUIRE(componentCatalog["entryCount"] == 3);
+  REQUIRE(componentCatalog["entries"][0]["kind"] == "component");
+
+  const json componentSchema = BuildSchemaJson(snapshot, "light", "component");
+  REQUIRE(componentSchema["name"] == "light");
+  REQUIRE(componentSchema["kind"] == "component");
+  REQUIRE(componentSchema["appliesTo"].size() == 2);
+  REQUIRE(componentSchema["fields"].size() == 4);
+  REQUIRE(NearlyEqualJsonFloat(componentSchema["fields"][1]["numeric"]["min"], 0.5f));
+
+  const json objectSchema = BuildSchemaJson(snapshot, "Light", "object");
+  REQUIRE(objectSchema["name"] == "Light");
+  REQUIRE(objectSchema["fields"][0]["options"][1] == "directional");
+  REQUIRE(objectSchema["fields"][2]["widget"] == "float");
+
   const json objectList = BuildObjectListJson(snapshot, 8, "Prop", "root", false);
   REQUIRE(objectList["matchedObjects"] == 2);
   REQUIRE(objectList["objects"].size() == 2);
@@ -552,18 +669,27 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   REQUIRE(ping["result"].empty());
 
   const json toolList = ProtocolRequest(protocol, "tools/list", json::object(), 3);
-  REQUIRE(toolList["result"]["tools"].size() == 31);
+  REQUIRE(toolList["result"]["tools"].size() == 33);
   REQUIRE(toolList["result"]["tools"][0]["name"] == "editor_search");
   const json* createObjectTool = nullptr;
+  const json* listSchemaTool = nullptr;
+  const json* getSchemaTool = nullptr;
   for (const json& tool : toolList["result"]["tools"]) {
     if (tool.value("name", std::string()) == "editor_create_object") {
       createObjectTool = &tool;
-      break;
     }
+    if (tool.value("name", std::string()) == "editor_list_schema_types")
+      listSchemaTool = &tool;
+    if (tool.value("name", std::string()) == "editor_get_schema")
+      getSchemaTool = &tool;
   }
   REQUIRE(createObjectTool != nullptr);
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["items"]["type"] == "number");
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["minItems"] == 3);
+  REQUIRE(listSchemaTool != nullptr);
+  REQUIRE((*listSchemaTool)["inputSchema"]["properties"]["kind"]["enum"].size() == 3);
+  REQUIRE(getSchemaTool != nullptr);
+  REQUIRE((*getSchemaTool)["inputSchema"]["required"][0] == "name");
 
   const json resourceList = ProtocolRequest(protocol, "resources/list", json::object(), 4);
   REQUIRE(resourceList["result"]["resources"].size() == 11);
@@ -665,8 +791,17 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   const json searchConsole = CallTool(protocol, "editor.search_console", json{{"query", "exploded"}, {"limit", 5}}, 115);
   REQUIRE(searchConsole["result"]["structuredContent"]["matchedLines"] == 1);
 
-  REQUIRE(activity.size() >= 20);
-  REQUIRE(activity.back().target == "editor.search_console");
+  const json listSchema = CallTool(protocol, "editor.list_schema_types", json{{"kind", "component"}}, 116);
+  REQUIRE(listSchema["result"]["structuredContent"]["kind"] == "component");
+  REQUIRE(listSchema["result"]["structuredContent"]["entryCount"] == 3);
+
+  const json getSchema = CallTool(protocol, "editor_get_schema", json{{"name", "light"}, {"kind", "component"}}, 117);
+  REQUIRE(getSchema["result"]["structuredContent"]["name"] == "light");
+  REQUIRE(getSchema["result"]["structuredContent"]["fields"].size() == 4);
+  REQUIRE(getSchema["result"]["structuredContent"]["fields"][0]["options"][1] == "directional");
+
+  REQUIRE(activity.size() >= 22);
+  REQUIRE(activity.back().target == "editor.get_schema");
   REQUIRE(activity.back().ok);
 }
 
@@ -878,6 +1013,9 @@ TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable pa
   const json unknownTool = CallTool(protocolWithSnapshot, "editor.missing", json::object(), 402);
   REQUIRE(unknownTool["error"]["message"] == "Unknown tool.");
 
+  const json missingSchema = CallTool(protocolWithSnapshot, "editor.get_schema", json{{"name", "missing"}}, 4021);
+  REQUIRE(missingSchema["error"]["message"] == "Schema not found.");
+
   const json objectNotFound = CallTool(protocolWithSnapshot, "editor.get_object", json{{"id", "missing"}}, 403);
   REQUIRE(objectNotFound["error"]["message"] == "Object not found.");
 
@@ -940,7 +1078,7 @@ TEST_CASE("McpController localhost server serves reads, writes, and status snaps
 
   const McpStatusSnapshot status = controller.GetStatusSnapshot();
   REQUIRE(status.running);
-  REQUIRE(status.toolCount == 31);
+  REQUIRE(status.toolCount == 33);
   REQUIRE(status.resourceCount == 11);
   REQUIRE(status.totalRequests >= 3);
 

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -442,6 +442,17 @@ json ParseBody(const McpHttpResponse& response) {
   return json::parse(response.body);
 }
 
+std::vector<json> ReadJsonLines(const std::filesystem::path& path) {
+  std::vector<json> lines;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty())
+      lines.push_back(json::parse(line));
+  }
+  return lines;
+}
+
 json ProtocolRequest(McpProtocol& protocol, const std::string& method, const json& params = json::object(), int id = 1) {
   const McpHttpResponse response = protocol.HandleHttp(
       McpHttpRequest{"POST", "/mcp", {}, json{{"jsonrpc", "2.0"}, {"id", id}, {"method", method}, {"params", params}}.dump()});
@@ -1060,6 +1071,77 @@ TEST_CASE("McpProtocol validates schema-backed mutations and preview tokens befo
           "previewToken does not match the current scene state or arguments.");
 
   REQUIRE(invoked.empty());
+}
+
+TEST_CASE("McpProtocol writes apply audit records to project root and fallback settings path",
+          "[mcp][protocol][audit]") {
+  namespace fs = std::filesystem;
+
+  EnvGuard env("horo_mcp_audit");
+  const fs::path projectRoot = env.tempHome / "project";
+  fs::create_directories(projectRoot / "assets");
+  {
+    std::ofstream presets(projectRoot / "CMakePresets.json");
+    presets << "{}";
+  }
+
+  McpEditorSnapshot snapshot = MakeSnapshot();
+  std::vector<std::string> invoked;
+  ProjectRootGuard projectRootGuard(projectRoot);
+  McpProtocol protocol(McpProtocolContext{
+      [&snapshot]() { return CloneSnapshot(snapshot); },
+      [&invoked](const std::string& toolName, const json&) {
+        invoked.push_back(toolName);
+        if (toolName == "editor.delete_asset")
+          return McpCommandResult{false, json::object(), "delete rejected"};
+        return McpCommandResult{true, json{{"handledTool", toolName}}, {}};
+      },
+      {},
+  });
+
+  const json deletePreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}, {"mode", "preview"}}, 700);
+  const std::string deleteToken =
+      deletePreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteApply =
+      CallTool(protocol, "editor.delete",
+               json{{"ids", json::array({"obj_light"})}, {"mode", "apply"}, {"previewToken", deleteToken}}, 701);
+  REQUIRE(deleteApply["result"]["structuredContent"]["handledTool"] == "editor.delete");
+
+  const json deleteAssetPreview =
+      CallTool(protocol, "editor.delete_asset", json{{"id", "hero"}, {"mode", "preview"}}, 702);
+  const std::string deleteAssetToken =
+      deleteAssetPreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteAssetApply =
+      CallTool(protocol, "editor.delete_asset",
+               json{{"id", "hero"}, {"mode", "apply"}, {"previewToken", deleteAssetToken}}, 703);
+  REQUIRE(deleteAssetApply["error"]["message"] == "delete rejected");
+
+  const fs::path auditPath = projectRoot / ".horo" / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(auditPath));
+  const std::vector<json> records = ReadJsonLines(auditPath);
+  REQUIRE(records.size() == 2);
+  REQUIRE(records[0]["tool"] == "editor.delete");
+  REQUIRE(records[0]["mode"] == "apply");
+  REQUIRE(records[0]["result"] == "success");
+  REQUIRE(records[0]["previewToken"] == deleteToken);
+  REQUIRE(records[0]["changedIds"][0] == "obj_light");
+  REQUIRE(records[1]["tool"] == "editor.delete_asset");
+  REQUIRE(records[1]["result"] == "error");
+  REQUIRE(records[1]["error"] == "delete rejected");
+  REQUIRE(records[1]["previewToken"] == deleteAssetToken);
+
+  invoked.clear();
+  ProjectRootGuard clearProjectRoot{std::filesystem::path()};
+  const json selectApply = CallTool(protocol, "editor.select", json{{"id", "obj_root"}}, 704);
+  REQUIRE(selectApply["result"]["structuredContent"]["handledTool"] == "editor.select");
+
+  const fs::path fallbackAuditPath = ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(fallbackAuditPath));
+  const std::vector<json> fallbackRecords = ReadJsonLines(fallbackAuditPath);
+  REQUIRE(fallbackRecords.size() == 1);
+  REQUIRE(fallbackRecords[0]["tool"] == "editor.select");
+  REQUIRE(fallbackRecords[0]["result"] == "success");
 }
 
 TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable paths", "[mcp][protocol]") {

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -432,10 +432,27 @@ TEST_CASE("McpSnapshot builders cover compact MCP resources", "[mcp][snapshot]")
   REQUIRE(catalog["matchedAssets"] == 1);
   REQUIRE(catalog["assets"][0]["id"] == "hero");
 
+  const json catalogCaseInsensitive = BuildAssetsCatalogJson(snapshot, 8, "HERO");
+  REQUIRE(catalogCaseInsensitive["matchedAssets"] == 1);
+
+  const json pagedCatalog = BuildAssetsCatalogJson(snapshot, 1, "", 1);
+  REQUIRE(pagedCatalog["offset"] == 1);
+  REQUIRE(pagedCatalog["limit"] == 1);
+  REQUIRE(pagedCatalog["returned"] == 1);
+  REQUIRE(pagedCatalog["hasMore"].get<bool>());
+  REQUIRE(pagedCatalog["assets"][0]["id"] == "hero");
+
   const json recentConsole = BuildConsoleJson(snapshot, 2);
   REQUIRE(recentConsole["lineCount"] == 4);
   REQUIRE(recentConsole["lines"].size() == 2);
   REQUIRE(recentConsole["lines"][1]["message"] == "Hero animation warmed");
+
+  const json pagedConsole = BuildConsoleJson(snapshot, 2, 1);
+  REQUIRE(pagedConsole["offset"] == 1);
+  REQUIRE(pagedConsole["returned"] == 2);
+  REQUIRE(pagedConsole["hasMore"].get<bool>());
+  REQUIRE(pagedConsole["lines"][0]["message"] == "Missing optional collider for obj_light");
+  REQUIRE(pagedConsole["lines"][1]["message"] == "Renderer exploded briefly");
 
   const json consoleSummary = BuildConsoleSummaryJson(snapshot, 2);
   REQUIRE(consoleSummary["infoCount"] == 2);
@@ -455,15 +472,30 @@ TEST_CASE("McpSnapshot builders cover compact MCP resources", "[mcp][snapshot]")
   REQUIRE(objectList["matchedObjects"] == 2);
   REQUIRE(objectList["objects"].size() == 2);
 
+  const json objectListCaseInsensitive = BuildObjectListJson(snapshot, 8, "prop", "ROOT", false);
+  REQUIRE(objectListCaseInsensitive["matchedObjects"] == 2);
+
   const json selectedOnly = BuildObjectListJson(snapshot, 8, "", "", true);
   REQUIRE(selectedOnly["matchedObjects"] == 2);
   REQUIRE(selectedOnly["objects"].size() == 2);
+
+  const json pagedObjects = BuildObjectListJson(snapshot, 1, "Prop", "", false, 1);
+  REQUIRE(pagedObjects["offset"] == 1);
+  REQUIRE(pagedObjects["returned"] == 1);
+  REQUIRE_FALSE(pagedObjects["hasMore"].get<bool>());
+  REQUIRE(pagedObjects["objects"][0]["id"] == "obj_child");
 
   const json hierarchy = BuildHierarchyJson(snapshot, 8);
   REQUIRE(hierarchy["objectCount"] == 4);
   REQUIRE(hierarchy["roots"] == 2);
   REQUIRE(hierarchy["entries"].size() == 4);
   REQUIRE(hierarchy["entries"][0]["depth"] == 0);
+
+  const json pagedHierarchy = BuildHierarchyJson(snapshot, 2, 1);
+  REQUIRE(pagedHierarchy["offset"] == 1);
+  REQUIRE(pagedHierarchy["limit"] == 2);
+  REQUIRE(pagedHierarchy["returned"] == 2);
+  REQUIRE(pagedHierarchy["hasMore"].get<bool>());
 
   const json searchAll = SearchSnapshot(snapshot, "hero", 5, "all");
   REQUIRE(searchAll["assets"].size() == 1);
@@ -547,6 +579,38 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
     REQUIRE(response["result"]["contents"][0]["uri"] == resourceUris[i]);
     REQUIRE_FALSE(response["result"]["contents"][0]["text"].get<std::string>().empty());
   }
+
+  const json resourceObjects =
+      ReadResource(protocol, "scene://objects", json{{"limit", 1}, {"offset", 1}, {"type", "Prop"}}, 30);
+  const json resourceObjectsPayload =
+      json::parse(resourceObjects["result"]["contents"][0]["text"].get<std::string>());
+  REQUIRE(resourceObjectsPayload["offset"] == 1);
+  REQUIRE(resourceObjectsPayload["returned"] == 1);
+  REQUIRE(resourceObjectsPayload["objects"][0]["id"] == "obj_child");
+
+  const json resourceConsole =
+      ReadResource(protocol, "console://recent", json{{"limit", 2}, {"offset", 1}}, 31);
+  const json resourceConsolePayload =
+      json::parse(resourceConsole["result"]["contents"][0]["text"].get<std::string>());
+  REQUIRE(resourceConsolePayload["offset"] == 1);
+  REQUIRE(resourceConsolePayload["returned"] == 2);
+  REQUIRE(resourceConsolePayload["hasMore"].get<bool>());
+
+  const json resourceHierarchy =
+      ReadResource(protocol, "scene://hierarchy", json{{"limit", 2}, {"offset", 1}}, 32);
+  const json resourceHierarchyPayload =
+      json::parse(resourceHierarchy["result"]["contents"][0]["text"].get<std::string>());
+  REQUIRE(resourceHierarchyPayload["offset"] == 1);
+  REQUIRE(resourceHierarchyPayload["returned"] == 2);
+  REQUIRE(resourceHierarchyPayload["hasMore"].get<bool>());
+
+  const json resourceCatalog =
+      ReadResource(protocol, "assets://catalog", json{{"limit", 1}, {"offset", 1}}, 33);
+  const json resourceCatalogPayload =
+      json::parse(resourceCatalog["result"]["contents"][0]["text"].get<std::string>());
+  REQUIRE(resourceCatalogPayload["offset"] == 1);
+  REQUIRE(resourceCatalogPayload["returned"] == 1);
+  REQUIRE(resourceCatalogPayload["hasMore"].get<bool>());
 
   const json getObject = CallTool(protocol, "editor.get_object", json{{"id", "obj_root"}}, 100);
   REQUIRE(getObject["result"]["structuredContent"]["id"] == "obj_root");


### PR DESCRIPTION
## What changed
- add shared limit and offset handling for list-style MCP resources
- return common paging fields (offset, limit, eturned, hasMore) while preserving compatibility fields
- document and test case-insensitive resource search behavior

## Why
Epic #55 needs predictable read contracts so AI clients can narrow large resource sets safely.

## Validation
- cmake --build --preset debug-msvc
- ctest --preset debug-msvc -C Debug --output-on-failure

## Stack
- Base branch: eat/55-56-mcp-resource-foundation
- Next PR: #59 schema surface

Refs #58
Refs #55