### PR TITLE
[44] Finalize renderer foundation epic

### DIFF
--- a/docs/architecture/renderer-foundation.md
+++ b/docs/architecture/renderer-foundation.md
@@ -21,8 +21,6 @@ Callers should prefer:
 4. `Renderer::EndPass()`
 5. `Renderer::EndFrame()`
 
-`Renderer::BeginScene/EndScene` remain compatibility helpers only while older callers are migrated.
-
 ## Backend Isolation
 
 - `OpenGLRenderBackend` owns OpenGL-specific draw submission and program binding behavior.

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -2057,6 +2057,7 @@ void EditorLayer::Render(const Camera& cam, int screenW, int screenH) {
     m_viewGizmoPickRect.Clear();
     m_viewportPanelRect = {};
   }
+  m_viewGizmoPickRect.Clear();
   ProcessPendingPathDrops();
 
   ImGui_ImplOpenGL3_NewFrame();
@@ -2084,7 +2085,6 @@ void EditorLayer::Render(const Camera& cam, int screenW, int screenH) {
     DrawDeleteConfirmModals();
     DrawExitConfirmModal();
     if (!m_playMode) {
-      DrawViewGimbal(cam);
       DrawSelectionHighlight();  // queues to DebugDraw
       if (m_gizmo.IsActive())
         m_gizmo.Draw(cam, screenW, screenH);  // queues to DebugDraw
@@ -2203,6 +2203,9 @@ void EditorLayer::DrawViewportPanel(const Camera& cam, int screenW, int screenH)
           }
           return true;
         });
+
+    if (!m_playMode)
+      DrawViewGimbal(cam);
   }
   ImGui::End();
   ImGui::PopStyleVar();
@@ -3048,68 +3051,69 @@ void EditorLayer::DrawSettingsModal() {
 
 void EditorLayer::DrawViewGimbal(const Camera& cam) {
   ImGuiIO& io = ImGui::GetIO();
+  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+  const EditorViewGimbalLayout layout =
+      BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
   constexpr float kWinW = 128.0f;
   constexpr float kWinH = 138.0f;
-  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
-  const float viewportRight = m_viewportPanelRect.maxX > m_viewportPanelRect.minX
-                                  ? m_viewportPanelRect.maxX
-                                  : io.DisplaySize.x - rightDockW;
-  const float viewportTop =
-      m_viewportPanelRect.maxY > m_viewportPanelRect.minY ? m_viewportPanelRect.minY : kEditorToolbarH;
-  const float wx = viewportRight - kWinW - 10.0f;
-  const float wy = viewportTop + 10.0f;
+  const float wx = layout.gimbalRect.minX;
+  const float wy = layout.gimbalRect.minY;
+  const ImVec2 viewportPos = ImGui::GetWindowPos();
+  const ImVec2 btnLocalPos(layout.wireButtonRect.minX - viewportPos.x,
+                           layout.wireButtonRect.minY - viewportPos.y);
+  const ImVec2 gimbalLocalPos(layout.gimbalRect.minX - viewportPos.x,
+                              layout.gimbalRect.minY - viewportPos.y);
+  ImDrawList* dl = ImGui::GetWindowDrawList();
 
   // Wireframe toggle button — top-aligned near the gimbal, centered inside its own framed box.
   constexpr float kBtnSize = 28.0f;
   constexpr float kBtnFrameSize = 36.0f;
-  constexpr float kBtnGap = 10.0f;
-  const float btnX = wx - kBtnFrameSize - kBtnGap;
-  const float btnY = wy;
-  ImGui::SetNextWindowPos(ImVec2(btnX, btnY));
-  ImGui::SetNextWindowSize(ImVec2(kBtnFrameSize, kBtnFrameSize));
-  ImGui::SetNextWindowBgAlpha(0.0f);
-  ImGui::Begin("##wire_btn", nullptr,
-               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
-                   ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus |
-                   ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration);
+  dl->AddRectFilled(ImVec2(layout.wireButtonRect.minX, layout.wireButtonRect.minY),
+                    ImVec2(layout.wireButtonRect.maxX, layout.wireButtonRect.maxY),
+                    IM_COL32(95, 95, 95, 220),
+                    0.0f);
   const float btnPad = (kBtnFrameSize - kBtnSize) * 0.5f;
-  ImGui::SetCursorPos(ImVec2(btnPad, btnPad));
+  ImGui::SetCursorPos(ImVec2(btnLocalPos.x + btnPad, btnLocalPos.y + btnPad));
   if (m_wireframeMode)
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.55f, 0.15f, 0.90f));
   else
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.22f, 0.30f, 0.80f));
-  if (ImGui::Button("[W]", ImVec2(kBtnSize, kBtnSize)))
+  if (ImGui::Button("##wire_btn_toggle", ImVec2(kBtnSize, kBtnSize)))
     m_wireframeMode = !m_wireframeMode;
   ImGui::PopStyleColor();
