### PR TITLE
[55/#57] Add safe MCP mutation previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ horo-engine/
 Horo Engine now ships with a built-in MCP server for the editor. Enable it from `File -> Settings...` in the editor and the server will auto-start on `http://127.0.0.1:39281/mcp` whenever the editor is open.
 
 User settings live in `~/.horo/settings.json` (Windows: `%USERPROFILE%\\.horo\\settings.json`). The MCP tab in the editor shows runtime status, recent requests, and copy-ready Claude/Codex configuration snippets.
+The recommended AI workflow is: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
+Apply-mode mutations also append audit records to `.horo/mcp-audit.jsonl` under the active project root
+when available.
 
 Integration details and token-minimal usage guidance live in [docs/mcp.md](/c:/Users/abdul/projects/fun/game/horo-engine/docs/mcp.md).
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -87,6 +87,9 @@ List-style resources accept `limit` and `offset`, and query-driven reads such as
 
 `editor.list_schema_types` and `editor.get_schema` expose the same object and component metadata that
 drives `assets/editor_schema.json`, including defaults, enum options, and numeric bounds.
+Write tools accept `mode: "preview" | "apply"`. Preview requests never mutate editor state and return
+a `previewToken`; destructive applies for `editor.delete`, `editor.delete_asset`, `editor.new_scene`,
+and `editor.reload_scene` require the matching token.
 
 ## Claude Code
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -90,6 +90,8 @@ drives `assets/editor_schema.json`, including defaults, enum options, and numeri
 Write tools accept `mode: "preview" | "apply"`. Preview requests never mutate editor state and return
 a `previewToken`; destructive applies for `editor.delete`, `editor.delete_asset`, `editor.new_scene`,
 and `editor.reload_scene` require the matching token.
+Apply requests append audit records to `<project-root>/.horo/mcp-audit.jsonl`, or
+`~/.horo/mcp-audit.jsonl` when no project root is resolved.
 
 ## Claude Code
 
@@ -180,6 +182,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage guidance
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Prefer `scene.summary` before calling object-level tools.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -172,6 +172,7 @@ Mcp::McpSchemaFieldSnapshot BuildMcpSchemaFieldSnapshot(const FieldDef& field) {
   snapshot.label = field.label;
   snapshot.description = field.description;
   snapshot.widget = FieldWidgetToString(field.widget);
+  snapshot.hasDefault = field.hasDefault;
   snapshot.required = field.required;
   snapshot.allowEmpty = field.allowEmpty;
   snapshot.allowCustomValue = field.allowCustomValue;
@@ -6838,7 +6839,7 @@ void EditorLayer::ApplySchemaDefaults(SceneObject& obj) const {
   if (!schema)
     return;
   for (const auto& fd : schema->fields)
-    if (obj.props.find(fd.key) == obj.props.end())
+    if (fd.hasDefault && obj.props.find(fd.key) == obj.props.end())
       obj.props[fd.key] = fd.defaultValue;
 }
 
@@ -6847,7 +6848,7 @@ void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
   if (!schema)
     return;
   for (const FieldDef& field : schema->fields) {
-    if (component.props.find(field.key) == component.props.end())
+    if (field.hasDefault && component.props.find(field.key) == component.props.end())
       component.props[field.key] = field.defaultValue;
   }
 }

--- a/editor/EditorSchema.cpp
+++ b/editor/EditorSchema.cpp
@@ -27,6 +27,7 @@ FieldDef ParseFieldDef(const json& fd) {
   field.key = fd.value("key", "");
   field.label = fd.value("label", field.key);
   field.description = fd.value("description", "");
+  field.hasDefault = fd.contains("default");
   field.defaultValue = fd.value("default", "");
   field.required = fd.value("required", false);
   field.allowEmpty = fd.value("allowEmpty", true);

--- a/editor/EditorSchema.h
+++ b/editor/EditorSchema.h
@@ -15,6 +15,7 @@ struct FieldDef {
   std::string label;
   std::string description;
   Widget widget = Widget::String;
+  bool hasDefault = false;
   bool required = false;
   bool allowEmpty = true;
   bool allowCustomValue = false;

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -5,9 +5,15 @@
 #include <chrono>
 #include <cctype>
 #include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <unordered_set>
+
+#include "core/ProjectPath.h"
+#include "mcp/McpSettings.h"
 
 namespace Monolith {
 namespace Mcp {
@@ -191,6 +197,113 @@ std::string FormatFloatText(double value) {
   std::ostringstream out;
   out << std::fixed << std::setprecision(4) << value;
   return out.str();
+}
+
+std::string FormatAuditTimestamp() {
+  using clock = std::chrono::system_clock;
+  const std::time_t now = clock::to_time_t(clock::now());
+  std::tm tmBuf{};
+#ifdef _WIN32
+  gmtime_s(&tmBuf, &now);
+#else
+  gmtime_r(&now, &tmBuf);
+#endif
+  char buffer[48];
+  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &tmBuf);
+  return buffer;
+}
+
+std::filesystem::path ResolveMcpAuditPath() {
+  namespace fs = std::filesystem;
+  const fs::path projectRoot = Monolith::ProjectPath::Root();
+  if (!projectRoot.empty()) {
+    std::error_code ec;
+    if (fs::exists(projectRoot, ec) && !ec)
+      return projectRoot / ".horo" / "mcp-audit.jsonl";
+  }
+  return ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+}
+
+json BuildChangedIds(const std::string& toolName, const json& arguments, const json& summary) {
+  json changedIds = json::array();
+  auto pushUnique = [&](const std::string& value) {
+    if (value.empty())
+      return;
+    for (const json& item : changedIds) {
+      if (item.is_string() && item.get<std::string>() == value)
+        return;
+    }
+    changedIds.push_back(value);
+  };
+
+  if (arguments.contains("id") && arguments["id"].is_string())
+    pushUnique(arguments["id"].get<std::string>());
+  if (arguments.contains("ids") && arguments["ids"].is_array()) {
+    for (const json& item : arguments["ids"]) {
+      if (item.is_string())
+        pushUnique(item.get<std::string>());
+    }
+  }
+  if (toolName == "editor.new_scene" && arguments.contains("sceneId") && arguments["sceneId"].is_string())
+    pushUnique(arguments["sceneId"].get<std::string>());
+
+  const std::vector<std::string> summaryKeys = {"created", "updated", "asset", "renamed", "duplicates"};
+  for (const std::string& key : summaryKeys) {
+    if (!summary.contains(key))
+      continue;
+    const json& value = summary[key];
+    if (value.is_object() && value.contains("id") && value["id"].is_string())
+      pushUnique(value["id"].get<std::string>());
+    if (value.is_array()) {
+      for (const json& item : value) {
+        if (item.is_object() && item.contains("id") && item["id"].is_string())
+          pushUnique(item["id"].get<std::string>());
+      }
+    }
+  }
+  for (const char* key : {"newId", "deletedAssetId", "sceneId"}) {
+    if (summary.contains(key) && summary[key].is_string())
+      pushUnique(summary[key].get<std::string>());
+  }
+
+  return changedIds;
+}
+
+void AppendMutationAuditRecord(const json& requestId,
+                               const McpEditorSnapshot& snapshot,
+                               const std::string& toolName,
+                               const std::string& mode,
+                               const json& arguments,
+                               bool ok,
+                               const json& summary,
+                               const std::string& errorText) {
+  namespace fs = std::filesystem;
+
+  const fs::path auditPath = ResolveMcpAuditPath();
+  std::error_code ec;
+  fs::create_directories(auditPath.parent_path(), ec);
+  if (ec)
+    return;
+
+  std::ofstream out(auditPath, std::ios::app);
+  if (!out.is_open())
+    return;
+
+  json record = {
+      {"timestamp", FormatAuditTimestamp()},
+      {"requestId", requestId.is_null() ? std::string() : JsonToCompactString(requestId)},
+      {"tool", toolName},
+      {"mode", mode},
+      {"previewToken", arguments.value("previewToken", std::string())},
+      {"sceneId", snapshot.sceneId},
+      {"sceneFilePath", snapshot.sceneFilePath},
+      {"result", ok ? "success" : "error"},
+      {"error", ok ? std::string() : errorText},
+      {"changedIds", BuildChangedIds(toolName, arguments, summary)},
+      {"summary", summary},
+  };
+
+  out << record.dump() << "\n";
 }
 
 bool TryParseFloatText(const std::string& text, double* out) {
@@ -1669,11 +1782,21 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     json normalizedArguments = json::object();
     if (!NormalizeWriteArguments(*snapshot, name, StripMutationControls(arguments), &normalizedArguments,
                                  &validationError)) {
+      if (mode == "apply") {
+        AppendMutationAuditRecord(id, *snapshot, name, mode, StripMutationControls(arguments), false,
+                                  json{{"arguments", StripMutationControls(arguments)}}, validationError);
+      }
       const json result = MakeError(id, -32602, validationError);
       finish("tool", name, method, id, false, 200, validationError, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
     normalizedArguments["mode"] = mode;
+
+    auto appendApplyAudit = [&](bool ok, const json& summary, const std::string& errorText) {
+      if (mode != "apply")
+        return;
+      AppendMutationAuditRecord(id, *snapshot, name, mode, normalizedArguments, ok, summary, errorText);
+    };
 
     auto storePreviewToken = [&](const json& canonicalArguments) {
       std::scoped_lock lock(m_previewMutex);
@@ -1721,6 +1844,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     if (IsDestructiveToolName(name)) {
       if (!arguments.contains("previewToken") || !arguments["previewToken"].is_string()) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                         "previewToken is required for apply mode.");
         const json result = MakeError(id, -32602, "previewToken is required for apply mode.");
         finish("tool", name, method, id, false, 200, "previewToken is required for apply mode.",
                &result, {});
@@ -1730,6 +1855,7 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
       std::string previewError;
       const json canonicalArguments = StripMutationControls(normalizedArguments);
       if (!consumePreviewToken(previewToken, canonicalArguments, &previewError)) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, canonicalArguments), previewError);
         const json result = MakeError(id, -32602, previewError);
         finish("tool", name, method, id, false, 200, previewError, &result, {});
         return MakeJsonResponse(200, "OK", result);
@@ -1738,6 +1864,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     }
 
     if (!m_context.commandInvoker) {
+      appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                       "Command queue unavailable.");
       const json result = MakeError(id, -32002, "Command queue unavailable.");
       finish("tool", name, method, id, false, 503, "Command queue unavailable.", &result, {});
       return MakeJsonResponse(503, "Service Unavailable", result);
@@ -1745,10 +1873,16 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     const McpCommandResult commandResult = m_context.commandInvoker(name, normalizedArguments);
     if (!commandResult.ok) {
+      appendApplyAudit(false,
+                       commandResult.data.empty()
+                           ? BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments))
+                           : commandResult.data,
+                       commandResult.error);
       const json result = MakeError(id, -32010, commandResult.error);
       finish("tool", name, method, id, false, 200, commandResult.error, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
+    appendApplyAudit(true, commandResult.data, std::string());
     const json result = MakeSuccess(id, BuildTextToolResult(commandResult.data));
     finish("tool", name, method, id, true, 200, std::string(), &result, {});
     return MakeJsonResponse(200, "OK", result);

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -1,8 +1,12 @@
 #include "mcp/McpProtocol.h"
 
 #include <algorithm>
+#include <cmath>
 #include <chrono>
 #include <cctype>
+#include <cstdlib>
+#include <iomanip>
+#include <sstream>
 #include <unordered_set>
 
 namespace Monolith {
@@ -167,6 +171,445 @@ bool IsKnownResourceUri(const std::string& uri) {
   return uris.find(uri) != uris.end();
 }
 
+bool IsWriteToolName(const std::string& name) {
+  return name == "editor.select" || name == "editor.clear_selection" ||
+         name == "editor.create_object" || name == "editor.create_object_from_asset" ||
+         name == "editor.update_object" || name == "editor.transform" ||
+         name == "editor.rename_object" || name == "editor.reparent_object" ||
+         name == "editor.duplicate" || name == "editor.delete" || name == "editor.select_asset" ||
+         name == "editor.update_asset" || name == "editor.delete_asset" ||
+         name == "editor.new_scene" || name == "editor.save_scene" ||
+         name == "editor.reload_scene";
+}
+
+bool IsDestructiveToolName(const std::string& name) {
+  return name == "editor.delete" || name == "editor.delete_asset" || name == "editor.new_scene" ||
+         name == "editor.reload_scene";
+}
+
+std::string FormatFloatText(double value) {
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(4) << value;
+  return out.str();
+}
+
+bool TryParseFloatText(const std::string& text, double* out) {
+  if (!out)
+    return false;
+  char* end = nullptr;
+  const double value = std::strtod(text.c_str(), &end);
+  if (end == text.c_str() || (end && *end != '\0') || !std::isfinite(value))
+    return false;
+  *out = value;
+  return true;
+}
+
+bool TryParseBoolText(const std::string& text, bool* out) {
+  if (!out)
+    return false;
+  const std::string lowered = ToLowerAscii(text);
+  if (lowered == "true" || lowered == "1") {
+    *out = true;
+    return true;
+  }
+  if (lowered == "false" || lowered == "0") {
+    *out = false;
+    return true;
+  }
+  return false;
+}
+
+bool NormalizeFreeformScalar(const json& value, std::string* out) {
+  if (!out)
+    return false;
+  if (value.is_string()) {
+    *out = value.get<std::string>();
+    return true;
+  }
+  if (value.is_number_integer() || value.is_number_unsigned() || value.is_number_float()) {
+    *out = value.dump();
+    return true;
+  }
+  if (value.is_boolean()) {
+    *out = value.get<bool>() ? "true" : "false";
+    return true;
+  }
+  if (value.is_null()) {
+    out->clear();
+    return true;
+  }
+  return false;
+}
+
+bool NormalizeVec3Argument(const json& value,
+                           const std::string& argumentName,
+                           json* out,
+                           std::string* error) {
+  if (!out)
+    return false;
+  if (!value.is_array() || value.size() != 3 || !value[0].is_number() || !value[1].is_number() ||
+      !value[2].is_number()) {
+    if (error)
+      *error = argumentName + " must be [x,y,z].";
+    return false;
+  }
+  *out = json::array({value[0].get<double>(), value[1].get<double>(), value[2].get<double>()});
+  return true;
+}
+
+bool NormalizeColor3Value(const json& value, std::string* out) {
+  if (!out)
+    return false;
+  if (value.is_string()) {
+    std::stringstream stream(value.get<std::string>());
+    std::string item;
+    std::vector<double> parts;
+    while (std::getline(stream, item, ',')) {
+      item.erase(std::remove_if(item.begin(), item.end(), [](unsigned char c) { return std::isspace(c); }),
+                 item.end());
+      double parsed = 0.0;
+      if (!TryParseFloatText(item, &parsed))
+        return false;
+      parts.push_back(parsed);
+    }
+    if (parts.size() != 3)
+      return false;
+    *out = FormatFloatText(parts[0]) + "," + FormatFloatText(parts[1]) + "," + FormatFloatText(parts[2]);
+    return true;
+  }
+  if (!value.is_array() || value.size() != 3 || !value[0].is_number() || !value[1].is_number() ||
+      !value[2].is_number()) {
+    return false;
+  }
+  *out = FormatFloatText(value[0].get<double>()) + "," + FormatFloatText(value[1].get<double>()) +
+         "," + FormatFloatText(value[2].get<double>());
+  return true;
+}
+
+const McpSchemaEntrySnapshot* FindSchemaEntryByName(const std::vector<McpSchemaEntrySnapshot>& entries,
+                                                    const std::string& name) {
+  const std::string loweredName = ToLowerAscii(name);
+  for (const McpSchemaEntrySnapshot& entry : entries) {
+    if (ToLowerAscii(entry.name) == loweredName)
+      return &entry;
+  }
+  return nullptr;
+}
+
+const McpSchemaFieldSnapshot* FindSchemaFieldByKey(const McpSchemaEntrySnapshot& schema,
+                                                   const std::string& key) {
+  const std::string loweredKey = ToLowerAscii(key);
+  for (const McpSchemaFieldSnapshot& field : schema.fields) {
+    if (ToLowerAscii(field.key) == loweredKey)
+      return &field;
+  }
+  return nullptr;
+}
+
+const McpSchemaEntrySnapshot* FindObjectSchema(const McpEditorSnapshot& snapshot, const std::string& typeName) {
+  return FindSchemaEntryByName(snapshot.schema.objectTypes, typeName);
+}
+
+const McpSchemaEntrySnapshot* FindComponentSchema(const McpEditorSnapshot& snapshot,
+                                                  const std::string& componentType) {
+  return FindSchemaEntryByName(snapshot.schema.components, componentType);
+}
+
+bool NormalizeFieldValue(const McpSchemaFieldSnapshot& field,
+                         const json& value,
+                         std::string* out,
+                         std::string* error) {
+  if (!out)
+    return false;
+
+  if (field.widget == "float") {
+    double numeric = 0.0;
+    if (value.is_number()) {
+      numeric = value.get<double>();
+    } else if (value.is_string()) {
+      if (!TryParseFloatText(value.get<std::string>(), &numeric)) {
+        if (error)
+          *error = "must be a number.";
+        return false;
+      }
+    } else {
+      if (error)
+        *error = "must be a number.";
+      return false;
+    }
+    if (!std::isfinite(numeric)) {
+      if (error)
+        *error = "must be finite.";
+      return false;
+    }
+    if (field.hasMin && numeric < static_cast<double>(field.minVal)) {
+      if (error)
+        *error = "must be >= " + FormatFloatText(field.minVal) + ".";
+      return false;
+    }
+    if (field.hasMax && numeric > static_cast<double>(field.maxVal)) {
+      if (error)
+        *error = "must be <= " + FormatFloatText(field.maxVal) + ".";
+      return false;
+    }
+    *out = FormatFloatText(numeric);
+    return true;
+  }
+
+  if (field.widget == "bool") {
+    bool boolValue = false;
+    if (value.is_boolean()) {
+      boolValue = value.get<bool>();
+    } else if (value.is_string()) {
+      if (!TryParseBoolText(value.get<std::string>(), &boolValue)) {
+        if (error)
+          *error = "must be true or false.";
+        return false;
+      }
+    } else {
+      if (error)
+        *error = "must be a boolean.";
+      return false;
+    }
+    *out = boolValue ? "true" : "false";
+    return true;
+  }
+
+  if (field.widget == "enum") {
+    if (!value.is_string()) {
+      if (error)
+        *error = "must be a string.";
+      return false;
+    }
+    const std::string text = value.get<std::string>();
+    const bool knownValue =
+        std::find(field.options.begin(), field.options.end(), text) != field.options.end();
+    if (!knownValue && !field.allowCustomValue) {
+      if (error) {
+        *error = "must be one of: ";
+        for (size_t i = 0; i < field.options.size(); ++i) {
+          if (i > 0)
+            *error += ", ";
+          *error += field.options[i];
+        }
+        *error += ".";
+      }
+      return false;
+    }
+    *out = text;
+    return true;
+  }
+
+  if (field.widget == "color3") {
+    if (!NormalizeColor3Value(value, out)) {
+      if (error)
+        *error = "must be a color3 string or [r,g,b] array.";
+      return false;
+    }
+    return true;
+  }
+
+  if (!value.is_string()) {
+    if (error)
+      *error = "must be a string.";
+    return false;
+  }
+  *out = value.get<std::string>();
+  if (!field.allowEmpty && out->empty()) {
+    if (error)
+      *error = "must not be empty.";
+    return false;
+  }
+  return true;
+}
+
+bool NormalizePropsObject(const json& input,
+                          const McpSchemaEntrySnapshot* schema,
+                          bool allowUnknown,
+                          bool applyDefaults,
+                          json* out,
+                          std::string* error,
+                          const std::string& prefix) {
+  if (!out)
+    return false;
+  if (!input.is_object()) {
+    if (error)
+      *error = prefix + " must be an object.";
+    return false;
+  }
+
+  json normalized = json::object();
+  if (applyDefaults && schema) {
+    for (const McpSchemaFieldSnapshot& field : schema->fields) {
+      if (field.hasDefault)
+        normalized[field.key] = field.defaultValue;
+    }
+  }
+
+  for (auto it = input.begin(); it != input.end(); ++it) {
+    const std::string key = it.key();
+    if (schema) {
+      if (const McpSchemaFieldSnapshot* field = FindSchemaFieldByKey(*schema, key)) {
+        std::string normalizedValue;
+        std::string fieldError;
+        if (!NormalizeFieldValue(*field, it.value(), &normalizedValue, &fieldError)) {
+          if (error)
+            *error = prefix + "." + key + " " + fieldError;
+          return false;
+        }
+        normalized[field->key] = normalizedValue;
+        continue;
+      }
+      if (!allowUnknown) {
+        if (error)
+          *error = "Unknown field in " + prefix + ": " + key + ".";
+        return false;
+      }
+    }
+
+    std::string scalar;
+    if (!NormalizeFreeformScalar(it.value(), &scalar)) {
+      if (error)
+        *error = prefix + "." + key + " must be a scalar value.";
+      return false;
+    }
+    normalized[key] = scalar;
+  }
+
+  if (schema) {
+    for (const McpSchemaFieldSnapshot& field : schema->fields) {
+      const bool hasField = normalized.contains(field.key);
+      if (field.required && (!hasField || normalized[field.key].get<std::string>().empty())) {
+        if (error)
+          *error = prefix + "." + field.key + " is required.";
+        return false;
+      }
+      if (hasField && !field.allowEmpty && normalized[field.key].get<std::string>().empty()) {
+        if (error)
+          *error = prefix + "." + field.key + " must not be empty.";
+        return false;
+      }
+    }
+  }
+
+  *out = std::move(normalized);
+  return true;
+}
+
+bool NormalizeComponentList(const json& input,
+                            const McpEditorSnapshot& snapshot,
+                            bool applyDefaults,
+                            json* out,
+                            std::string* error) {
+  if (!out)
+    return false;
+  if (!input.is_array()) {
+    if (error)
+      *error = "components must be an array of objects.";
+    return false;
+  }
+
+  json normalized = json::array();
+  for (size_t index = 0; index < input.size(); ++index) {
+    const json& item = input[index];
+    if (!item.is_object() || !item.contains("type") || !item["type"].is_string()) {
+      if (error)
+        *error = "components[" + std::to_string(index) + "] must include a string type.";
+      return false;
+    }
+    const std::string componentType = item["type"].get<std::string>();
+    const McpSchemaEntrySnapshot* schema = FindComponentSchema(snapshot, componentType);
+    if (!schema) {
+      if (error)
+        *error = "Unknown component type: " + componentType + ".";
+      return false;
+    }
+    json props = json::object();
+    if (!NormalizePropsObject(item.value("props", json::object()), schema, false, applyDefaults, &props,
+                              error, "components[" + std::to_string(index) + "].props")) {
+      return false;
+    }
+    normalized.push_back(json{{"type", schema->name}, {"props", std::move(props)}});
+  }
+
+  *out = std::move(normalized);
+  return true;
+}
+
+bool ParseMutationMode(const json& arguments, std::string* outMode, std::string* error) {
+  if (!outMode)
+    return false;
+  *outMode = "apply";
+  if (!arguments.contains("mode"))
+    return true;
+  if (!arguments["mode"].is_string()) {
+    if (error)
+      *error = "mode must be \"preview\" or \"apply\".";
+    return false;
+  }
+  const std::string mode = ToLowerAscii(arguments["mode"].get<std::string>());
+  if (mode != "preview" && mode != "apply") {
+    if (error)
+      *error = "mode must be \"preview\" or \"apply\".";
+    return false;
+  }
+  *outMode = mode;
+  return true;
+}
+
+json StripMutationControls(const json& arguments) {
+  json stripped = arguments.is_object() ? arguments : json::object();
+  stripped.erase("mode");
+  stripped.erase("previewToken");
+  return stripped;
+}
+
+bool ObjectExists(const McpEditorSnapshot& snapshot, const std::string& id) {
+  return FindObjectById(snapshot, id) != nullptr;
+}
+
+bool AssetExists(const McpEditorSnapshot& snapshot, const std::string& id) {
+  return FindAssetById(snapshot, id) != nullptr;
+}
+
+bool ParentWouldCreateCycle(const McpEditorSnapshot& snapshot,
+                            const std::string& childId,
+                            const std::string& parentId) {
+  std::string current = parentId;
+  while (!current.empty()) {
+    if (current == childId)
+      return true;
+    const McpObjectSnapshot* parent = FindObjectById(snapshot, current);
+    if (!parent)
+      return false;
+    current = GetParentId(*parent);
+  }
+  return false;
+}
+
+bool NormalizeObjectTypeName(const std::string& raw, std::string* outType) {
+  if (!outType)
+    return false;
+  const std::string lowered = ToLowerAscii(raw);
+  if (lowered == "panel") {
+    *outType = "Panel";
+    return true;
+  }
+  if (lowered == "prop") {
+    *outType = "Prop";
+    return true;
+  }
+  if (lowered == "light") {
+    *outType = "Light";
+    return true;
+  }
+  if (lowered == "camera") {
+    *outType = "Camera";
+    return true;
+  }
+  return false;
+}
+
 json BuildToolList() {
   json tools = json::array();
   for (const McpCatalogEntry& entry : GetToolCatalog()) {
@@ -197,6 +640,7 @@ json BuildToolList() {
         tool["inputSchema"]["properties"]["mesh"] = {{"type", "string"}};
         tool["inputSchema"]["properties"]["renderScale"] = {{"type", "string"}};
         tool["inputSchema"]["properties"]["albedoMap"] = {{"type", "string"}};
+        tool["inputSchema"]["properties"]["displayName"] = {{"type", "string"}};
       }
       if (entry.name == "editor.rename_object")
         tool["inputSchema"]["required"] = json::array({"id", "newId"});
@@ -235,7 +679,7 @@ json BuildToolList() {
                                            {"yaw", {{"type", "number"}}},
                                            {"pitch", {{"type", "number"}}},
                                            {"roll", {{"type", "number"}}}};
-    } else if (entry.name == "editor.update_object" || entry.name == "editor.transform") {
+    } else if (entry.name == "editor.update_object") {
       tool["inputSchema"]["required"] = json::array({"id"});
       tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
                                            {"assetId", {{"type", "string"}}},
@@ -246,6 +690,14 @@ json BuildToolList() {
                                            {"roll", {{"type", "number"}}},
                                            {"props", {{"type", "object"}}},
                                            {"components", {{"type", "array"}}}};
+    } else if (entry.name == "editor.transform") {
+      tool["inputSchema"]["required"] = json::array({"id"});
+      tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
+                                           {"position", MakeVec3Schema()},
+                                           {"scale", MakeVec3Schema()},
+                                           {"yaw", {{"type", "number"}}},
+                                           {"pitch", {{"type", "number"}}},
+                                           {"roll", {{"type", "number"}}}};
     } else if (entry.name == "editor.duplicate") {
       tool["inputSchema"]["required"] = json::array({"id"});
       tool["inputSchema"]["properties"] = {{"id", {{"type", "string"}}},
@@ -267,6 +719,14 @@ json BuildToolList() {
     } else if (entry.name == "editor.new_scene") {
       tool["inputSchema"]["properties"] = {{"sceneName", {{"type", "string"}}},
                                            {"sceneId", {{"type", "string"}}}};
+    }
+    if (IsWriteToolName(entry.name)) {
+      tool["inputSchema"]["properties"]["mode"] = {
+          {"type", "string"},
+          {"enum", json::array({"preview", "apply"})},
+      };
+      if (IsDestructiveToolName(entry.name))
+        tool["inputSchema"]["properties"]["previewToken"] = {{"type", "string"}};
     }
     tools.push_back(std::move(tool));
   }
@@ -312,6 +772,561 @@ json BuildResourcePayload(const McpEditorSnapshot& snapshot, const std::string& 
 json BuildResourceReadResult(const McpEditorSnapshot& snapshot, const std::string& uri, const json& params) {
   const json payload = BuildResourcePayload(snapshot, uri, params);
   return json{{"contents", json::array({{{"uri", uri}, {"mimeType", "application/json"}, {"text", payload.dump()}}})}};
+}
+
+Vec3 JsonArrayToVec3(const json& value) {
+  return Vec3(value[0].get<float>(), value[1].get<float>(), value[2].get<float>());
+}
+
+bool NormalizeWriteArguments(const McpEditorSnapshot& snapshot,
+                             const std::string& toolName,
+                             const json& arguments,
+                             json* out,
+                             std::string* error) {
+  if (!out)
+    return false;
+  if (!arguments.is_object()) {
+    if (error)
+      *error = "arguments must be an object.";
+    return false;
+  }
+
+  json normalized = json::object();
+
+  if (toolName == "editor.select" || toolName == "editor.delete" || toolName == "editor.duplicate") {
+    if (arguments.contains("id")) {
+      if (!arguments["id"].is_string()) {
+        if (error)
+          *error = "id must be a string.";
+        return false;
+      }
+      normalized["id"] = arguments["id"].get<std::string>();
+    }
+    if (arguments.contains("ids")) {
+      if (!arguments["ids"].is_array()) {
+        if (error)
+          *error = "ids must be an array of strings.";
+        return false;
+      }
+      json ids = json::array();
+      for (const json& item : arguments["ids"]) {
+        if (!item.is_string()) {
+          if (error)
+            *error = "ids must be an array of strings.";
+          return false;
+        }
+        ids.push_back(item.get<std::string>());
+      }
+      normalized["ids"] = std::move(ids);
+    }
+    if (toolName == "editor.duplicate" && arguments.contains("count")) {
+      if (!arguments["count"].is_number_integer()) {
+        if (error)
+          *error = "count must be an integer.";
+        return false;
+      }
+      const int count = arguments["count"].get<int>();
+      if (count < 1 || count > 8) {
+        if (error)
+          *error = "count must be between 1 and 8.";
+        return false;
+      }
+      normalized["count"] = count;
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.clear_selection" || toolName == "editor.save_scene") {
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.select_asset" || toolName == "editor.delete_asset") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string assetId = arguments["id"].get<std::string>();
+    if (!assetId.empty() && !AssetExists(snapshot, assetId)) {
+      if (error)
+        *error = "Asset not found.";
+      return false;
+    }
+    normalized["id"] = assetId;
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.update_asset") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string assetId = arguments["id"].get<std::string>();
+    if (!AssetExists(snapshot, assetId)) {
+      if (error)
+        *error = "Asset not found.";
+      return false;
+    }
+    normalized["id"] = assetId;
+    for (const char* key : {"mesh", "renderScale", "albedoMap", "displayName"}) {
+      if (!arguments.contains(key))
+        continue;
+      if (!arguments[key].is_string() && !arguments[key].is_null()) {
+        if (error)
+          *error = std::string(key) + " must be a string or null.";
+        return false;
+      }
+      normalized[key] = arguments[key];
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.rename_object") {
+    if (!arguments.contains("id") || !arguments["id"].is_string() || !arguments.contains("newId") ||
+        !arguments["newId"].is_string()) {
+      if (error)
+        *error = "id and newId are required.";
+      return false;
+    }
+    const std::string id = arguments["id"].get<std::string>();
+    const std::string newId = arguments["newId"].get<std::string>();
+    if (!ObjectExists(snapshot, id)) {
+      if (error)
+        *error = "Object not found.";
+      return false;
+    }
+    if (newId.empty()) {
+      if (error)
+        *error = "newId is required.";
+      return false;
+    }
+    if (const McpObjectSnapshot* existing = FindObjectById(snapshot, newId)) {
+      if (existing->id != id) {
+        if (error)
+          *error = "Object id already exists.";
+        return false;
+      }
+    }
+    normalized["id"] = id;
+    normalized["newId"] = newId;
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.reparent_object") {
+    if (!arguments.contains("id") || !arguments["id"].is_string()) {
+      if (error)
+        *error = "id is required.";
+      return false;
+    }
+    const std::string id = arguments["id"].get<std::string>();
+    if (!ObjectExists(snapshot, id)) {
+      if (error)
+        *error = "Object not found.";
+      return false;
+    }
+    normalized["id"] = id;
+    if (arguments.contains("parentId")) {
+      if (!arguments["parentId"].is_string() && !arguments["parentId"].is_null()) {
+        if (error)
+          *error = "parentId must be a string or null.";
+        return false;
+      }
+      const std::string parentId =
+          arguments["parentId"].is_null() ? std::string() : arguments["parentId"].get<std::string>();
+      if (!parentId.empty()) {
+        if (!ObjectExists(snapshot, parentId)) {
+          if (error)
+            *error = "Parent object not found.";
+          return false;
+        }
+        if (parentId == id) {
+          if (error)
+            *error = "Object cannot parent itself.";
+          return false;
+        }
+        if (ParentWouldCreateCycle(snapshot, id, parentId)) {
+          if (error)
+            *error = "Parent would create a cycle.";
+          return false;
+        }
+        normalized["parentId"] = parentId;
+      } else {
+        normalized["parentId"] = nullptr;
+      }
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.new_scene") {
+    if (arguments.contains("sceneId") && !arguments["sceneId"].is_string()) {
+      if (error)
+        *error = "sceneId must be a string.";
+      return false;
+    }
+    if (arguments.contains("sceneName") && !arguments["sceneName"].is_string()) {
+      if (error)
+        *error = "sceneName must be a string.";
+      return false;
+    }
+    if (arguments.contains("sceneId"))
+      normalized["sceneId"] = arguments["sceneId"].get<std::string>();
+    if (arguments.contains("sceneName"))
+      normalized["sceneName"] = arguments["sceneName"].get<std::string>();
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.reload_scene") {
+    *out = std::move(normalized);
+    return true;
+  }
+
+  if (toolName == "editor.create_object" || toolName == "editor.create_object_from_asset" ||
+      toolName == "editor.update_object" || toolName == "editor.transform") {
+    const McpObjectSnapshot* existingObject = nullptr;
+    std::string objectTypeName;
+
+    if (toolName == "editor.create_object") {
+      if (!arguments.contains("type") || !arguments["type"].is_string()) {
+        if (error)
+          *error = "type is required.";
+        return false;
+      }
+      if (!NormalizeObjectTypeName(arguments["type"].get<std::string>(), &objectTypeName)) {
+        if (error)
+          *error = "Invalid object type.";
+        return false;
+      }
+      normalized["type"] = objectTypeName;
+    } else if (toolName == "editor.update_object" || toolName == "editor.transform") {
+      if (!arguments.contains("id") || !arguments["id"].is_string()) {
+        if (error)
+          *error = "id is required.";
+        return false;
+      }
+      const std::string objectId = arguments["id"].get<std::string>();
+      existingObject = FindObjectById(snapshot, objectId);
+      if (!existingObject) {
+        if (error)
+          *error = "Object not found.";
+        return false;
+      }
+      normalized["id"] = objectId;
+      objectTypeName = existingObject->type;
+    }
+
+    if (toolName == "editor.create_object_from_asset") {
+      if (!arguments.contains("assetId") || !arguments["assetId"].is_string()) {
+        if (error)
+          *error = "assetId is required.";
+        return false;
+      }
+      const std::string assetId = arguments["assetId"].get<std::string>();
+      if (!AssetExists(snapshot, assetId)) {
+        if (error)
+          *error = "Asset not found.";
+        return false;
+      }
+      normalized["assetId"] = assetId;
+      objectTypeName = "Prop";
+      if (arguments.contains("scale") || arguments.contains("props") || arguments.contains("components")) {
+        if (error)
+          *error = "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+    }
+
+    const McpSchemaEntrySnapshot* objectSchema =
+        objectTypeName.empty() ? nullptr : FindObjectSchema(snapshot, objectTypeName);
+
+    if (arguments.contains("id")) {
+      if (!arguments["id"].is_string()) {
+        if (error)
+          *error = "id must be a string.";
+        return false;
+      }
+      const std::string objectId = arguments["id"].get<std::string>();
+      if ((toolName == "editor.create_object" || toolName == "editor.create_object_from_asset") &&
+          ObjectExists(snapshot, objectId)) {
+        if (error)
+          *error = "Object id already exists.";
+        return false;
+      }
+      normalized["id"] = objectId;
+    }
+    if (arguments.contains("assetId")) {
+      if (toolName == "editor.transform") {
+        if (error)
+          *error = "transform only accepts id, position, scale, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!arguments["assetId"].is_string() && !arguments["assetId"].is_null()) {
+        if (error)
+          *error = "assetId must be a string or null.";
+        return false;
+      }
+      const std::string assetId =
+          arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
+      if (!assetId.empty() && !AssetExists(snapshot, assetId)) {
+        if (error)
+          *error = "Asset not found.";
+        return false;
+      }
+      normalized["assetId"] = arguments["assetId"];
+    }
+    if (arguments.contains("parentId")) {
+      if (toolName == "editor.update_object" || toolName == "editor.transform") {
+        if (error)
+          *error = "parentId must be changed with editor.reparent_object.";
+        return false;
+      }
+      if (!arguments["parentId"].is_string()) {
+        if (error)
+          *error = "parentId must be a string.";
+        return false;
+      }
+      const std::string parentId = arguments["parentId"].get<std::string>();
+      if (!ObjectExists(snapshot, parentId)) {
+        if (error)
+          *error = "Parent object not found.";
+        return false;
+      }
+      normalized["parentId"] = parentId;
+    }
+    if (arguments.contains("position") &&
+        !NormalizeVec3Argument(arguments["position"], "position", &normalized["position"], error)) {
+      return false;
+    }
+    if (arguments.contains("scale") &&
+        !NormalizeVec3Argument(arguments["scale"], "scale", &normalized["scale"], error)) {
+      return false;
+    }
+    for (const char* key : {"yaw", "pitch", "roll"}) {
+      if (!arguments.contains(key))
+        continue;
+      if (!arguments[key].is_number()) {
+        if (error)
+          *error = std::string(key) + " must be a number.";
+        return false;
+      }
+      normalized[key] = arguments[key].get<double>();
+    }
+    if (arguments.contains("props")) {
+      if (toolName == "editor.transform" || toolName == "editor.create_object_from_asset") {
+        if (error)
+          *error = toolName == "editor.transform"
+                       ? "transform only accepts id, position, scale, yaw, pitch, and roll."
+                       : "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!NormalizePropsObject(arguments["props"], objectSchema, true,
+                                toolName == "editor.create_object", &normalized["props"], error, "props")) {
+        return false;
+      }
+    } else if (toolName == "editor.create_object" && objectSchema) {
+      if (!NormalizePropsObject(json::object(), objectSchema, true, true, &normalized["props"], error, "props"))
+        return false;
+    }
+    if (arguments.contains("components")) {
+      if (toolName == "editor.transform" || toolName == "editor.create_object_from_asset") {
+        if (error)
+          *error = toolName == "editor.transform"
+                       ? "transform only accepts id, position, scale, yaw, pitch, and roll."
+                       : "create_object_from_asset only supports id, parentId, position, yaw, pitch, and roll.";
+        return false;
+      }
+      if (!NormalizeComponentList(arguments["components"], snapshot, true, &normalized["components"], error))
+        return false;
+    }
+    *out = std::move(normalized);
+    return true;
+  }
+
+  return false;
+}
+
+json BuildMutationPreviewPayload(const McpEditorSnapshot& snapshot,
+                                 const std::string& toolName,
+                                 const json& arguments) {
+  if (toolName == "editor.select") {
+    json ids = arguments.value("ids", json::array());
+    if (arguments.contains("id") && arguments["id"].is_string())
+      ids.push_back(arguments["id"].get<std::string>());
+    return json{{"tool", toolName}, {"selectedObjectIds", std::move(ids)}};
+  }
+  if (toolName == "editor.clear_selection") {
+    return json{{"tool", toolName}, {"cleared", true}};
+  }
+  if (toolName == "editor.create_object") {
+    McpObjectSnapshot object;
+    object.id = arguments.value("id", std::string("(auto-generated)"));
+    object.type = arguments.value("type", std::string("Panel"));
+    if (arguments.contains("position"))
+      object.position = JsonArrayToVec3(arguments["position"]);
+    if (arguments.contains("scale"))
+      object.scale = JsonArrayToVec3(arguments["scale"]);
+    object.yaw = arguments.value("yaw", 0.0f);
+    object.pitch = arguments.value("pitch", 0.0f);
+    object.roll = arguments.value("roll", 0.0f);
+    object.assetId = arguments.value("assetId", std::string());
+    if (arguments.contains("props")) {
+      for (auto it = arguments["props"].begin(); it != arguments["props"].end(); ++it)
+        object.props[it.key()] = it.value().get<std::string>();
+    }
+    if (arguments.contains("parentId"))
+      object.props["parentId"] = arguments["parentId"].get<std::string>();
+    if (arguments.contains("components")) {
+      for (const json& item : arguments["components"]) {
+        McpComponentSnapshot component;
+        component.type = item["type"].get<std::string>();
+        for (auto it = item["props"].begin(); it != item["props"].end(); ++it)
+          component.props[it.key()] = it.value().get<std::string>();
+        object.components.push_back(std::move(component));
+      }
+    }
+    return json{{"tool", toolName}, {"created", BuildObjectJson(object)}};
+  }
+  if (toolName == "editor.create_object_from_asset") {
+    json preview{{"tool", toolName},
+                 {"assetId", arguments.value("assetId", std::string())},
+                 {"id", arguments.value("id", std::string("(auto-generated)"))}};
+    if (const McpAssetSnapshot* asset =
+            FindAssetById(snapshot, arguments.value("assetId", std::string()))) {
+      preview["asset"] = BuildAssetJson(*asset);
+    }
+    if (arguments.contains("parentId"))
+      preview["parentId"] = arguments["parentId"];
+    if (arguments.contains("position"))
+      preview["position"] = arguments["position"];
+    preview["yaw"] = arguments.value("yaw", 0.0f);
+    preview["pitch"] = arguments.value("pitch", 0.0f);
+    preview["roll"] = arguments.value("roll", 0.0f);
+    return preview;
+  }
+  if (toolName == "editor.update_object" || toolName == "editor.transform") {
+    const McpObjectSnapshot* current = FindObjectById(snapshot, arguments.value("id", std::string()));
+    if (!current)
+      return json{{"tool", toolName}, {"id", arguments.value("id", std::string())}};
+    McpObjectSnapshot updated = *current;
+    if (arguments.contains("position"))
+      updated.position = JsonArrayToVec3(arguments["position"]);
+    if (arguments.contains("scale"))
+      updated.scale = JsonArrayToVec3(arguments["scale"]);
+    if (arguments.contains("yaw"))
+      updated.yaw = arguments["yaw"].get<float>();
+    if (arguments.contains("pitch"))
+      updated.pitch = arguments["pitch"].get<float>();
+    if (arguments.contains("roll"))
+      updated.roll = arguments["roll"].get<float>();
+    if (arguments.contains("assetId"))
+      updated.assetId = arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
+    if (arguments.contains("props")) {
+      for (auto it = arguments["props"].begin(); it != arguments["props"].end(); ++it)
+        updated.props[it.key()] = it.value().get<std::string>();
+    }
+    if (arguments.contains("components")) {
+      updated.components.clear();
+      for (const json& item : arguments["components"]) {
+        McpComponentSnapshot component;
+        component.type = item["type"].get<std::string>();
+        for (auto it = item["props"].begin(); it != item["props"].end(); ++it)
+          component.props[it.key()] = it.value().get<std::string>();
+        updated.components.push_back(std::move(component));
+      }
+    }
+    return json{{"tool", toolName}, {"before", BuildObjectJson(*current)}, {"after", BuildObjectJson(updated)}};
+  }
+  if (toolName == "editor.rename_object") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"newId", arguments.value("newId", std::string())}};
+  }
+  if (toolName == "editor.reparent_object") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"parentId", arguments.contains("parentId") ? arguments["parentId"] : json(nullptr)}};
+  }
+  if (toolName == "editor.duplicate") {
+    return json{{"tool", toolName},
+                {"id", arguments.value("id", std::string())},
+                {"ids", arguments.value("ids", json::array())},
+                {"count", arguments.value("count", 1)}};
+  }
+  if (toolName == "editor.delete") {
+    json deleted = json::array();
+    std::vector<std::string> ids;
+    if (arguments.contains("id") && arguments["id"].is_string())
+      ids.push_back(arguments["id"].get<std::string>());
+    if (arguments.contains("ids")) {
+      for (const json& item : arguments["ids"])
+        ids.push_back(item.get<std::string>());
+    }
+    for (const std::string& id : ids) {
+      if (const McpObjectSnapshot* object = FindObjectById(snapshot, id))
+        deleted.push_back(BuildObjectJson(*object));
+    }
+    return json{{"tool", toolName},
+                {"deletedCount", deleted.size()},
+                {"objects", std::move(deleted)}};
+  }
+  if (toolName == "editor.select_asset") {
+    return json{{"tool", toolName}, {"selectedAssetId", arguments.value("id", std::string())}};
+  }
+  if (toolName == "editor.update_asset") {
+    const std::string assetId = arguments.value("id", std::string());
+    json preview{{"tool", toolName}, {"id", assetId}};
+    if (const McpAssetSnapshot* asset = FindAssetById(snapshot, assetId))
+      preview["before"] = BuildAssetJson(*asset);
+    json after = preview.value("before", json::object());
+    after["id"] = assetId;
+    for (const char* key : {"mesh", "renderScale", "albedoMap", "displayName"}) {
+      if (arguments.contains(key))
+        after[key] = arguments[key];
+    }
+    preview["after"] = std::move(after);
+    return preview;
+  }
+  if (toolName == "editor.delete_asset") {
+    const std::string assetId = arguments.value("id", std::string());
+    json preview{{"tool", toolName}, {"deletedAssetId", assetId}};
+    if (const McpAssetSnapshot* asset = FindAssetById(snapshot, assetId)) {
+      preview["asset"] = BuildAssetJson(*asset);
+      size_t referenceCount = 0;
+      for (const McpObjectSnapshot& object : snapshot.objects) {
+        if (object.assetId == assetId)
+          ++referenceCount;
+      }
+      preview["clearedObjectReferences"] = referenceCount;
+    }
+    return preview;
+  }
+  if (toolName == "editor.new_scene") {
+    return json{{"tool", toolName},
+                {"currentSceneId", snapshot.sceneId},
+                {"currentSceneName", snapshot.sceneName},
+                {"sceneId", arguments.value("sceneId", std::string("scene"))},
+                {"sceneName", arguments.value("sceneName", std::string("Scene"))}};
+  }
+  if (toolName == "editor.save_scene") {
+    return json{{"tool", toolName},
+                {"filePath", snapshot.sceneFilePath.empty() ? "assets/scenes/scene.json"
+                                                             : snapshot.sceneFilePath},
+                {"dirty", snapshot.dirty}};
+  }
+  if (toolName == "editor.reload_scene") {
+    return json{{"tool", toolName},
+                {"filePath", snapshot.sceneFilePath},
+                {"dirty", snapshot.dirty},
+                {"reloadPending", snapshot.reloadPending}};
+  }
+  return json{{"tool", toolName}};
 }
 
 }  // namespace
@@ -637,25 +1652,98 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
       return MakeJsonResponse(200, "OK", result);
     }
 
-    const bool isWriteTool =
-        name == "editor.select" || name == "editor.clear_selection" || name == "editor.create_object" ||
-        name == "editor.create_object_from_asset" || name == "editor.update_object" ||
-        name == "editor.transform" || name == "editor.rename_object" || name == "editor.reparent_object" ||
-        name == "editor.duplicate" || name == "editor.delete" || name == "editor.select_asset" ||
-        name == "editor.update_asset" || name == "editor.delete_asset" || name == "editor.new_scene" ||
-        name == "editor.save_scene" || name == "editor.reload_scene";
-    if (!isWriteTool) {
+    if (!IsWriteToolName(name)) {
       const json result = MakeError(id, -32601, "Unknown tool.");
       finish("tool", name, method, id, false, 200, "Unknown tool.", &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
+
+    std::string mode;
+    std::string validationError;
+    if (!ParseMutationMode(arguments, &mode, &validationError)) {
+      const json result = MakeError(id, -32602, validationError);
+      finish("tool", name, method, id, false, 200, validationError, &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+
+    json normalizedArguments = json::object();
+    if (!NormalizeWriteArguments(*snapshot, name, StripMutationControls(arguments), &normalizedArguments,
+                                 &validationError)) {
+      const json result = MakeError(id, -32602, validationError);
+      finish("tool", name, method, id, false, 200, validationError, &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+    normalizedArguments["mode"] = mode;
+
+    auto storePreviewToken = [&](const json& canonicalArguments) {
+      std::scoped_lock lock(m_previewMutex);
+      if (m_previewRecords.size() >= 128)
+        m_previewRecords.clear();
+      std::ostringstream token;
+      token << "preview_" << ++m_nextPreviewToken;
+      m_previewRecords[token.str()] = PreviewRecord{name, canonicalArguments, snapshot->sceneId,
+                                                    snapshot->sceneFilePath};
+      return token.str();
+    };
+
+    auto consumePreviewToken = [&](const std::string& previewToken,
+                                   const json& canonicalArguments,
+                                   std::string* outError) {
+      std::scoped_lock lock(m_previewMutex);
+      const auto it = m_previewRecords.find(previewToken);
+      if (it == m_previewRecords.end()) {
+        if (outError)
+          *outError = "previewToken is invalid or expired.";
+        return false;
+      }
+      const PreviewRecord& record = it->second;
+      if (record.toolName != name || record.arguments != canonicalArguments ||
+          record.sceneId != snapshot->sceneId || record.sceneFilePath != snapshot->sceneFilePath) {
+        if (outError)
+          *outError = "previewToken does not match the current scene state or arguments.";
+        return false;
+      }
+      m_previewRecords.erase(it);
+      return true;
+    };
+
+    if (mode == "preview") {
+      const json canonicalArguments = StripMutationControls(normalizedArguments);
+      const std::string previewToken = storePreviewToken(canonicalArguments);
+      json previewPayload = {{"tool", name},
+                             {"mode", "preview"},
+                             {"previewToken", previewToken},
+                             {"preview", BuildMutationPreviewPayload(*snapshot, name, canonicalArguments)}};
+      const json result = MakeSuccess(id, BuildTextToolResult(previewPayload));
+      finish("tool", name, method, id, true, 200, std::string(), &result, {});
+      return MakeJsonResponse(200, "OK", result);
+    }
+
+    if (IsDestructiveToolName(name)) {
+      if (!arguments.contains("previewToken") || !arguments["previewToken"].is_string()) {
+        const json result = MakeError(id, -32602, "previewToken is required for apply mode.");
+        finish("tool", name, method, id, false, 200, "previewToken is required for apply mode.",
+               &result, {});
+        return MakeJsonResponse(200, "OK", result);
+      }
+      const std::string previewToken = arguments["previewToken"].get<std::string>();
+      std::string previewError;
+      const json canonicalArguments = StripMutationControls(normalizedArguments);
+      if (!consumePreviewToken(previewToken, canonicalArguments, &previewError)) {
+        const json result = MakeError(id, -32602, previewError);
+        finish("tool", name, method, id, false, 200, previewError, &result, {});
+        return MakeJsonResponse(200, "OK", result);
+      }
+      normalizedArguments["previewToken"] = previewToken;
+    }
+
     if (!m_context.commandInvoker) {
       const json result = MakeError(id, -32002, "Command queue unavailable.");
       finish("tool", name, method, id, false, 503, "Command queue unavailable.", &result, {});
       return MakeJsonResponse(503, "Service Unavailable", result);
     }
 
-    const McpCommandResult commandResult = m_context.commandInvoker(name, arguments);
+    const McpCommandResult commandResult = m_context.commandInvoker(name, normalizedArguments);
     if (!commandResult.ok) {
       const json result = MakeError(id, -32010, commandResult.error);
       finish("tool", name, method, id, false, 200, commandResult.error, &result, {});

--- a/mcp/McpProtocol.h
+++ b/mcp/McpProtocol.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -70,7 +72,17 @@ class McpProtocol {
   const std::vector<McpCatalogEntry>& ResourceCatalog() const;
 
  private:
+  struct PreviewRecord {
+    std::string toolName;
+    nlohmann::json arguments = nlohmann::json::object();
+    std::string sceneId;
+    std::string sceneFilePath;
+  };
+
   McpProtocolContext m_context;
+  mutable std::mutex m_previewMutex;
+  mutable uint64_t m_nextPreviewToken = 0;
+  mutable std::unordered_map<std::string, PreviewRecord> m_previewRecords;
 };
 
 }  // namespace Mcp

--- a/mcp/McpSnapshot.cpp
+++ b/mcp/McpSnapshot.cpp
@@ -141,6 +141,7 @@ json BuildSchemaFieldJson(const McpSchemaFieldSnapshot& field) {
       {"label", field.label},
       {"description", field.description},
       {"widget", field.widget},
+      {"hasDefault", field.hasDefault},
       {"default", field.defaultValue},
       {"required", field.required},
       {"allowEmpty", field.allowEmpty},

--- a/mcp/McpSnapshot.h
+++ b/mcp/McpSnapshot.h
@@ -73,6 +73,7 @@ struct McpSchemaFieldSnapshot {
   std::string label;
   std::string description;
   std::string widget = "string";
+  bool hasDefault = false;
   bool required = false;
   bool allowEmpty = true;
   bool allowCustomValue = false;

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,6 +88,8 @@ choices, and numeric bounds for object and component fields.
 Every write tool accepts `mode: "preview" | "apply"`. Preview calls never mutate the editor and return
 a `previewToken`; destructive apply calls for delete/new-scene/reload flows must present the matching
 token from the latest preview.
+Apply calls append JSONL audit entries to `<project-root>/.horo/mcp-audit.jsonl`, or to
+`ResolveMcpSettingsDirectory()/mcp-audit.jsonl` when no project root is available.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.
@@ -249,6 +251,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage tips
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Ask for `scene.summary` first instead of broad object dumps.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -85,6 +85,9 @@ Tools:
 The design is intentionally summary-first to keep token usage low.
 Schema tools expose the same `assets/editor_schema.json` metadata that powers editor defaults, enum
 choices, and numeric bounds for object and component fields.
+Every write tool accepts `mode: "preview" | "apply"`. Preview calls never mutate the editor and return
+a `previewToken`; destructive apply calls for delete/new-scene/reload flows must present the matching
+token from the latest preview.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -198,6 +198,7 @@ McpSchemaFieldSnapshot MakeSchemaField(std::string key,
   field.label = std::move(label);
   field.description = std::move(description);
   field.widget = std::move(widget);
+  field.hasDefault = true;
   field.defaultValue = std::move(defaultValue);
   field.options = std::move(options);
   field.hasMin = hasMin;
@@ -686,10 +687,20 @@ TEST_CASE("McpProtocol serves initialize, lists, all resources, and all read too
   REQUIRE(createObjectTool != nullptr);
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["items"]["type"] == "number");
   REQUIRE((*createObjectTool)["inputSchema"]["properties"]["position"]["minItems"] == 3);
+  REQUIRE((*createObjectTool)["inputSchema"]["properties"]["mode"]["enum"][0] == "preview");
   REQUIRE(listSchemaTool != nullptr);
   REQUIRE((*listSchemaTool)["inputSchema"]["properties"]["kind"]["enum"].size() == 3);
   REQUIRE(getSchemaTool != nullptr);
   REQUIRE((*getSchemaTool)["inputSchema"]["required"][0] == "name");
+  const json* deleteTool = nullptr;
+  for (const json& tool : toolList["result"]["tools"]) {
+    if (tool.value("name", std::string()) == "editor_delete") {
+      deleteTool = &tool;
+      break;
+    }
+  }
+  REQUIRE(deleteTool != nullptr);
+  REQUIRE((*deleteTool)["inputSchema"]["properties"]["previewToken"]["type"] == "string");
 
   const json resourceList = ProtocolRequest(protocol, "resources/list", json::object(), 4);
   REQUIRE(resourceList["result"]["resources"].size() == 11);
@@ -935,7 +946,7 @@ TEST_CASE("Editor MCP delete_asset reports managed file deletion details", "[mcp
   REQUIRE_FALSE(fs::exists(projectRoot / "assets" / "models" / "stone"));
 }
 
-TEST_CASE("McpProtocol dispatches every write tool and serializes success and failure", "[mcp][protocol]") {
+TEST_CASE("McpProtocol dispatches write tools and gates destructive apply behind previews", "[mcp][protocol]") {
   McpEditorSnapshot snapshot = MakeSnapshot();
   std::vector<std::string> invoked;
   McpProtocol protocol(McpProtocolContext{
@@ -949,7 +960,7 @@ TEST_CASE("McpProtocol dispatches every write tool and serializes success and fa
       {},
   });
 
-  const std::vector<std::pair<std::string, json>> writeTools = {
+  const std::vector<std::pair<std::string, json>> applyOnlyTools = {
       {"editor.select", json{{"id", "obj_root"}}},
       {"editor.clear_selection", json::object()},
       {"editor.create_object", json{{"type", "Prop"}, {"id", "spawned"}}},
@@ -959,28 +970,96 @@ TEST_CASE("McpProtocol dispatches every write tool and serializes success and fa
       {"editor.rename_object", json{{"id", "obj_root"}, {"newId", "obj_root_renamed"}}},
       {"editor.reparent_object", json{{"id", "obj_child"}, {"parentId", "obj_camera"}}},
       {"editor.duplicate", json{{"id", "obj_root"}, {"count", 2}}},
-      {"editor.delete", json{{"ids", json::array({"obj_light"})}}},
       {"editor.select_asset", json{{"id", "crate"}}},
       {"editor.update_asset", json{{"id", "crate"}, {"mesh", "assets/models/crate_v2.obj"}}},
+      {"editor.save_scene", json::object()},
+  };
+
+  for (size_t i = 0; i < applyOnlyTools.size(); ++i) {
+    const json response =
+        CallTool(protocol, applyOnlyTools[i].first, applyOnlyTools[i].second, 300 + static_cast<int>(i));
+    REQUIRE(response["result"]["structuredContent"]["handledTool"] == applyOnlyTools[i].first);
+    REQUIRE(response["result"]["structuredContent"]["echo"]["mode"] == "apply");
+  }
+
+  const std::vector<std::pair<std::string, json>> destructiveTools = {
+      {"editor.delete", json{{"ids", json::array({"obj_light"})}}},
       {"editor.delete_asset", json{{"id", "hero"}}},
       {"editor.new_scene", json{{"sceneId", "fresh"}, {"sceneName", "Fresh"}}},
-      {"editor.save_scene", json::object()},
       {"editor.reload_scene", json::object()},
   };
 
-  for (size_t i = 0; i < writeTools.size(); ++i) {
-    const json response = CallTool(protocol, writeTools[i].first, writeTools[i].second, 300 + static_cast<int>(i));
-    if (writeTools[i].first == "editor.delete_asset") {
+  for (size_t i = 0; i < destructiveTools.size(); ++i) {
+    json previewArguments = destructiveTools[i].second;
+    previewArguments["mode"] = "preview";
+    const json preview =
+        CallTool(protocol, destructiveTools[i].first, previewArguments, 400 + static_cast<int>(i));
+    REQUIRE(preview["result"]["structuredContent"]["mode"] == "preview");
+    REQUIRE(preview["result"]["structuredContent"]["previewToken"].is_string());
+
+    json applyArguments = destructiveTools[i].second;
+    applyArguments["mode"] = "apply";
+    applyArguments["previewToken"] = preview["result"]["structuredContent"]["previewToken"];
+    const json response =
+        CallTool(protocol, destructiveTools[i].first, applyArguments, 500 + static_cast<int>(i));
+    if (destructiveTools[i].first == "editor.delete_asset") {
       REQUIRE(response["error"]["message"] == "delete rejected");
       continue;
     }
-    REQUIRE(response["result"]["structuredContent"]["handledTool"] == writeTools[i].first);
-    REQUIRE(response["result"]["structuredContent"]["echo"] == writeTools[i].second);
+    REQUIRE(response["result"]["structuredContent"]["handledTool"] == destructiveTools[i].first);
+    REQUIRE(response["result"]["structuredContent"]["echo"]["mode"] == "apply");
+    REQUIRE(response["result"]["structuredContent"]["echo"]["previewToken"].is_string());
   }
 
-  REQUIRE(invoked.size() == writeTools.size());
+  REQUIRE(invoked.size() == applyOnlyTools.size() + destructiveTools.size());
   REQUIRE(invoked.front() == "editor.select");
   REQUIRE(invoked.back() == "editor.reload_scene");
+}
+
+TEST_CASE("McpProtocol validates schema-backed mutations and preview tokens before queueing",
+          "[mcp][protocol]") {
+  McpEditorSnapshot snapshot = MakeSnapshot();
+  std::vector<std::string> invoked;
+  McpProtocol protocol(McpProtocolContext{
+      [&snapshot]() { return CloneSnapshot(snapshot); },
+      [&invoked](const std::string& toolName, const json&) {
+        invoked.push_back(toolName);
+        return McpCommandResult{true, json{{"handledTool", toolName}}, {}};
+      },
+      {},
+  });
+
+  const json invalidEnum = CallTool(
+      protocol, "editor.create_object",
+      json{{"type", "Light"}, {"props", json{{"lightType", "spot"}}}}, 600);
+  REQUIRE(invalidEnum["error"]["message"] == "props.lightType must be one of: point, directional.");
+
+  const json invalidComponentRange =
+      CallTool(protocol, "editor.update_object",
+               json{{"id", "obj_root"},
+                    {"components", json::array({json{{"type", "light"},
+                                                     {"props", json{{"radius", 0.1}}}}})}},
+               601);
+  REQUIRE(invalidComponentRange["error"]["message"] ==
+          "components[0].props.radius must be >= 0.5000.");
+
+  const json deleteWithoutPreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}}, 602);
+  REQUIRE(deleteWithoutPreview["error"]["message"] == "previewToken is required for apply mode.");
+
+  const json deletePreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}, {"mode", "preview"}}, 603);
+  REQUIRE(deletePreview["result"]["structuredContent"]["preview"]["deletedCount"] == 1);
+  const std::string previewToken =
+      deletePreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+
+  const json deleteMismatchedApply = CallTool(
+      protocol, "editor.delete",
+      json{{"ids", json::array({"obj_root"})}, {"mode", "apply"}, {"previewToken", previewToken}}, 604);
+  REQUIRE(deleteMismatchedApply["error"]["message"] ==
+          "previewToken does not match the current scene state or arguments.");
+
+  REQUIRE(invoked.empty());
 }
 
 TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable paths", "[mcp][protocol]") {

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -442,6 +442,17 @@ json ParseBody(const McpHttpResponse& response) {
   return json::parse(response.body);
 }
 
+std::vector<json> ReadJsonLines(const std::filesystem::path& path) {
+  std::vector<json> lines;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty())
+      lines.push_back(json::parse(line));
+  }
+  return lines;
+}
+
 json ProtocolRequest(McpProtocol& protocol, const std::string& method, const json& params = json::object(), int id = 1) {
   const McpHttpResponse response = protocol.HandleHttp(
       McpHttpRequest{"POST", "/mcp", {}, json{{"jsonrpc", "2.0"}, {"id", id}, {"method", method}, {"params", params}}.dump()});
@@ -1060,6 +1071,77 @@ TEST_CASE("McpProtocol validates schema-backed mutations and preview tokens befo
           "previewToken does not match the current scene state or arguments.");
 
   REQUIRE(invoked.empty());
+}
+
+TEST_CASE("McpProtocol writes apply audit records to project root and fallback settings path",
+          "[mcp][protocol][audit]") {
+  namespace fs = std::filesystem;
+
+  EnvGuard env("horo_mcp_audit");
+  const fs::path projectRoot = env.tempHome / "project";
+  fs::create_directories(projectRoot / "assets");
+  {
+    std::ofstream presets(projectRoot / "CMakePresets.json");
+    presets << "{}";
+  }
+
+  McpEditorSnapshot snapshot = MakeSnapshot();
+  std::vector<std::string> invoked;
+  ProjectRootGuard projectRootGuard(projectRoot);
+  McpProtocol protocol(McpProtocolContext{
+      [&snapshot]() { return CloneSnapshot(snapshot); },
+      [&invoked](const std::string& toolName, const json&) {
+        invoked.push_back(toolName);
+        if (toolName == "editor.delete_asset")
+          return McpCommandResult{false, json::object(), "delete rejected"};
+        return McpCommandResult{true, json{{"handledTool", toolName}}, {}};
+      },
+      {},
+  });
+
+  const json deletePreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}, {"mode", "preview"}}, 700);
+  const std::string deleteToken =
+      deletePreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteApply =
+      CallTool(protocol, "editor.delete",
+               json{{"ids", json::array({"obj_light"})}, {"mode", "apply"}, {"previewToken", deleteToken}}, 701);
+  REQUIRE(deleteApply["result"]["structuredContent"]["handledTool"] == "editor.delete");
+
+  const json deleteAssetPreview =
+      CallTool(protocol, "editor.delete_asset", json{{"id", "hero"}, {"mode", "preview"}}, 702);
+  const std::string deleteAssetToken =
+      deleteAssetPreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteAssetApply =
+      CallTool(protocol, "editor.delete_asset",
+               json{{"id", "hero"}, {"mode", "apply"}, {"previewToken", deleteAssetToken}}, 703);
+  REQUIRE(deleteAssetApply["error"]["message"] == "delete rejected");
+
+  const fs::path auditPath = projectRoot / ".horo" / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(auditPath));
+  const std::vector<json> records = ReadJsonLines(auditPath);
+  REQUIRE(records.size() == 2);
+  REQUIRE(records[0]["tool"] == "editor.delete");
+  REQUIRE(records[0]["mode"] == "apply");
+  REQUIRE(records[0]["result"] == "success");
+  REQUIRE(records[0]["previewToken"] == deleteToken);
+  REQUIRE(records[0]["changedIds"][0] == "obj_light");
+  REQUIRE(records[1]["tool"] == "editor.delete_asset");
+  REQUIRE(records[1]["result"] == "error");
+  REQUIRE(records[1]["error"] == "delete rejected");
+  REQUIRE(records[1]["previewToken"] == deleteAssetToken);
+
+  invoked.clear();
+  ProjectRootGuard clearProjectRoot{std::filesystem::path()};
+  const json selectApply = CallTool(protocol, "editor.select", json{{"id", "obj_root"}}, 704);
+  REQUIRE(selectApply["result"]["structuredContent"]["handledTool"] == "editor.select");
+
+  const fs::path fallbackAuditPath = ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(fallbackAuditPath));
+  const std::vector<json> fallbackRecords = ReadJsonLines(fallbackAuditPath);
+  REQUIRE(fallbackRecords.size() == 1);
+  REQUIRE(fallbackRecords[0]["tool"] == "editor.select");
+  REQUIRE(fallbackRecords[0]["result"] == "success");
 }
 
 TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable paths", "[mcp][protocol]") {


### PR DESCRIPTION
## What changed
- enforce write-tool argument validation at the MCP protocol boundary
- add mode: preview|apply to write tools and require previewToken for destructive apply flows
- validate schema-backed object and component field values before commands reach the editor queue

## Why
Epic #55 needs safe, inspectable mutation flows so AI clients can preview destructive changes and get deterministic validation errors.

## Validation
- cmake --build --preset debug-msvc
- ctest --preset debug-msvc -C Debug --output-on-failure

## Stack
- Base branch: eat/55-59-mcp-schema-surface
- Next PR: #60 audit and workflow docs

Refs #57
Refs #55