### PR TITLE
ci: gate pull requests with starter integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,17 @@ jobs:
           name: coverage-report-${{ github.sha }}
           path: build/coverage/html
           retention-days: 30
+
+  # ----------------------------------------------------------------
+  # Starter integration — validates this PR branch inside the public
+  # consumer starter repo as the final CI gate for pull requests.
+  # ----------------------------------------------------------------
+  starter-integration:
+    name: Starter Integration
+    if: github.event_name == 'pull_request'
+    needs: [coverage]
+    uses: abdullahbodur/horo-engine-starter/.github/workflows/engine-test.yml@main
+    with:
+      engine_repository: ${{ github.repository }}
+      engine_ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a starter integration GitHub Actions job that runs only for pull requests
- use the public starter repository workflow as the final CI gate after coverage succeeds

## Motivation
- engine-only CI can stay green while a consuming starter project breaks
- this adds a real downstream validation step before merge without affecting non-PR events

## Validation
- [ ] Manual smoke tested if applicable
- [x] Workflow diff reviewed