### PR TITLE
refactor(core): split window graphics ownership traits

### DIFF
--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -109,7 +109,8 @@ void Application::Run() {
     OnUpdate(Time::DeltaTime());
     OnRender(alpha);
 
-    m_window->SwapBuffers();
+    if (m_window->OwnsPresentation())
+      m_window->SwapBuffers();
   }
 
   OnShutdown();

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -11,14 +11,34 @@
 
 namespace Monolith {
 
+WindowGraphicsApiTraits GetWindowGraphicsApiTraits(WindowGraphicsApi graphicsApi) {
+  switch (graphicsApi) {
+    case WindowGraphicsApi::OpenGL:
+      return {.createsClientContext = true,
+              .windowOwnsPresentation = true,
+              .windowOwnsVSync = true,
+              .windowOwnsViewportResize = true,
+              .requestsMsaaSamples = true};
+    case WindowGraphicsApi::Vulkan:
+      return {.createsClientContext = false,
+              .windowOwnsPresentation = false,
+              .windowOwnsVSync = false,
+              .windowOwnsViewportResize = false,
+              .requestsMsaaSamples = false};
+  }
+
+  return {};
+}
+
 Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.height) {
   if (!glfwInit())
     throw std::runtime_error("glfwInit failed");
 
   m_graphicsApi = spec.graphicsApi;
   m_vsync = spec.vsync;
+  const WindowGraphicsApiTraits traits = GetGraphicsApiTraits();
 
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+  if (traits.createsClientContext) {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -31,7 +51,7 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   }
 
   glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (traits.requestsMsaaSamples)
     glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
 
   m_window = glfwCreateWindow(spec.width, spec.height, spec.title.c_str(), nullptr, nullptr);
@@ -40,7 +60,7 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
     throw std::runtime_error("glfwCreateWindow failed");
   }
 
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+  if (traits.createsClientContext) {
     glfwMakeContextCurrent(m_window);
     if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
       glfwDestroyWindow(m_window);
@@ -72,7 +92,7 @@ void Window::PollEvents() {
 }
 
 void Window::SwapBuffers() {
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (OwnsPresentation())
     glfwSwapBuffers(m_window);
 }
 
@@ -82,12 +102,28 @@ bool Window::ShouldClose() const {
 
 void Window::SetVSync(bool enabled) {
   m_vsync = enabled;
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (OwnsVSync())
     glfwSwapInterval(enabled ? 1 : 0);
 }
 
 float Window::GetAspect() const {
   return m_height > 0 ? static_cast<float>(m_width) / m_height : 1.0f;
+}
+
+WindowGraphicsApiTraits Window::GetGraphicsApiTraits() const {
+  return Monolith::GetWindowGraphicsApiTraits(m_graphicsApi);
+}
+
+bool Window::OwnsPresentation() const {
+  return GetGraphicsApiTraits().windowOwnsPresentation;
+}
+
+bool Window::OwnsVSync() const {
+  return GetGraphicsApiTraits().windowOwnsVSync;
+}
+
+bool Window::OwnsViewportResize() const {
+  return GetGraphicsApiTraits().windowOwnsViewportResize;
 }
 
 void Window::SetCursorMode(CursorMode mode)
@@ -106,7 +142,7 @@ void Window::FramebufferSizeCallback(GLFWwindow* win, int w, int h) {
   auto* self = static_cast<Window*>(glfwGetWindowUserPointer(win));
   self->m_width = w;
   self->m_height = h;
-  if (self->m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (self->OwnsViewportResize())
     glViewport(0, 0, w, h);
   if (self->m_resizeCb)
     self->m_resizeCb(w, h);

--- a/core/Window.h
+++ b/core/Window.h
@@ -20,6 +20,16 @@ enum class WindowGraphicsApi {
   Vulkan,
 };
 
+struct WindowGraphicsApiTraits {
+  bool createsClientContext = false;
+  bool windowOwnsPresentation = false;
+  bool windowOwnsVSync = false;
+  bool windowOwnsViewportResize = false;
+  bool requestsMsaaSamples = false;
+};
+
+WindowGraphicsApiTraits GetWindowGraphicsApiTraits(WindowGraphicsApi graphicsApi);
+
 struct WindowSpec {
   std::string title = "Monolith";
   int width = 1280;
@@ -50,6 +60,10 @@ class Window {
   float GetAspect() const;
   bool IsVSyncEnabled() const { return m_vsync; }
   WindowGraphicsApi GetGraphicsApi() const { return m_graphicsApi; }
+  WindowGraphicsApiTraits GetGraphicsApiTraits() const;
+  bool OwnsPresentation() const;
+  bool OwnsVSync() const;
+  bool OwnsViewportResize() const;
 
   GLFWwindow* GetNativeHandle() const { return m_window; }
 

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -5,8 +5,10 @@
 #include <cstring>
 #include <filesystem>
 
+#include "core/Application.h"
 #include "core/Logger.h"
 #include "core/ProjectPath.h"
+#include "core/Window.h"
 #include "math/MathUtils.h"
 
 using namespace Monolith;
@@ -67,6 +69,36 @@ TEST_CASE("Logger: mixed formatted arguments are handled", "[logger]") {
 TEST_CASE("ProjectPath: Init accepts empty path", "[core][projectpath]") {
     ProjectPath::Init(std::filesystem::path{});
     REQUIRE(ProjectPath::Root().empty());
+}
+
+TEST_CASE("WindowGraphicsApiTraits: OpenGL keeps window-owned presentation behavior",
+          "[core][window]") {
+    const WindowGraphicsApiTraits traits = GetWindowGraphicsApiTraits(WindowGraphicsApi::OpenGL);
+
+    REQUIRE(traits.createsClientContext);
+    REQUIRE(traits.windowOwnsPresentation);
+    REQUIRE(traits.windowOwnsVSync);
+    REQUIRE(traits.windowOwnsViewportResize);
+    REQUIRE(traits.requestsMsaaSamples);
+}
+
+TEST_CASE("WindowGraphicsApiTraits: Vulkan leaves presentation and resize to the backend",
+          "[core][window]") {
+    const WindowGraphicsApiTraits traits = GetWindowGraphicsApiTraits(WindowGraphicsApi::Vulkan);
+
+    REQUIRE_FALSE(traits.createsClientContext);
+    REQUIRE_FALSE(traits.windowOwnsPresentation);
+    REQUIRE_FALSE(traits.windowOwnsVSync);
+    REQUIRE_FALSE(traits.windowOwnsViewportResize);
+    REQUIRE_FALSE(traits.requestsMsaaSamples);
+}
+
+TEST_CASE("AppSpec: aggregate initialization keeps scene path compatibility", "[core][application]") {
+    const AppSpec spec{"Compat App", 1280, 720, true, "assets/scenes/starter_world.json"};
+
+    REQUIRE(spec.name == "Compat App");
+    REQUIRE(spec.defaultSceneFile == "assets/scenes/starter_world.json");
+    REQUIRE(spec.graphicsApi == WindowGraphicsApi::OpenGL);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- introduce explicit `WindowGraphicsApiTraits` so window bootstrap states which graphics API owns client context creation, presentation, vsync, viewport resize, and MSAA hints
- route `Window` startup/runtime behavior and the main `Application` loop through those ownership traits instead of OpenGL-specific checks scattered inline
- add core regressions that lock the OpenGL and Vulkan ownership model and preserve `AppSpec` aggregate initialization compatibility for downstream starter apps

## Motivation
- PR #118 started the OpenGL/Vulkan bootstrap split, but ownership rules for present, vsync, and resize behavior were still implicit in `Window.cpp`
- issue #123 needs those boundaries to be explicit and testable before `RenderContext` and later Vulkan backend work continue

## Implementation Notes
- OpenGL remains window-owned for presentation, vsync, resize viewport updates, and MSAA sample requests
- Vulkan is modeled as backend-owned for those behaviors, leaving `Window` responsible only for platform window creation and event dispatch
- `Application::Run()` now reflects that split by only calling `SwapBuffers()` when the active window path owns presentation

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_core test_renderer_foundation test_editor
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_core|test_renderer_foundation|test_editor"
```

## Issue Links
- Refs #123
- Parent epic: #119

## Stack Notes
- base branch: `feat/120-vulkan-parity-scope`
- stacked on top of PR #132 and rooted in PR #118