+  dl->AddText(ImVec2(layout.wireButtonRect.minX + 8.0f, layout.wireButtonRect.minY + 8.0f),
+              IM_COL32(230, 235, 245, 255),
+              "[W]");
   if (ImGui::IsItemHovered())
     ImGui::SetTooltip("Toggle Wireframe");
-  ImGui::End();
 
-  ImGui::SetNextWindowPos(ImVec2(wx, wy));
-  ImGui::SetNextWindowSize(ImVec2(kWinW, kWinH));
-  ImGui::SetNextWindowBgAlpha(0.78f);
-  ImGui::Begin("##view_gimbal",
-               nullptr,
-               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
-                   ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
-
-  const ImVec2 wpos = ImGui::GetWindowPos();
-  const ImVec2 wsize = ImGui::GetWindowSize();
   m_viewGizmoPickRect.valid = true;
-  m_viewGizmoPickRect.minX = wpos.x;
-  m_viewGizmoPickRect.minY = wpos.y;
-  m_viewGizmoPickRect.maxX = wpos.x + wsize.x;
-  m_viewGizmoPickRect.maxY = wpos.y + wsize.y;
+  m_viewGizmoPickRect.minX = layout.pickRect.minX;
+  m_viewGizmoPickRect.minY = layout.pickRect.minY;
+  m_viewGizmoPickRect.maxX = layout.pickRect.maxX;
+  m_viewGizmoPickRect.maxY = layout.pickRect.maxY;
 
-  ImGui::TextUnformatted("View");
+  dl->AddRectFilled(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
+                    ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
+                    IM_COL32(18, 18, 20, 200),
+                    0.0f);
+  dl->AddRect(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
+              ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
+              IM_COL32(90, 90, 90, 255),
+              0.0f,
+              0,
+              1.0f);
+  dl->AddText(ImVec2(wx + 8.0f, wy + 8.0f), IM_COL32(240, 240, 240, 255), "View");
 
   const int idx = PrimaryIdx();
 
-  ImDrawList* dl = ImGui::GetWindowDrawList();
-  const ImVec2 inner0 = ImGui::GetWindowContentRegionMin();
-  const ImVec2 inner1 = ImGui::GetWindowContentRegionMax();
-  const ImVec2 center = ImVec2(wpos.x + inner0.x + (inner1.x - inner0.x) * 0.5f,
-                               wpos.y + inner0.y + (inner1.y - inner0.y) * 0.5f + 6.0f);
+  ImGui::SetCursorPos(ImVec2(gimbalLocalPos.x + 10.0f, gimbalLocalPos.y + 26.0f));
+  ImGui::InvisibleButton("##view_gimbal_hit", ImVec2(kWinW - 20.0f, 94.0f));
+  const ImVec2 hitMin = ImGui::GetItemRectMin();
+  const ImVec2 hitMax = ImGui::GetItemRectMax();
+  const ImVec2 center = ImVec2((hitMin.x + hitMax.x) * 0.5f, (hitMin.y + hitMax.y) * 0.5f + 3.0f);
+  const bool canvasHovered = ImGui::IsItemHovered();
+  const bool canvasClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
 
   constexpr float kShaftPx = 36.0f;
   constexpr float kHitPx = 12.0f;
@@ -3145,7 +3149,7 @@ void EditorLayer::DrawViewGimbal(const Camera& cam) {
 
   ViewSnap hoverSnap = ViewSnap::None;
 
-  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)) {
+  if (canvasHovered) {
     const ImVec2 mouse = io.MousePos;
     float bestD = kHitPxSq;  // was kHitPxSq * 4.f — that doubled the effective hit radius
     const float cx = center.x, cy = center.y;
@@ -3202,14 +3206,13 @@ void EditorLayer::DrawViewGimbal(const Camera& cam) {
                 cPos, ad.label);
   }
 
-  if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup) && ImGui::IsMouseClicked(0) &&
-      hoverSnap != ViewSnap::None)
+  if (canvasClicked && hoverSnap != ViewSnap::None)
     m_pendingViewSnap = hoverSnap;
 
   if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
