### PR TITLE
ci(pr): run starter integration workflow as final gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,17 @@ jobs:
           name: coverage-report-${{ github.sha }}
           path: build/coverage/html
           retention-days: 30
+
+  # ----------------------------------------------------------------
+  # Starter integration — final PR gate.
+  # Validates this PR commit inside horo-engine-starter on all OS targets.
+  # ----------------------------------------------------------------
+  starter-integration:
+    name: Starter Integration
+    if: github.event_name == 'pull_request'
+    needs: [coverage]
+    uses: abdullahbodur/horo-engine-starter/.github/workflows/engine-test.yml@main
+    with:
+      engine_repository: ${{ github.repository }}
+      engine_ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a final starter-integration job to engine CI that runs only for pull requests
- call horo-engine-starter/.github/workflows/engine-test.yml@main with the current PR head SHA
- ensure starter repo validates this PR commit on Linux, Windows, and macOS after coverage passes

## Why
- verify real consumer integration before merging engine PRs
- catch submodule/consumer build breakages that engine-only CI cannot see