### PR TITLE
[55/#60] Audit MCP apply workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ horo-engine/
 Horo Engine now ships with a built-in MCP server for the editor. Enable it from `File -> Settings...` in the editor and the server will auto-start on `http://127.0.0.1:39281/mcp` whenever the editor is open.
 
 User settings live in `~/.horo/settings.json` (Windows: `%USERPROFILE%\\.horo\\settings.json`). The MCP tab in the editor shows runtime status, recent requests, and copy-ready Claude/Codex configuration snippets.
+The recommended AI workflow is: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
+Apply-mode mutations also append audit records to `.horo/mcp-audit.jsonl` under the active project root
+when available.
 
 Integration details and token-minimal usage guidance live in [docs/mcp.md](/c:/Users/abdul/projects/fun/game/horo-engine/docs/mcp.md).
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -90,6 +90,8 @@ drives `assets/editor_schema.json`, including defaults, enum options, and numeri
 Write tools accept `mode: "preview" | "apply"`. Preview requests never mutate editor state and return
 a `previewToken`; destructive applies for `editor.delete`, `editor.delete_asset`, `editor.new_scene`,
 and `editor.reload_scene` require the matching token.
+Apply requests append audit records to `<project-root>/.horo/mcp-audit.jsonl`, or
+`~/.horo/mcp-audit.jsonl` when no project root is resolved.
 
 ## Claude Code
 
@@ -180,6 +182,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage guidance
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Prefer `scene.summary` before calling object-level tools.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/mcp/McpProtocol.cpp
+++ b/mcp/McpProtocol.cpp
@@ -5,9 +5,15 @@
 #include <chrono>
 #include <cctype>
 #include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <unordered_set>
+
+#include "core/ProjectPath.h"
+#include "mcp/McpSettings.h"
 
 namespace Monolith {
 namespace Mcp {
@@ -191,6 +197,113 @@ std::string FormatFloatText(double value) {
   std::ostringstream out;
   out << std::fixed << std::setprecision(4) << value;
   return out.str();
+}
+
+std::string FormatAuditTimestamp() {
+  using clock = std::chrono::system_clock;
+  const std::time_t now = clock::to_time_t(clock::now());
+  std::tm tmBuf{};
+#ifdef _WIN32
+  gmtime_s(&tmBuf, &now);
+#else
+  gmtime_r(&now, &tmBuf);
+#endif
+  char buffer[48];
+  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &tmBuf);
+  return buffer;
+}
+
+std::filesystem::path ResolveMcpAuditPath() {
+  namespace fs = std::filesystem;
+  const fs::path projectRoot = Monolith::ProjectPath::Root();
+  if (!projectRoot.empty()) {
+    std::error_code ec;
+    if (fs::exists(projectRoot, ec) && !ec)
+      return projectRoot / ".horo" / "mcp-audit.jsonl";
+  }
+  return ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+}
+
+json BuildChangedIds(const std::string& toolName, const json& arguments, const json& summary) {
+  json changedIds = json::array();
+  auto pushUnique = [&](const std::string& value) {
+    if (value.empty())
+      return;
+    for (const json& item : changedIds) {
+      if (item.is_string() && item.get<std::string>() == value)
+        return;
+    }
+    changedIds.push_back(value);
+  };
+
+  if (arguments.contains("id") && arguments["id"].is_string())
+    pushUnique(arguments["id"].get<std::string>());
+  if (arguments.contains("ids") && arguments["ids"].is_array()) {
+    for (const json& item : arguments["ids"]) {
+      if (item.is_string())
+        pushUnique(item.get<std::string>());
+    }
+  }
+  if (toolName == "editor.new_scene" && arguments.contains("sceneId") && arguments["sceneId"].is_string())
+    pushUnique(arguments["sceneId"].get<std::string>());
+
+  const std::vector<std::string> summaryKeys = {"created", "updated", "asset", "renamed", "duplicates"};
+  for (const std::string& key : summaryKeys) {
+    if (!summary.contains(key))
+      continue;
+    const json& value = summary[key];
+    if (value.is_object() && value.contains("id") && value["id"].is_string())
+      pushUnique(value["id"].get<std::string>());
+    if (value.is_array()) {
+      for (const json& item : value) {
+        if (item.is_object() && item.contains("id") && item["id"].is_string())
+          pushUnique(item["id"].get<std::string>());
+      }
+    }
+  }
+  for (const char* key : {"newId", "deletedAssetId", "sceneId"}) {
+    if (summary.contains(key) && summary[key].is_string())
+      pushUnique(summary[key].get<std::string>());
+  }
+
+  return changedIds;
+}
+
+void AppendMutationAuditRecord(const json& requestId,
+                               const McpEditorSnapshot& snapshot,
+                               const std::string& toolName,
+                               const std::string& mode,
+                               const json& arguments,
+                               bool ok,
+                               const json& summary,
+                               const std::string& errorText) {
+  namespace fs = std::filesystem;
+
+  const fs::path auditPath = ResolveMcpAuditPath();
+  std::error_code ec;
+  fs::create_directories(auditPath.parent_path(), ec);
+  if (ec)
+    return;
+
+  std::ofstream out(auditPath, std::ios::app);
+  if (!out.is_open())
+    return;
+
+  json record = {
+      {"timestamp", FormatAuditTimestamp()},
+      {"requestId", requestId.is_null() ? std::string() : JsonToCompactString(requestId)},
+      {"tool", toolName},
+      {"mode", mode},
+      {"previewToken", arguments.value("previewToken", std::string())},
+      {"sceneId", snapshot.sceneId},
+      {"sceneFilePath", snapshot.sceneFilePath},
+      {"result", ok ? "success" : "error"},
+      {"error", ok ? std::string() : errorText},
+      {"changedIds", BuildChangedIds(toolName, arguments, summary)},
+      {"summary", summary},
+  };
+
+  out << record.dump() << "\n";
 }
 
 bool TryParseFloatText(const std::string& text, double* out) {
@@ -1669,11 +1782,21 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     json normalizedArguments = json::object();
     if (!NormalizeWriteArguments(*snapshot, name, StripMutationControls(arguments), &normalizedArguments,
                                  &validationError)) {
+      if (mode == "apply") {
+        AppendMutationAuditRecord(id, *snapshot, name, mode, StripMutationControls(arguments), false,
+                                  json{{"arguments", StripMutationControls(arguments)}}, validationError);
+      }
       const json result = MakeError(id, -32602, validationError);
       finish("tool", name, method, id, false, 200, validationError, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
     normalizedArguments["mode"] = mode;
+
+    auto appendApplyAudit = [&](bool ok, const json& summary, const std::string& errorText) {
+      if (mode != "apply")
+        return;
+      AppendMutationAuditRecord(id, *snapshot, name, mode, normalizedArguments, ok, summary, errorText);
+    };
 
     auto storePreviewToken = [&](const json& canonicalArguments) {
       std::scoped_lock lock(m_previewMutex);
@@ -1721,6 +1844,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     if (IsDestructiveToolName(name)) {
       if (!arguments.contains("previewToken") || !arguments["previewToken"].is_string()) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                         "previewToken is required for apply mode.");
         const json result = MakeError(id, -32602, "previewToken is required for apply mode.");
         finish("tool", name, method, id, false, 200, "previewToken is required for apply mode.",
                &result, {});
@@ -1730,6 +1855,7 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
       std::string previewError;
       const json canonicalArguments = StripMutationControls(normalizedArguments);
       if (!consumePreviewToken(previewToken, canonicalArguments, &previewError)) {
+        appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, canonicalArguments), previewError);
         const json result = MakeError(id, -32602, previewError);
         finish("tool", name, method, id, false, 200, previewError, &result, {});
         return MakeJsonResponse(200, "OK", result);
@@ -1738,6 +1864,8 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
     }
 
     if (!m_context.commandInvoker) {
+      appendApplyAudit(false, BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments)),
+                       "Command queue unavailable.");
       const json result = MakeError(id, -32002, "Command queue unavailable.");
       finish("tool", name, method, id, false, 503, "Command queue unavailable.", &result, {});
       return MakeJsonResponse(503, "Service Unavailable", result);
@@ -1745,10 +1873,16 @@ McpHttpResponse McpProtocol::HandleHttp(const McpHttpRequest& request) const {
 
     const McpCommandResult commandResult = m_context.commandInvoker(name, normalizedArguments);
     if (!commandResult.ok) {
+      appendApplyAudit(false,
+                       commandResult.data.empty()
+                           ? BuildMutationPreviewPayload(*snapshot, name, StripMutationControls(normalizedArguments))
+                           : commandResult.data,
+                       commandResult.error);
       const json result = MakeError(id, -32010, commandResult.error);
       finish("tool", name, method, id, false, 200, commandResult.error, &result, {});
       return MakeJsonResponse(200, "OK", result);
     }
+    appendApplyAudit(true, commandResult.data, std::string());
     const json result = MakeSuccess(id, BuildTextToolResult(commandResult.data));
     finish("tool", name, method, id, true, 200, std::string(), &result, {});
     return MakeJsonResponse(200, "OK", result);

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,6 +88,8 @@ choices, and numeric bounds for object and component fields.
 Every write tool accepts `mode: "preview" | "apply"`. Preview calls never mutate the editor and return
 a `previewToken`; destructive apply calls for delete/new-scene/reload flows must present the matching
 token from the latest preview.
+Apply calls append JSONL audit entries to `<project-root>/.horo/mcp-audit.jsonl`, or to
+`ResolveMcpSettingsDirectory()/mcp-audit.jsonl` when no project root is available.
 
 For client compatibility, `tools/list` exposes these tool ids with underscores instead of dots
 (for example `editor_search`). The server continues to accept the dotted aliases as well.
@@ -249,6 +251,8 @@ code --add-mcp "{\"name\":\"horoEngine\",\"type\":\"http\",\"url\":\"http://127.
 - If Horo's port changes, update the VS Code MCP config and restart the server
 
 ## Token-minimal usage tips
+
+Recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit.
 
 - Ask for `scene.summary` first instead of broad object dumps.
 - Use `limit` + `offset` on `scene.objects`, `scene.hierarchy`, `assets.catalog`, and `console.recent`.

--- a/tests/test_mcp.cpp
+++ b/tests/test_mcp.cpp
@@ -442,6 +442,17 @@ json ParseBody(const McpHttpResponse& response) {
   return json::parse(response.body);
 }
 
+std::vector<json> ReadJsonLines(const std::filesystem::path& path) {
+  std::vector<json> lines;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty())
+      lines.push_back(json::parse(line));
+  }
+  return lines;
+}
+
 json ProtocolRequest(McpProtocol& protocol, const std::string& method, const json& params = json::object(), int id = 1) {
   const McpHttpResponse response = protocol.HandleHttp(
       McpHttpRequest{"POST", "/mcp", {}, json{{"jsonrpc", "2.0"}, {"id", id}, {"method", method}, {"params", params}}.dump()});
@@ -1060,6 +1071,77 @@ TEST_CASE("McpProtocol validates schema-backed mutations and preview tokens befo
           "previewToken does not match the current scene state or arguments.");
 
   REQUIRE(invoked.empty());
+}
+
+TEST_CASE("McpProtocol writes apply audit records to project root and fallback settings path",
+          "[mcp][protocol][audit]") {
+  namespace fs = std::filesystem;
+
+  EnvGuard env("horo_mcp_audit");
+  const fs::path projectRoot = env.tempHome / "project";
+  fs::create_directories(projectRoot / "assets");
+  {
+    std::ofstream presets(projectRoot / "CMakePresets.json");
+    presets << "{}";
+  }
+
+  McpEditorSnapshot snapshot = MakeSnapshot();
+  std::vector<std::string> invoked;
+  ProjectRootGuard projectRootGuard(projectRoot);
+  McpProtocol protocol(McpProtocolContext{
+      [&snapshot]() { return CloneSnapshot(snapshot); },
+      [&invoked](const std::string& toolName, const json&) {
+        invoked.push_back(toolName);
+        if (toolName == "editor.delete_asset")
+          return McpCommandResult{false, json::object(), "delete rejected"};
+        return McpCommandResult{true, json{{"handledTool", toolName}}, {}};
+      },
+      {},
+  });
+
+  const json deletePreview =
+      CallTool(protocol, "editor.delete", json{{"ids", json::array({"obj_light"})}, {"mode", "preview"}}, 700);
+  const std::string deleteToken =
+      deletePreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteApply =
+      CallTool(protocol, "editor.delete",
+               json{{"ids", json::array({"obj_light"})}, {"mode", "apply"}, {"previewToken", deleteToken}}, 701);
+  REQUIRE(deleteApply["result"]["structuredContent"]["handledTool"] == "editor.delete");
+
+  const json deleteAssetPreview =
+      CallTool(protocol, "editor.delete_asset", json{{"id", "hero"}, {"mode", "preview"}}, 702);
+  const std::string deleteAssetToken =
+      deleteAssetPreview["result"]["structuredContent"]["previewToken"].get<std::string>();
+  const json deleteAssetApply =
+      CallTool(protocol, "editor.delete_asset",
+               json{{"id", "hero"}, {"mode", "apply"}, {"previewToken", deleteAssetToken}}, 703);
+  REQUIRE(deleteAssetApply["error"]["message"] == "delete rejected");
+
+  const fs::path auditPath = projectRoot / ".horo" / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(auditPath));
+  const std::vector<json> records = ReadJsonLines(auditPath);
+  REQUIRE(records.size() == 2);
+  REQUIRE(records[0]["tool"] == "editor.delete");
+  REQUIRE(records[0]["mode"] == "apply");
+  REQUIRE(records[0]["result"] == "success");
+  REQUIRE(records[0]["previewToken"] == deleteToken);
+  REQUIRE(records[0]["changedIds"][0] == "obj_light");
+  REQUIRE(records[1]["tool"] == "editor.delete_asset");
+  REQUIRE(records[1]["result"] == "error");
+  REQUIRE(records[1]["error"] == "delete rejected");
+  REQUIRE(records[1]["previewToken"] == deleteAssetToken);
+
+  invoked.clear();
+  ProjectRootGuard clearProjectRoot{std::filesystem::path()};
+  const json selectApply = CallTool(protocol, "editor.select", json{{"id", "obj_root"}}, 704);
+  REQUIRE(selectApply["result"]["structuredContent"]["handledTool"] == "editor.select");
+
+  const fs::path fallbackAuditPath = ResolveMcpSettingsDirectory() / "mcp-audit.jsonl";
+  REQUIRE(fs::exists(fallbackAuditPath));
+  const std::vector<json> fallbackRecords = ReadJsonLines(fallbackAuditPath);
+  REQUIRE(fallbackRecords.size() == 1);
+  REQUIRE(fallbackRecords[0]["tool"] == "editor.select");
+  REQUIRE(fallbackRecords[0]["result"] == "success");
 }
 
 TEST_CASE("McpProtocol returns expected errors for unsupported or unavailable paths", "[mcp][protocol]") {


### PR DESCRIPTION
## What changed
- persist JSONL audit records for successful and failed apply-mode mutations
- write audit logs to <project-root>/.horo/mcp-audit.jsonl with a settings-directory fallback
- document the recommended AI workflow: inspect -> narrow query -> schema lookup -> preview -> apply -> audit

## Why
Epic #55 needs a durable audit trail and a documented operator workflow for production AI-assisted editor actions.

## Validation
- cmake --build --preset debug-msvc
- ctest --preset debug-msvc -C Debug --output-on-failure

## Stack
- Base branch: eat/55-57-mcp-safe-mutations
- Next PR: #55 rollup

Refs #60
Refs #55