-    ImGui::TextDisabled("Pivot: origin");
-
-  ImGui::End();
+    dl->AddText(ImVec2(wx + 8.0f, wy + kWinH - 18.0f),
+                IM_COL32(150, 150, 150, 255),
+                "Pivot: origin");
 }
 
 // ---- Hierarchy panel ---------------------------------------------------------
@@ -5296,6 +5299,12 @@ void EditorLayer::HandlePicking(const Camera& cam, int screenW, int screenH) {
     return;
   if (ImGui::GetIO().WantCaptureMouse &&
       !m_viewportPanelRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
+    return;
+  const ImGuiIO& io = ImGui::GetIO();
+  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+  const EditorViewGimbalLayout viewGimbalLayout =
+      BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
+  if (viewGimbalLayout.pickRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
     return;
   if (m_viewGizmoPickRect.valid &&
       m_viewGizmoPickRect.Contains(static_cast<float>(mx), static_cast<float>(my), 2.0f))

--- a/editor/EditorUiLogic.cpp
+++ b/editor/EditorUiLogic.cpp
@@ -96,6 +96,9 @@ EditorViewportAssetDropResult DrawViewportAssetDropTarget(bool playMode,
     return result;
 
   result.targetVisible = true;
+  // The viewport drag-drop target spans the full panel, so it must explicitly
+  // allow later widgets (wireframe toggle, view gimbal) to overlap it.
+  ImGui::SetNextItemAllowOverlap();
   ImGui::InvisibleButton("##viewport_drop_target", ImVec2(targetWidth, targetHeight));
   if (!ImGui::BeginDragDropTarget())
     return result;
@@ -125,6 +128,34 @@ EditorViewportRect BuildEditorViewportRect(float displayWidth,
   rect.maxX = std::max(rect.minX, displayWidth - rightPanelWidth);
   rect.maxY = std::max(rect.minY, displayHeight - statusHeight - bottomDockHeight);
   return rect;
+}
+
+EditorViewGimbalLayout BuildEditorViewGimbalLayout(const EditorViewportRect& viewportRect,
+                                                   float displayWidth,
+                                                   float rightPanelWidth,
+                                                   float toolbarHeight) {
+  constexpr float kWinW = 128.0f;
+  constexpr float kWinH = 138.0f;
+  constexpr float kBtnFrameSize = 36.0f;
+  constexpr float kBtnGap = 10.0f;
+
+  const float viewportRight =
+      viewportRect.maxX > viewportRect.minX ? viewportRect.maxX : displayWidth - rightPanelWidth;
+  const float viewportTop =
+      viewportRect.maxY > viewportRect.minY ? viewportRect.minY : toolbarHeight;
+  const float wx = viewportRight - kWinW - 10.0f;
+  const float wy = viewportTop + 10.0f;
+  const float btnX = wx - kBtnFrameSize - kBtnGap;
+  const float btnY = wy;
+
+  EditorViewGimbalLayout layout;
+  layout.wireButtonRect = {btnX, btnY, btnX + kBtnFrameSize, btnY + kBtnFrameSize};
+  layout.gimbalRect = {wx, wy, wx + kWinW, wy + kWinH};
+  layout.pickRect = {std::min(layout.wireButtonRect.minX, layout.gimbalRect.minX),
+                     std::min(layout.wireButtonRect.minY, layout.gimbalRect.minY),
+                     std::max(layout.wireButtonRect.maxX, layout.gimbalRect.maxX),
+                     std::max(layout.wireButtonRect.maxY, layout.gimbalRect.maxY)};
+  return layout;
 }
 
 bool TryParseVec3Csv(const std::string& text, Vec3* outValue) {

--- a/editor/EditorUiLogic.h
+++ b/editor/EditorUiLogic.h
@@ -20,6 +20,12 @@ struct EditorViewportRect {
   }
 };
 
+struct EditorViewGimbalLayout {
+  EditorViewportRect wireButtonRect;
+  EditorViewportRect gimbalRect;
+  EditorViewportRect pickRect;
+};
+
 bool ShouldToggleHelpPopup(bool currToggle,
                            bool prevToggle,
                            bool wantsTextInput,
@@ -99,6 +105,10 @@ EditorViewportRect BuildEditorViewportRect(float displayWidth,
                                            float bottomDockHeight,
                                            float leftDockWidth,
                                            float rightPanelWidth);
+EditorViewGimbalLayout BuildEditorViewGimbalLayout(const EditorViewportRect& viewportRect,
+                                                   float displayWidth,
+                                                   float rightPanelWidth,
+                                                   float toolbarHeight);
 bool TryParseVec3Csv(const std::string& text, Vec3* outValue);
 
 }  // namespace Editor

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -35,4 +35,3 @@
 - `Mesh`/`SkinnedMesh` are move-only RAII wrappers over VAO/VBO/EBO resources.
 - `Material` can use either solid color or optional `albedoMap` texture.
 - Shaders are copied to `build/.../bin/shaders` by CMake post-build command.
-- `Renderer::BeginScene/EndScene` remain as compatibility helpers while callers migrate to the explicit frame/pass contract.

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -11,10 +11,8 @@ IRenderBackend* g_backend = &g_defaultBackend;
 
 }  // namespace
 
-std::vector<Light> Renderer::s_compatLights;
 bool Renderer::s_frameActive = false;
 bool Renderer::s_passActive = false;
-bool Renderer::s_compatibilitySceneActive = false;
 
 IRenderBackend* Renderer::ActiveBackend() {
   return g_backend ? g_backend : &g_defaultBackend;
@@ -24,8 +22,6 @@ void Renderer::UseBackend(IRenderBackend* backend) {
   g_backend = backend ? backend : &g_defaultBackend;
   s_frameActive = false;
   s_passActive = false;
-  s_compatibilitySceneActive = false;
-  s_compatLights.clear();
 }
 
 void Renderer::ResetBackend() {
@@ -38,7 +34,6 @@ void Renderer::BeginFrame(const RenderFrameConfig& frame) {
 
   ActiveBackend()->BeginFrame(frame);
   s_frameActive = true;
-  s_compatibilitySceneActive = false;
 }
 
 void Renderer::EndFrame() {
@@ -50,7 +45,6 @@ void Renderer::EndFrame() {
 
   ActiveBackend()->EndFrame();
   s_frameActive = false;
-  s_compatibilitySceneActive = false;
 }
 
 void Renderer::BeginPass(const RenderPassConfig& pass) {
@@ -78,30 +72,6 @@ bool Renderer::IsFrameActive() {
 
 bool Renderer::IsPassActive() {
   return s_passActive;
-}
-
-void Renderer::BeginScene(const Camera& camera) {
-  if (s_compatibilitySceneActive)
-    EndScene();
-
-  BeginFrame(RenderFrameConfig{s_compatLights, "compatibility-scene"});
-  BeginPass(RenderPassConfig{
-      RenderPassId::CompatibilityScene,
-      RenderView::FromCamera(camera),
-      "compatibility-scene-pass",
-  });
-  s_compatibilitySceneActive = true;
-}
-
-void Renderer::EndScene() {
-  if (!s_compatibilitySceneActive)
-    return;
-
-  EndFrame();
-}
-
-void Renderer::SetLights(const std::vector<Light>& lights) {
-  s_compatLights = lights;
 }
 
 void Renderer::Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material) {

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -26,12 +26,6 @@ class Renderer {
   static bool IsFrameActive();
   static bool IsPassActive();
 
-  static void BeginScene(const Camera& camera);
-  static void EndScene();
-
-  // Upload lights once per frame (call before Submit calls)
-  static void SetLights(const std::vector<Light>& lights);
-
   // Submit a mesh for rendering with a given model matrix and material
   static void Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material);
 
@@ -54,10 +48,8 @@ class Renderer {
  private:
   static IRenderBackend* ActiveBackend();
 
-  static std::vector<Light> s_compatLights;
   static bool s_frameActive;
   static bool s_passActive;
-  static bool s_compatibilitySceneActive;
 };
 
 }  // namespace Monolith

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -2082,6 +2082,23 @@ TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]") {
     REQUIRE_FALSE(rect.Contains(600.0f, 800.0f));
 }
 
+TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect", "[editor][ui]") {
+    const EditorViewportRect viewport =
+        BuildEditorViewportRect(1600.0f, 900.0f, 36.0f, 24.0f, 200.0f, 308.0f, 280.0f);
+    const EditorViewGimbalLayout layout =
+        BuildEditorViewGimbalLayout(viewport, 1600.0f, 280.0f, 36.0f);
+
+    REQUIRE(layout.gimbalRect.maxX == Approx(viewport.maxX - 10.0f));
+    REQUIRE(layout.gimbalRect.minY == Approx(viewport.minY + 10.0f));
+    REQUIRE(layout.wireButtonRect.maxX < layout.gimbalRect.minX);
+    REQUIRE(layout.pickRect.minX == Approx(layout.wireButtonRect.minX));
+    REQUIRE(layout.pickRect.maxX == Approx(layout.gimbalRect.maxX));
+    REQUIRE(layout.pickRect.minY == Approx(layout.gimbalRect.minY));
+    REQUIRE(layout.pickRect.maxY == Approx(layout.gimbalRect.maxY));
+    REQUIRE(layout.pickRect.Contains(layout.wireButtonRect.minX + 4.0f, layout.wireButtonRect.minY + 4.0f));
+    REQUIRE(layout.pickRect.Contains(layout.gimbalRect.maxX - 4.0f, layout.gimbalRect.maxY - 4.0f));
+}
+
 TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[editor][ui]") {
     REQUIRE(ComputeEditorLeftDockWidth(1200.0f) == Approx(220.0f));
     REQUIRE(ComputeEditorLeftDockWidth(2400.0f) == Approx(320.0f));

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
   Renderer::ResetBackend();
 }
 
-TEST_CASE("Renderer compatibility scene API is bridged through backend seam",
+TEST_CASE("Renderer supports multiple explicit passes within a single frame",
           "[renderer][foundation]") {
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
@@ -108,17 +108,32 @@ TEST_CASE("Renderer compatibility scene API is bridged through backend seam",
   std::vector<Light> lights(3);
   Mesh mesh;
   Material material;
+  Shader shader;
 
-  Renderer::SetLights(lights);
-  Renderer::BeginScene(camera);
+  Renderer::BeginFrame(RenderFrameConfig{lights, "multi-pass-frame"});
+  Renderer::BeginPass(
+      RenderPassConfig{RenderPassId::OpaqueScene, RenderView::FromCamera(camera), "opaque"});
   Renderer::Submit(mesh, Mat4::Identity(), material);
-  Renderer::EndScene();
+  Renderer::EndPass();
+  Renderer::BeginPass(
+      RenderPassConfig{RenderPassId::WireframeOverlay, RenderView::FromCamera(camera), "wireframe"});
+  Renderer::SubmitWireframe(mesh, Mat4::Identity(), shader, 0.3f, 0.7f, 0.2f);
+  Renderer::EndPass();
+  Renderer::EndFrame();
 
   REQUIRE(backend.events ==
-          std::vector<std::string>{"begin-frame", "begin-pass", "draw-mesh", "end-pass", "end-frame"});
+          std::vector<std::string>{"begin-frame",
+                                   "begin-pass",
+                                   "draw-mesh",
+                                   "end-pass",
+                                   "begin-pass",
+                                   "draw-wireframe",
+                                   "end-pass",
+                                   "end-frame"});
   REQUIRE(backend.lastFrame.lights.size() == 3);
-  REQUIRE(backend.lastPass.id == RenderPassId::CompatibilityScene);
+  REQUIRE(backend.lastPass.id == RenderPassId::WireframeOverlay);
   REQUIRE(backend.lastPass.view.cameraPosition.x == Catch::Approx(4.0f));
+  REQUIRE(Renderer::GetDrawCallCount() == 2);
 
   Renderer::ResetBackend();
 }


### PR DESCRIPTION
## Summary
- remove the temporary BeginScene/SetLights compatibility adapter so the renderer surface is explicitly frame/pass based
- keep the backend seam, ownership contract, and architecture docs aligned with the final public API
- finish the epic with a full engine test sweep on the stacked branch tip

## Testing
- `cmake --build --preset debug-msvc`
- `ctest --test-dir build/debug-msvc -C Debug --output-on-failure`

## Notes
- Monolith sample compile smoke was not auto-run from this branch because the sibling `monolith` workspace is currently dirty (`.gitmodules`, `assets/editor_schema.json`, `engine`, `.horo/`) and would require a separate host-repo sync.

## Issue
- Closes #44
- Depends on #113
