### PR TITLE
refactor(core): prepare window bootstrap for Vulkan backend parity

### DIFF
--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -1,7 +1,5 @@
 #include "core/Application.h"
 
-#include <glad/glad.h>
-
 #include <filesystem>
 #include <string_view>
 #include <system_error>
@@ -69,6 +67,7 @@ Application::Application(const AppSpec& spec) {
   ws.width = spec.width;
   ws.height = spec.height;
   ws.vsync = spec.vsync;
+  ws.graphicsApi = spec.graphicsApi;
 
   m_window = std::make_unique<Window>(ws);
   m_window->SetCloseCallback([this]() { m_running = false; });

--- a/core/Application.h
+++ b/core/Application.h
@@ -12,10 +12,12 @@ struct AppSpec {
   int width = 1280;
   int height = 720;
   bool vsync = true;
-  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
   // Repo-relative path to the main scene file (e.g. "assets/scenes/scene.json").
   // Resolved to an absolute path via ProjectPath at construction time.
   std::string defaultSceneFile;
+  // Kept after defaultSceneFile to preserve aggregate-initialization compatibility
+  // with existing starter/integration apps that pass scene path as the 5th field.
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
 };
 
 class Application {

--- a/core/Application.h
+++ b/core/Application.h
@@ -12,6 +12,7 @@ struct AppSpec {
   int width = 1280;
   int height = 720;
   bool vsync = true;
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
   // Repo-relative path to the main scene file (e.g. "assets/scenes/scene.json").
   // Resolved to an absolute path via ProjectPath at construction time.
   std::string defaultSceneFile;

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -15,14 +15,24 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   if (!glfwInit())
     throw std::runtime_error("glfwInit failed");
 
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  m_graphicsApi = spec.graphicsApi;
+  m_vsync = spec.vsync;
+
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #ifdef __APPLE__
-  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
 #endif
+  } else {
+    // Vulkan path: no client graphics context should be created by GLFW.
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  }
+
   glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-  glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
 
   m_window = glfwCreateWindow(spec.width, spec.height, spec.title.c_str(), nullptr, nullptr);
   if (!m_window) {
@@ -30,13 +40,18 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
     throw std::runtime_error("glfwCreateWindow failed");
   }
 
-  glfwMakeContextCurrent(m_window);
-  glfwSwapInterval(spec.vsync ? 1 : 0);
-
-  if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
-    glfwDestroyWindow(m_window);
-    glfwTerminate();
-    throw std::runtime_error("gladLoadGLLoader failed");
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+    glfwMakeContextCurrent(m_window);
+    if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
+      glfwDestroyWindow(m_window);
+      glfwTerminate();
+      throw std::runtime_error("gladLoadGLLoader failed");
+    }
+    SetVSync(spec.vsync);
+    LOG_INFO("OpenGL %s — %s", glGetString(GL_VERSION), glGetString(GL_RENDERER));
+  } else {
+    // Vulkan presentation pacing is backend-owned; the window stores the preference.
+    LOG_INFO("Window initialized for Vulkan backend (GLFW no-client-api surface).");
   }
 
   // Store this pointer for callbacks
@@ -44,8 +59,6 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   glfwSetFramebufferSizeCallback(m_window, FramebufferSizeCallback);
   glfwSetWindowCloseCallback(m_window, WindowCloseCallback);
   glfwSetDropCallback(m_window, DropPathsThunk);
-
-  LOG_INFO("OpenGL %s — %s", glGetString(GL_VERSION), glGetString(GL_RENDERER));
 }
 
 Window::~Window() {
@@ -57,12 +70,22 @@ Window::~Window() {
 void Window::PollEvents() {
   glfwPollEvents();
 }
+
 void Window::SwapBuffers() {
-  glfwSwapBuffers(m_window);
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwSwapBuffers(m_window);
 }
+
 bool Window::ShouldClose() const {
   return glfwWindowShouldClose(m_window);
 }
+
+void Window::SetVSync(bool enabled) {
+  m_vsync = enabled;
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwSwapInterval(enabled ? 1 : 0);
+}
+
 float Window::GetAspect() const {
   return m_height > 0 ? static_cast<float>(m_width) / m_height : 1.0f;
 }
@@ -83,7 +106,8 @@ void Window::FramebufferSizeCallback(GLFWwindow* win, int w, int h) {
   auto* self = static_cast<Window*>(glfwGetWindowUserPointer(win));
   self->m_width = w;
   self->m_height = h;
-  glViewport(0, 0, w, h);
+  if (self->m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glViewport(0, 0, w, h);
   if (self->m_resizeCb)
     self->m_resizeCb(w, h);
 }

--- a/core/Window.h
+++ b/core/Window.h
@@ -13,11 +13,19 @@ enum class CursorMode
     Disabled,
 };
 
+// Window-level graphics API preference used during platform/window bootstrap.
+// This lives in core so startup does not depend on renderer module headers.
+enum class WindowGraphicsApi {
+  OpenGL,
+  Vulkan,
+};
+
 struct WindowSpec {
   std::string title = "Monolith";
   int width = 1280;
   int height = 720;
   bool vsync = true;
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
 };
 
 class Window {
@@ -35,10 +43,13 @@ class Window {
   void PollEvents();
   void SwapBuffers();
   bool ShouldClose() const;
+  void SetVSync(bool enabled);
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
   float GetAspect() const;
+  bool IsVSyncEnabled() const { return m_vsync; }
+  WindowGraphicsApi GetGraphicsApi() const { return m_graphicsApi; }
 
   GLFWwindow* GetNativeHandle() const { return m_window; }
 
@@ -52,6 +63,8 @@ class Window {
   GLFWwindow* m_window = nullptr;
   int m_width = 0;
   int m_height = 0;
+  bool m_vsync = true;
+  WindowGraphicsApi m_graphicsApi = WindowGraphicsApi::OpenGL;
   ResizeCallback m_resizeCb;
   CloseCallback m_closeCb;
   FileDropCallback m_fileDropCb;

--- a/scene/STARTER_TEMPLATE.h
+++ b/scene/STARTER_TEMPLATE.h
@@ -36,9 +36,7 @@ namespace MyGame {
 // STEP 1: Create a minimal app class.
 class MyGameApp : public Monolith::Application {
  public:
-  MyGameApp() : Application(AppSpec{
-      "My Game", 1280, 720, true, "assets/scenes/level.json"
-  }) {}
+  MyGameApp() : Application(BuildAppSpec()) {}
 
   protected:
   // STEP 2: Setup (called once at startup).
@@ -88,6 +86,17 @@ class MyGameApp : public Monolith::Application {
   Monolith::Scene m_scene;
   std::unique_ptr<Monolith::SceneReferenceRuntime> m_referenceRuntime;
   Monolith::Camera m_camera;
+
+  static Monolith::AppSpec BuildAppSpec() {
+    Monolith::AppSpec spec;
+    spec.name = "My Game";
+    spec.width = 1280;
+    spec.height = 720;
+    spec.vsync = true;
+    spec.graphicsApi = Monolith::WindowGraphicsApi::OpenGL;
+    spec.defaultSceneFile = "assets/scenes/level.json";
+    return spec;
+  }
 
   void LoadSceneFromFile(const std::string& path) {
     const Monolith::Editor::SceneDocument doc = Monolith::Editor::SceneSerializer::LoadFromFile(path);


### PR DESCRIPTION
## Summary
- add a graphics API selector to `AppSpec`/`WindowSpec` so window bootstrap no longer assumes OpenGL-only startup
- split `Window` initialization into OpenGL and Vulkan-ready GLFW paths (`GLFW_NO_API` for non-OpenGL)
- guard swap interval, swap buffers, and resize viewport side effects behind API-aware checks while preserving OpenGL default behavior

## Motivation
- Vulkan backend integration needs a platform window path that can exist without creating an OpenGL client context
- this is the first prerequisite slice from the Vulkan parity plan and keeps current OpenGL behavior stable

## Implementation Notes
- OpenGL remains the default (`WindowGraphicsApi::OpenGL`) to avoid behavior drift for existing flows
- `Application` now threads graphics API intent into `WindowSpec`
- starter template moved to a builder helper to stay resilient as `AppSpec` evolves

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_renderer_foundation test_editor
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_renderer_foundation|test_editor"
```

## Risks / Follow-up
- `RenderContext`, debug utilities, and editor offscreen paths still carry OpenGL assumptions
- Vulkan presentation and resize handling are not implemented yet; this PR only prepares window/bootstrap seams