### PR TITLE
refactor(renderer): hide OpenGL payloads behind resource storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
     option(MONOLITH_ENGINE_BUILD_TESTS "Build engine unit tests" ON)
+    option(MONOLITH_ENGINE_ENABLE_VULKAN "Fetch Vulkan headers/loader and compile Vulkan backend scaffolding" OFF)
 
     if(MSVC)
         add_compile_options(/W4 /WX /Zc:preprocessor)
@@ -60,6 +61,11 @@ target_link_libraries(MonolithEngine
         nlohmann_json::nlohmann_json
         tinygltf
 )
+
+if(MONOLITH_ENGINE_ENABLE_VULKAN)
+    target_link_libraries(MonolithEngine PUBLIC monolith_volk monolith_vulkan_headers)
+    target_compile_definitions(MonolithEngine PUBLIC MONOLITH_HAS_VULKAN=1)
+endif()
 
 if(APPLE)
     target_link_libraries(MonolithEngine PUBLIC "-framework OpenGL")

--- a/core/Screenshot.cpp
+++ b/core/Screenshot.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "core/Logger.h"
+#include "renderer/Renderer.h"
 
 namespace Monolith {
 
@@ -73,6 +74,11 @@ static bool WriteBMP(const std::string& path, int w, int h, const std::vector<ui
 std::string Screenshot::Save(int w, int h, const std::string& folder) {
   if (w <= 0 || h <= 0)
     return {};
+
+  if (!Renderer::GetBackendCapabilities().supportsReadback) {
+    LOG_WARN("Screenshot: active render backend does not support readback capture.");
+    return {};
+  }
 
   // Read framebuffer — GL_BGR so bytes land in BMP order directly
   std::vector<uint8_t> pixels(static_cast<size_t>(w * h * 3));

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -993,6 +993,10 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 // meshKey must be the resolved mesh path (same key used in meshCache).
 static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
                                           const std::string& meshKey) {
+  const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+  if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
+    return 0;
+
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
@@ -1090,6 +1094,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
     return false;
 
   auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+    if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
+      return 0;
     if (path.empty())
       return 0;
     std::error_code ec;
@@ -3052,6 +3058,9 @@ void EditorLayer::DrawSettingsModal() {
 void EditorLayer::DrawViewGimbal(const Camera& cam) {
   ImGuiIO& io = ImGui::GetIO();
   const EditorViewGimbalMetrics& metrics = GetEditorViewGimbalMetrics();
+  const bool supportsWireframeOverlay = Renderer::GetBackendCapabilities().supportsWireframeOverlay;
+  if (!supportsWireframeOverlay)
+    m_wireframeMode = false;
   const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
   const EditorViewGimbalLayout layout =
       BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
@@ -3075,15 +3084,23 @@ void EditorLayer::DrawViewGimbal(const Camera& cam) {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.55f, 0.15f, 0.90f));
   else
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.22f, 0.30f, 0.80f));
+  if (!supportsWireframeOverlay)
+    ImGui::BeginDisabled();
   if (ImGui::Button("##wire_btn_toggle", ImVec2(metrics.buttonSize, metrics.buttonSize)))
     m_wireframeMode = !m_wireframeMode;
+  if (!supportsWireframeOverlay)
+    ImGui::EndDisabled();
   ImGui::PopStyleColor();
   dl->AddText(ImVec2(layout.wireButtonRect.minX + metrics.titleOffsetX,
                      layout.wireButtonRect.minY + metrics.titleOffsetY),
               IM_COL32(230, 235, 245, 255),
               "[W]");
-  if (ImGui::IsItemHovered())
-    ImGui::SetTooltip("Toggle Wireframe");
+  if (ImGui::IsItemHovered()) {
+    if (supportsWireframeOverlay)
+      ImGui::SetTooltip("Toggle Wireframe");
+    else
+      ImGui::SetTooltip("Wireframe overlay is unavailable on the active render backend");
+  }
 
   m_viewGizmoPickRect.valid = true;
   m_viewGizmoPickRect.minX = layout.pickRect.minX;
@@ -6869,6 +6886,11 @@ void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
 // ---- Wireframe overlay -------------------------------------------------------
 
 void EditorLayer::DrawWireframeOverlay(const Camera& cam) {
+  if (!Renderer::GetBackendCapabilities().supportsWireframeOverlay) {
+    m_wireframeMode = false;
+    return;
+  }
+
   if (!m_wireframeMode || !m_wireframeShader.IsValid())
     return;
 

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -991,21 +991,21 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 
 // Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
 // meshKey must be the resolved mesh path (same key used in meshCache).
-static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
-                                          const std::string& meshKey) {
+static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
+                                                const std::string& meshKey) {
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
-    return 0;
+    return {};
 
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
   auto cacheIt = renderer.renderedTextureCache.find(meshKey);
   if (cacheIt != renderer.renderedTextureCache.end())
-    return cacheIt->second;
+    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
 
   if (!renderer.IsValid())
-    return 0;
+    return {};
 
   // Save GL state (viewport)
   GLint prevViewport[4] = {0, 0, 1, 1};
@@ -1072,18 +1072,15 @@ static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMe
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
 
-  return destTex;
+  return RenderTargetHandle::OpenGLTexture(destTex, true);
 }
 
-static bool TryGetAssetPreviewTextureId(const std::string& assetId,
-                                        const AssetDef& asset,
-                                        unsigned int* outTextureId,
-                                        bool* outNeedsYFlip = nullptr) {
-  if (!outTextureId)
+static bool TryGetAssetPreviewHandle(const std::string& assetId,
+                                     const AssetDef& asset,
+                                     RenderTargetHandle* outHandle) {
+  if (!outHandle)
     return false;
-  *outTextureId = 0;
-  if (outNeedsYFlip)
-    *outNeedsYFlip = false;
+  *outHandle = {};
 
   static std::unordered_map<std::string, Texture> s_textureByPath;
   static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
@@ -1093,14 +1090,14 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
     return false;
 
-  auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+  auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
     if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
-      return 0;
+      return {};
     if (path.empty())
-      return 0;
+      return {};
     std::error_code ec;
     if (!std::filesystem::is_regular_file(path, ec) || ec)
-      return 0;
+      return {};
     const std::string abs = path.generic_string();
     auto it = s_textureByPath.find(abs);
     if (it == s_textureByPath.end()) {
@@ -1108,8 +1105,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       it = s_textureByPath.emplace(abs, std::move(tex)).first;
     }
     if (!it->second.IsValid())
-      return 0;
-    return it->second.GetNativeId();
+      return {};
+    return it->second.GetRenderTargetHandle();
   };
 
   // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
@@ -1119,13 +1116,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {
         const std::string meshKey =
             ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
-        const unsigned int texId = RenderMeshToThumbnail(*meshEntry, meshKey);
-        if (texId != 0) {
-          *outTextureId = texId;
-          // OpenGL FBO textures have origin at bottom-left; ImGui expects top-left.
-          // Caller must flip Y UVs when displaying this texture.
-          if (outNeedsYFlip)
-            *outNeedsYFlip = true;
+        const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
+        if (handle.IsValid()) {
+          *outHandle = handle;
           return true;
         }
       }
@@ -1135,9 +1128,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   // Priority 2: Fallback to texture-based thumbnails
   if (!asset.albedoMap.empty()) {
     const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
-    const unsigned int texId = loadTextureByPath(albedo);
-    if (texId != 0) {
-      *outTextureId = texId;
+    const RenderTargetHandle handle = loadTextureByPath(albedo);
+    if (handle.IsValid()) {
+      *outHandle = handle;
       return true;
     }
   }
@@ -1148,9 +1141,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
 
     if (ext == ".obj") {
       const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
-      const unsigned int texId = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
-      if (texId != 0) {
-        *outTextureId = texId;
+      const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
+      if (handle.IsValid()) {
+        *outHandle = handle;
         return true;
       }
     }
@@ -1164,7 +1157,7 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
           it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
       }
       if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid()) {
-        *outTextureId = it->second->GetNativeId();
+        *outHandle = it->second->GetRenderTargetHandle();
         return true;
       }
     }
@@ -1174,8 +1167,10 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   return false;
 }
 
-static ImTextureID ToImTextureId(unsigned int textureId) {
-  return (ImTextureID)(intptr_t)textureId;
+static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
+  if (!handle.IsValid() || handle.nativeType != RenderNativeHandleType::OpenGLTexture2D)
+    return (ImTextureID)0;
+  return (ImTextureID)(intptr_t)handle.nativeHandle;
 }
 
 std::string PickTextureFilePath() {
@@ -3932,12 +3927,11 @@ void EditorLayer::DrawAssetsPanel() {
                       6.0f);
     dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
 
-    unsigned int previewTexId = 0;
-    bool previewNeedsYFlip = false;
-    if (TryGetAssetPreviewTextureId(assetId, asset, &previewTexId, &previewNeedsYFlip) && previewTexId != 0) {
-      const ImVec2 uv0 = previewNeedsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
-      const ImVec2 uv1 = previewNeedsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
-      dl->AddImage(ToImTextureId(previewTexId), thumbMin, thumbMax, uv0, uv1);
+    RenderTargetHandle previewHandle;
+    if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid()) {
+      const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
+      const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
+      dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
     } else {
       const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
       const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "input/Input.h"
+#include "renderer/Renderer.h"
 #include "input/KeyCodes.h"
 
 // Windows headers (pulled in by glad) define DrawText as DrawTextA — undefine to avoid collision
@@ -1237,6 +1238,12 @@ void DebugHUD::Init(int screenW, int screenH) {
   s_screenW = screenW;
   s_screenH = screenH;
 
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud) {
+    s_initialized = false;
+    s_visible = false;
+    return;
+  }
+
   s_shader = std::make_unique<Shader>(Shader::FromSource(HUD_VERT, HUD_FRAG));
 
   BuildFontAtlas();
@@ -1343,6 +1350,9 @@ void DebugHUD::SubmitWorldLabel(const Vec3& worldPos, const Mat4& vp, const char
 // ---- Update ----
 
 void DebugHUD::Update(float dt, const HUDStats& stats) {
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud)
+    return;
+
   if (Input::IsKeyPressed(Key::F3))
     s_visible = !s_visible;
   if (Input::IsKeyPressed(Key::F4))
@@ -1377,6 +1387,8 @@ void DebugHUD::Update(float dt, const HUDStats& stats) {
 // ---- Render ----
 
 void DebugHUD::Render() {
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud)
+    return;
   if (!s_initialized)
     return;
   const bool forceNoCameraOverlay = s_stats.showNoCameraOverlay;

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -4,50 +4,59 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <utility>
 
 #include "math/MathUtils.h"
 
 namespace Monolith {
 
+struct Mesh::GpuStorage {
+  unsigned int vao = 0;
+  unsigned int vbo = 0;
+  unsigned int ebo = 0;
+};
+
+Mesh::Mesh() = default;
+
 Mesh::~Mesh() {
   Release();
 }
 
 Mesh::Mesh(Mesh&& o) noexcept
-    : m_vao(o.m_vao),
-      m_vbo(o.m_vbo),
-      m_ebo(o.m_ebo),
+    : m_gpu(std::move(o.m_gpu)),
       m_indexCount(o.m_indexCount),
       m_halfExtents(o.m_halfExtents),
       m_localAabbCenter(o.m_localAabbCenter) {
-  o.m_vao = o.m_vbo = o.m_ebo = 0;
   o.m_indexCount = 0;
 }
 
 Mesh& Mesh::operator=(Mesh&& o) noexcept {
   if (this != &o) {
     Release();
-    m_vao = o.m_vao;
-    m_vbo = o.m_vbo;
-    m_ebo = o.m_ebo;
+    m_gpu = std::move(o.m_gpu);
     m_indexCount = o.m_indexCount;
     m_halfExtents = o.m_halfExtents;
     m_localAabbCenter = o.m_localAabbCenter;
-    o.m_vao = o.m_vbo = o.m_ebo = 0;
     o.m_indexCount = 0;
   }
   return *this;
 }
 
+bool Mesh::IsValid() const {
+  return m_gpu && m_gpu->vao != 0;
+}
+
 void Mesh::Release() {
-  if (m_ebo)
-    glDeleteBuffers(1, &m_ebo);
-  if (m_vbo)
-    glDeleteBuffers(1, &m_vbo);
-  if (m_vao)
-    glDeleteVertexArrays(1, &m_vao);
-  m_vao = m_vbo = m_ebo = 0;
+  if (m_gpu) {
+    if (m_gpu->ebo)
+      glDeleteBuffers(1, &m_gpu->ebo);
+    if (m_gpu->vbo)
+      glDeleteBuffers(1, &m_gpu->vbo);
+    if (m_gpu->vao)
+      glDeleteVertexArrays(1, &m_gpu->vao);
+    m_gpu.reset();
+  }
   m_indexCount = 0;
 }
 
@@ -74,19 +83,20 @@ void Mesh::SetData(const std::vector<Vertex>& vertices, const std::vector<unsign
 
 void Mesh::Upload(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices) {
   m_indexCount = static_cast<int>(indices.size());
+  m_gpu = std::make_unique<GpuStorage>();
 
-  glGenVertexArrays(1, &m_vao);
-  glBindVertexArray(m_vao);
+  glGenVertexArrays(1, &m_gpu->vao);
+  glBindVertexArray(m_gpu->vao);
 
-  glGenBuffers(1, &m_vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+  glGenBuffers(1, &m_gpu->vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
   glBufferData(GL_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(vertices.size() * sizeof(Vertex)),
                vertices.data(),
                GL_STATIC_DRAW);
 
-  glGenBuffers(1, &m_ebo);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ebo);
+  glGenBuffers(1, &m_gpu->ebo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
                indices.data(),
@@ -130,7 +140,9 @@ void Mesh::Upload(const std::vector<Vertex>& vertices, const std::vector<unsigne
 }
 
 void Mesh::Draw() const {
-  glBindVertexArray(m_vao);
+  if (!m_gpu)
+    return;
+  glBindVertexArray(m_gpu->vao);
   glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
   glBindVertexArray(0);
 }

--- a/renderer/Mesh.h
+++ b/renderer/Mesh.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <vector>
 
 #include "math/Vec2.h"
@@ -14,7 +15,7 @@ struct Vertex {
 
 class Mesh {
  public:
-  Mesh() = default;
+  Mesh();
   ~Mesh();
 
   Mesh(const Mesh&) = delete;
@@ -26,7 +27,7 @@ class Mesh {
   void Draw() const;
   void DrawWireframe() const;
 
-  bool IsValid() const { return m_vao != 0; }
+  bool IsValid() const;
   int GetIndexCount() const { return m_indexCount; }
   Vec3 GetHalfExtents() const { return m_halfExtents; }
   Vec3 GetLocalAabbCenter() const { return m_localAabbCenter; }
@@ -40,9 +41,8 @@ class Mesh {
   static Mesh CreateQuad();
 
  private:
-  unsigned int m_vao = 0;
-  unsigned int m_vbo = 0;
-  unsigned int m_ebo = 0;
+  struct GpuStorage;
+  std::unique_ptr<GpuStorage> m_gpu;
   int m_indexCount = 0;
   Vec3 m_halfExtents = {0.5f, 0.5f, 0.5f};
   Vec3 m_localAabbCenter = Vec3::Zero();

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -41,7 +41,11 @@ bool IsRenderBackendSupported(RenderBackendId backendId) {
     case RenderBackendId::OpenGL:
       return true;
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      return true;
+#else
       return false;
+#endif
     case RenderBackendId::Auto:
       break;
   }

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -26,6 +26,10 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
     case RenderBackendId::OpenGL:
       return {.supportsWireframeOverlay = true,
               .supportsDebugLabels = false,
+              .supportsOffscreenTargets = true,
+              .supportsNativeTextureHandles = true,
+              .supportsReadback = true,
+              .supportsDebugHud = true,
               .supportsComputePasses = false,
               .supportsGpuTimestamps = false,
               .supportsBindlessResources = false};

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -20,6 +20,7 @@ struct RenderBackendCapabilities {
 
 struct RenderBackendSelection {
   RenderBackendId requested = RenderBackendId::Auto;
+  void* nativeWindowHandle = nullptr;
 };
 
 struct RenderBackendInitResult {

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -13,6 +13,10 @@ enum class RenderBackendId {
 struct RenderBackendCapabilities {
   bool supportsWireframeOverlay = false;
   bool supportsDebugLabels = false;
+  bool supportsOffscreenTargets = false;
+  bool supportsNativeTextureHandles = false;
+  bool supportsReadback = false;
+  bool supportsDebugHud = false;
   bool supportsComputePasses = false;
   bool supportsGpuTimestamps = false;
   bool supportsBindlessResources = false;

--- a/renderer/RenderBackendFactory.cpp
+++ b/renderer/RenderBackendFactory.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "renderer/OpenGLRenderBackend.h"
+#include "renderer/VulkanRenderBackend.h"
 
 namespace Monolith {
 
@@ -12,9 +13,24 @@ RenderBackendCreateResult CreateRenderBackend(const RenderBackendSelection& sele
     case RenderBackendId::OpenGL:
       return {std::make_unique<OpenGLRenderBackend>(), RenderBackendId::OpenGL, {}};
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+    {
+      std::unique_ptr<VulkanRenderBackend> backend =
+          std::make_unique<VulkanRenderBackend>(selection.nativeWindowHandle);
+      if (!backend->IsInitialized()) {
+        return {nullptr,
+                RenderBackendId::Vulkan,
+                backend->GetLastError().empty()
+                    ? std::string("Vulkan backend initialization failed.")
+                    : backend->GetLastError()};
+      }
+      return {std::move(backend), RenderBackendId::Vulkan, {}};
+    }
+#else
       return {nullptr,
               RenderBackendId::Vulkan,
-              "Vulkan backend is not integrated yet. Select OpenGL or Auto for now."};
+              "Vulkan backend support is not compiled in. Enable MONOLITH_ENGINE_ENABLE_VULKAN to build it."};
+#endif
     case RenderBackendId::Auto:
       break;
   }

--- a/renderer/RenderContext.cpp
+++ b/renderer/RenderContext.cpp
@@ -1,6 +1,19 @@
 #include "renderer/RenderContext.h"
 
+#include "renderer/Renderer.h"
+
 namespace Monolith {
+
+void RenderContext::Init() {}
+
+void RenderContext::BeginFrame(const Vec4& clearColor) {
+  Renderer::BeginFrame(MakeFrameConfig({}, "compat-render-context-frame", clearColor));
+}
+
+void RenderContext::EndFrame() {
+  if (Renderer::IsFrameActive())
+    Renderer::EndFrame();
+}
 
 RenderFrameConfig RenderContext::MakeFrameConfig(std::vector<Light> lights,
                                                  std::string debugLabel,

--- a/renderer/RenderContext.h
+++ b/renderer/RenderContext.h
@@ -13,6 +13,12 @@ namespace Monolith {
 // Graphics API state is owned by the active render backend, not by this type.
 class RenderContext {
  public:
+  // Legacy compatibility shim for downstream starter apps. No explicit global
+  // graphics initialization remains here; the active backend owns frame state.
+  static void Init();
+  static void BeginFrame(const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f});
+  static void EndFrame();
+
   static RenderFrameConfig MakeFrameConfig(std::vector<Light> lights = {},
                                            std::string debugLabel = {},
                                            const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f},

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#include "renderer/RenderBackend.h"
+
+namespace Monolith {
+
+enum class RenderNativeHandleType {
+  None,
+  OpenGLTexture2D,
+};
+
+struct RenderTargetHandle {
+  RenderBackendId backendId = RenderBackendId::Auto;
+  RenderNativeHandleType nativeType = RenderNativeHandleType::None;
+  uint64_t nativeHandle = 0;
+  bool needsYFlip = false;
+
+  bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
+
+  static RenderTargetHandle OpenGLTexture(uint32_t textureId, bool yFlip = false) {
+    return {RenderBackendId::OpenGL,
+            RenderNativeHandleType::OpenGLTexture2D,
+            static_cast<uint64_t>(textureId),
+            yFlip};
+  }
+};
+
+}  // namespace Monolith

--- a/renderer/Shader.cpp
+++ b/renderer/Shader.cpp
@@ -3,32 +3,45 @@
 #include <glad/glad.h>
 
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
 
 #include "core/Logger.h"
 
 namespace Monolith {
 
+struct Shader::ProgramStorage {
+  unsigned int program = 0;
+  std::unordered_map<std::string, int> uniformCache;
+};
+
+Shader::Shader() = default;
+
 Shader::~Shader() {
-  if (m_program)
-    glDeleteProgram(m_program);
+  if (m_programStorage && m_programStorage->program)
+    glDeleteProgram(m_programStorage->program);
 }
 
 Shader::Shader(Shader&& o) noexcept
-    : m_program(o.m_program), m_uniformCache(std::move(o.m_uniformCache)) {
-  o.m_program = 0;
-}
+    : m_programStorage(std::move(o.m_programStorage)) {}
 
 Shader& Shader::operator=(Shader&& o) noexcept {
   if (this != &o) {
-    if (m_program)
-      glDeleteProgram(m_program);
-    m_program = o.m_program;
-    m_uniformCache = std::move(o.m_uniformCache);
-    o.m_program = 0;
+    if (m_programStorage && m_programStorage->program)
+      glDeleteProgram(m_programStorage->program);
+    m_programStorage = std::move(o.m_programStorage);
   }
   return *this;
+}
+
+bool Shader::IsValid() const {
+  return m_programStorage && m_programStorage->program != 0;
+}
+
+unsigned int Shader::GetProgramID() const {
+  return m_programStorage ? m_programStorage->program : 0;
 }
 
 static std::string ReadFile(const std::string& path) {
@@ -46,9 +59,10 @@ Shader Shader::FromFiles(const std::string& vertPath, const std::string& fragPat
 
 Shader Shader::FromSource(const std::string& vertSrc, const std::string& fragSrc) {
   Shader s;
+  s.m_programStorage = std::make_unique<ProgramStorage>();
   unsigned int vert = CompileShader(GL_VERTEX_SHADER, vertSrc);
   unsigned int frag = CompileShader(GL_FRAGMENT_SHADER, fragSrc);
-  s.m_program = LinkProgram(vert, frag);
+  s.m_programStorage->program = LinkProgram(vert, frag);
   glDeleteShader(vert);
   glDeleteShader(frag);
   return s;
@@ -91,19 +105,22 @@ unsigned int Shader::LinkProgram(unsigned int vert, unsigned int frag) {
 }
 
 void Shader::Bind() const {
-  glUseProgram(m_program);
+  glUseProgram(GetProgramID());
 }
 void Shader::Unbind() const {
   glUseProgram(0);
 }
 
 int Shader::GetUniformLocation(const std::string& name) const {
-  auto it = m_uniformCache.find(name);
-  if (it != m_uniformCache.end())
+  if (!m_programStorage)
+    return -1;
+
+  auto it = m_programStorage->uniformCache.find(name);
+  if (it != m_programStorage->uniformCache.end())
     return it->second;
 
-  int loc = glGetUniformLocation(m_program, name.c_str());
-  m_uniformCache[name] = loc;
+  int loc = glGetUniformLocation(m_programStorage->program, name.c_str());
+  m_programStorage->uniformCache[name] = loc;
   return loc;
 }
 

--- a/renderer/Shader.h
+++ b/renderer/Shader.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <memory>
 #include <string>
-#include <unordered_map>
 
 #include "math/Mat3.h"
 #include "math/Mat4.h"
@@ -11,7 +11,7 @@ namespace Monolith {
 
 class Shader {
  public:
-  Shader() = default;
+  Shader();
   ~Shader();
 
   Shader(const Shader&) = delete;
@@ -28,8 +28,8 @@ class Shader {
   void Bind() const;
   void Unbind() const;
 
-  bool IsValid() const { return m_program != 0; }
-  unsigned int GetProgramID() const { return m_program; }
+  bool IsValid() const;
+  unsigned int GetProgramID() const;
 
   // Uniform setters
   void SetInt(const std::string& name, int v) const;
@@ -45,8 +45,8 @@ class Shader {
   void SetMat4Array(const std::string& name, int count, const float* data) const;
 
  private:
-  unsigned int m_program = 0;
-  mutable std::unordered_map<std::string, int> m_uniformCache;
+  struct ProgramStorage;
+  std::unique_ptr<ProgramStorage> m_programStorage;
 
   int GetUniformLocation(const std::string& name) const;
   static unsigned int CompileShader(unsigned int type, const std::string& src);

--- a/renderer/SkinnedMesh.cpp
+++ b/renderer/SkinnedMesh.cpp
@@ -4,9 +4,18 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <memory>
 #include <utility>
 
 namespace Monolith {
+
+struct SkinnedMesh::GpuStorage {
+  unsigned int vao = 0;
+  unsigned int vbo = 0;
+  unsigned int ebo = 0;
+};
+
+SkinnedMesh::SkinnedMesh() = default;
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -17,29 +26,27 @@ SkinnedMesh::~SkinnedMesh() {
 }
 
 SkinnedMesh::SkinnedMesh(SkinnedMesh&& o) noexcept
-    : m_vao(o.m_vao),
-      m_vbo(o.m_vbo),
-      m_ebo(o.m_ebo),
+    : m_gpu(std::move(o.m_gpu)),
       m_indexCount(o.m_indexCount),
       m_halfExtents(o.m_halfExtents),
       m_localAabbCenter(o.m_localAabbCenter) {
-  o.m_vao = o.m_vbo = o.m_ebo = 0;
   o.m_indexCount = 0;
 }
 
 SkinnedMesh& SkinnedMesh::operator=(SkinnedMesh&& o) noexcept {
   if (this != &o) {
     Release();
-    m_vao              = o.m_vao;
-    m_vbo              = o.m_vbo;
-    m_ebo              = o.m_ebo;
+    m_gpu              = std::move(o.m_gpu);
     m_indexCount       = o.m_indexCount;
     m_halfExtents      = o.m_halfExtents;
     m_localAabbCenter  = o.m_localAabbCenter;
-    o.m_vao = o.m_vbo = o.m_ebo = 0;
     o.m_indexCount = 0;
   }
   return *this;
+}
+
+bool SkinnedMesh::IsValid() const {
+  return m_gpu && m_gpu->vao != 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -53,7 +60,9 @@ void SkinnedMesh::SetData(const std::vector<SkinnedVertex>& vertices,
 }
 
 void SkinnedMesh::Draw() const {
-  glBindVertexArray(m_vao);
+  if (!m_gpu)
+    return;
+  glBindVertexArray(m_gpu->vao);
   glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
   glBindVertexArray(0);
 }
@@ -65,21 +74,22 @@ void SkinnedMesh::Draw() const {
 void SkinnedMesh::Upload(const std::vector<SkinnedVertex>& vertices,
                          const std::vector<unsigned int>& indices) {
   m_indexCount = static_cast<int>(indices.size());
+  m_gpu = std::make_unique<GpuStorage>();
 
-  glGenVertexArrays(1, &m_vao);
-  glBindVertexArray(m_vao);
+  glGenVertexArrays(1, &m_gpu->vao);
+  glBindVertexArray(m_gpu->vao);
 
   // --- VBO ---
-  glGenBuffers(1, &m_vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+  glGenBuffers(1, &m_gpu->vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
   glBufferData(GL_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(vertices.size() * sizeof(SkinnedVertex)),
                vertices.data(),
                GL_STATIC_DRAW);
 
   // --- EBO ---
-  glGenBuffers(1, &m_ebo);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ebo);
+  glGenBuffers(1, &m_gpu->ebo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
                indices.data(),
@@ -152,13 +162,15 @@ void SkinnedMesh::Upload(const std::vector<SkinnedVertex>& vertices,
 }
 
 void SkinnedMesh::Release() {
-  if (m_ebo)
-    glDeleteBuffers(1, &m_ebo);
-  if (m_vbo)
-    glDeleteBuffers(1, &m_vbo);
-  if (m_vao)
-    glDeleteVertexArrays(1, &m_vao);
-  m_vao = m_vbo = m_ebo = 0;
+  if (m_gpu) {
+    if (m_gpu->ebo)
+      glDeleteBuffers(1, &m_gpu->ebo);
+    if (m_gpu->vbo)
+      glDeleteBuffers(1, &m_gpu->vbo);
+    if (m_gpu->vao)
+      glDeleteVertexArrays(1, &m_gpu->vao);
+    m_gpu.reset();
+  }
   m_indexCount = 0;
 }
 

--- a/renderer/SkinnedMesh.h
+++ b/renderer/SkinnedMesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "math/Vec3.h"
@@ -24,7 +25,7 @@ namespace Monolith {
 // Non-copyable (owns GPU resources).  Move-only, matching the Mesh convention.
 class SkinnedMesh {
  public:
-  SkinnedMesh() = default;
+  SkinnedMesh();
   ~SkinnedMesh();
 
   SkinnedMesh(const SkinnedMesh&) = delete;
@@ -42,7 +43,7 @@ class SkinnedMesh {
   // Bind the VAO and issue a single glDrawElements call.
   void Draw() const;
 
-  bool IsValid() const { return m_vao != 0; }
+  bool IsValid() const;
   int  GetIndexCount() const { return m_indexCount; }
 
   // Axis-aligned bounding box in local (bind-pose) space.
@@ -50,9 +51,8 @@ class SkinnedMesh {
   Vec3 GetLocalAabbCenter() const { return m_localAabbCenter; }
 
  private:
-  unsigned int m_vao = 0;
-  unsigned int m_vbo = 0;
-  unsigned int m_ebo = 0;
+  struct GpuStorage;
+  std::unique_ptr<GpuStorage> m_gpu;
   int  m_indexCount = 0;
   Vec3 m_halfExtents     = {0.5f, 0.5f, 0.5f};
   Vec3 m_localAabbCenter = Vec3::Zero();

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -44,6 +44,10 @@ unsigned int Texture::GetNativeId() const {
   return m_textureStorage ? m_textureStorage->id : 0;
 }
 
+RenderTargetHandle Texture::GetRenderTargetHandle(bool needsYFlip) const {
+  return RenderTargetHandle::OpenGLTexture(GetNativeId(), needsYFlip);
+}
+
 Texture Texture::FromFile(const std::string& path, bool flipY) {
   stbi_set_flip_vertically_on_load(flipY ? 1 : 0);
   int w, h, ch;

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -5,29 +5,43 @@
 #include <glad/glad.h>
 #include <stb_image.h>
 
+#include <memory>
+
 #include "core/Logger.h"
 
 namespace Monolith {
 
+struct Texture::TextureStorage {
+  unsigned int id = 0;
+};
+
+Texture::Texture() = default;
+
 Texture::~Texture() {
-  if (m_id)
-    glDeleteTextures(1, &m_id);
+  if (m_textureStorage && m_textureStorage->id)
+    glDeleteTextures(1, &m_textureStorage->id);
 }
 
-Texture::Texture(Texture&& o) noexcept : m_id(o.m_id), m_width(o.m_width), m_height(o.m_height) {
-  o.m_id = 0;
-}
+Texture::Texture(Texture&& o) noexcept
+    : m_textureStorage(std::move(o.m_textureStorage)), m_width(o.m_width), m_height(o.m_height) {}
 
 Texture& Texture::operator=(Texture&& o) noexcept {
   if (this != &o) {
-    if (m_id)
-      glDeleteTextures(1, &m_id);
-    m_id = o.m_id;
+    if (m_textureStorage && m_textureStorage->id)
+      glDeleteTextures(1, &m_textureStorage->id);
+    m_textureStorage = std::move(o.m_textureStorage);
     m_width = o.m_width;
     m_height = o.m_height;
-    o.m_id = 0;
   }
   return *this;
+}
+
+bool Texture::IsValid() const {
+  return m_textureStorage && m_textureStorage->id != 0;
+}
+
+unsigned int Texture::GetNativeId() const {
+  return m_textureStorage ? m_textureStorage->id : 0;
 }
 
 Texture Texture::FromFile(const std::string& path, bool flipY) {
@@ -40,8 +54,9 @@ Texture Texture::FromFile(const std::string& path, bool flipY) {
   }
 
   Texture t;
-  glGenTextures(1, &t.m_id);
-  glBindTexture(GL_TEXTURE_2D, t.m_id);
+  t.m_textureStorage = std::make_unique<TextureStorage>();
+  glGenTextures(1, &t.m_textureStorage->id);
+  glBindTexture(GL_TEXTURE_2D, t.m_textureStorage->id);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
   glGenerateMipmap(GL_TEXTURE_2D);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
@@ -57,8 +72,9 @@ Texture Texture::FromFile(const std::string& path, bool flipY) {
 
 Texture Texture::CreateWhite1x1() {
   Texture t;
-  glGenTextures(1, &t.m_id);
-  glBindTexture(GL_TEXTURE_2D, t.m_id);
+  t.m_textureStorage = std::make_unique<TextureStorage>();
+  glGenTextures(1, &t.m_textureStorage->id);
+  glBindTexture(GL_TEXTURE_2D, t.m_textureStorage->id);
   unsigned char white[4] = {255, 255, 255, 255};
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, white);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -70,7 +86,7 @@ Texture Texture::CreateWhite1x1() {
 
 void Texture::Bind(unsigned int slot) const {
   glActiveTexture(GL_TEXTURE0 + slot);
-  glBindTexture(GL_TEXTURE_2D, m_id);
+  glBindTexture(GL_TEXTURE_2D, GetNativeId());
 }
 
 void Texture::Unbind() const {

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -1,11 +1,12 @@
 #pragma once
+#include <memory>
 #include <string>
 
 namespace Monolith {
 
 class Texture {
  public:
-  Texture() = default;
+  Texture();
   ~Texture();
 
   Texture(const Texture&) = delete;
@@ -19,13 +20,16 @@ class Texture {
   void Bind(unsigned int slot = 0) const;
   void Unbind() const;
 
-  bool IsValid() const { return m_id != 0; }
+  bool IsValid() const;
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
-  unsigned int GetNativeId() const { return m_id; }
+  // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
+  // texture presentation is fully backend-neutral.
+  unsigned int GetNativeId() const;
 
  private:
-  unsigned int m_id = 0;
+  struct TextureStorage;
+  std::unique_ptr<TextureStorage> m_textureStorage;
   int m_width = 0;
   int m_height = 0;
 };

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -2,6 +2,8 @@
 #include <memory>
 #include <string>
 
+#include "renderer/RenderTargetHandle.h"
+
 namespace Monolith {
 
 class Texture {
@@ -26,6 +28,7 @@ class Texture {
   // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
   // texture presentation is fully backend-neutral.
   unsigned int GetNativeId() const;
+  RenderTargetHandle GetRenderTargetHandle(bool needsYFlip = false) const;
 
  private:
   struct TextureStorage;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -103,6 +103,10 @@ VulkanRenderBackend::~VulkanRenderBackend() {
 RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
   RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   caps.supportsDebugLabels = false;
+  caps.supportsOffscreenTargets = false;
+  caps.supportsNativeTextureHandles = false;
+  caps.supportsReadback = false;
+  caps.supportsDebugHud = false;
   caps.supportsComputePasses = false;
   caps.supportsGpuTimestamps = false;
   caps.supportsBindlessResources = false;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -1,0 +1,794 @@
+#include "renderer/VulkanRenderBackend.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "core/Assert.h"
+
+#if defined(MONOLITH_HAS_VULKAN)
+#include <volk.h>
+#include <GLFW/glfw3.h>
+#endif
+
+namespace Monolith {
+
+#if defined(MONOLITH_HAS_VULKAN)
+
+namespace {
+
+constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
+
+const char* VkResultName(VkResult result) {
+  switch (result) {
+    case VK_SUCCESS:
+      return "VK_SUCCESS";
+    case VK_NOT_READY:
+      return "VK_NOT_READY";
+    case VK_TIMEOUT:
+      return "VK_TIMEOUT";
+    case VK_EVENT_SET:
+      return "VK_EVENT_SET";
+    case VK_EVENT_RESET:
+      return "VK_EVENT_RESET";
+    case VK_INCOMPLETE:
+      return "VK_INCOMPLETE";
+    case VK_ERROR_OUT_OF_HOST_MEMORY:
+      return "VK_ERROR_OUT_OF_HOST_MEMORY";
+    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+      return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+    case VK_ERROR_INITIALIZATION_FAILED:
+      return "VK_ERROR_INITIALIZATION_FAILED";
+    case VK_ERROR_DEVICE_LOST:
+      return "VK_ERROR_DEVICE_LOST";
+    case VK_ERROR_SURFACE_LOST_KHR:
+      return "VK_ERROR_SURFACE_LOST_KHR";
+    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+      return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+    case VK_SUBOPTIMAL_KHR:
+      return "VK_SUBOPTIMAL_KHR";
+    case VK_ERROR_OUT_OF_DATE_KHR:
+      return "VK_ERROR_OUT_OF_DATE_KHR";
+    default:
+      return "VK_ERROR_UNKNOWN";
+  }
+}
+
+bool CheckVk(VkResult result, std::string& outError, const char* context) {
+  if (result == VK_SUCCESS)
+    return true;
+  outError = std::string(context) + " failed: " + VkResultName(result);
+  return false;
+}
+
+}  // namespace
+
+struct VulkanRenderBackend::Context {
+  GLFWwindow* window = nullptr;
+  VkInstance instance = VK_NULL_HANDLE;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  VkQueue graphicsQueue = VK_NULL_HANDLE;
+  VkQueue presentQueue = VK_NULL_HANDLE;
+  uint32_t graphicsQueueFamily = kInvalidQueueFamily;
+  uint32_t presentQueueFamily = kInvalidQueueFamily;
+  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+  VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+  VkExtent2D swapchainExtent = {1, 1};
+  std::vector<VkImage> swapchainImages;
+  std::vector<VkImageView> swapchainImageViews;
+  std::vector<VkCommandBuffer> commandBuffers;
+  std::vector<bool> imageWasPresented;
+  VkCommandPool commandPool = VK_NULL_HANDLE;
+  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+  VkFence inFlightFence = VK_NULL_HANDLE;
+  uint32_t activeImageIndex = 0;
+  bool frameCommandsRecorded = false;
+};
+
+VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
+  Initialize(nativeWindowHandle);
+}
+
+VulkanRenderBackend::~VulkanRenderBackend() {
+  Shutdown();
+}
+
+RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
+  RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  caps.supportsDebugLabels = false;
+  caps.supportsComputePasses = false;
+  caps.supportsGpuTimestamps = false;
+  caps.supportsBindlessResources = false;
+  return caps;
+}
+
+bool VulkanRenderBackend::IsInitialized() const {
+  return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
+  m_lastError.clear();
+  if (!nativeWindowHandle) {
+    m_lastError = "Vulkan backend requires a native GLFW window handle.";
+    return false;
+  }
+
+  if (!glfwVulkanSupported()) {
+    m_lastError = "GLFW reports that Vulkan is not supported on this system.";
+    return false;
+  }
+
+  if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
+    return false;
+
+  m_context = std::make_unique<Context>();
+  m_context->window = static_cast<GLFWwindow*>(nativeWindowHandle);
+
+  uint32_t extensionCount = 0;
+  const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
+  if (!glfwExtensions || extensionCount == 0) {
+    m_lastError = "GLFW did not provide required Vulkan instance extensions.";
+    Shutdown();
+    return false;
+  }
+
+  const VkApplicationInfo appInfo{
+      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+      .pNext = nullptr,
+      .pApplicationName = "MonolithEngine",
+      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+      .pEngineName = "MonolithEngine",
+      .engineVersion = VK_MAKE_VERSION(0, 1, 0),
+      .apiVersion = VK_API_VERSION_1_1,
+  };
+
+  std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
+  const VkInstanceCreateInfo instanceInfo{
+      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .pApplicationInfo = &appInfo,
+      .enabledLayerCount = 0,
+      .ppEnabledLayerNames = nullptr,
+      .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
+      .ppEnabledExtensionNames = instanceExtensions.data(),
+  };
+  if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
+               "vkCreateInstance")) {
+    Shutdown();
+    return false;
+  }
+
+  volkLoadInstance(m_context->instance);
+
+  if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
+                                       &m_context->surface),
+               m_lastError,
+               "glfwCreateWindowSurface")) {
+    Shutdown();
+    return false;
+  }
+
+  uint32_t physicalDeviceCount = 0;
+  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
+               m_lastError,
+               "vkEnumeratePhysicalDevices(count)")) {
+    Shutdown();
+    return false;
+  }
+  if (physicalDeviceCount == 0) {
+    m_lastError = "No Vulkan physical devices were found.";
+    Shutdown();
+    return false;
+  }
+
+  std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
+                                          physicalDevices.data()),
+               m_lastError,
+               "vkEnumeratePhysicalDevices")) {
+    Shutdown();
+    return false;
+  }
+
+  const std::array<const char*, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  for (VkPhysicalDevice device : physicalDevices) {
+    uint32_t queueFamilyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+    std::optional<uint32_t> graphicsFamily;
+    std::optional<uint32_t> presentFamily;
+    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
+      if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+        graphicsFamily = i;
+
+      VkBool32 presentSupported = VK_FALSE;
+      vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
+      if (presentSupported == VK_TRUE)
+        presentFamily = i;
+    }
+
+    if (!graphicsFamily || !presentFamily)
+      continue;
+
+    uint32_t extensionCountAvailable = 0;
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
+    std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
+    vkEnumerateDeviceExtensionProperties(device,
+                                         nullptr,
+                                         &extensionCountAvailable,
+                                         extensions.data());
+    std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
+                                            requiredDeviceExtensions.end());
+    for (const auto& extension : extensions)
+      missingExtensions.erase(extension.extensionName);
+    if (!missingExtensions.empty())
+      continue;
+
+    uint32_t surfaceFormatCount = 0;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+    uint32_t presentModeCount = 0;
+    vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+                                              m_context->surface,
+                                              &presentModeCount,
+                                              nullptr);
+    if (surfaceFormatCount == 0 || presentModeCount == 0)
+      continue;
+
+    m_context->physicalDevice = device;
+    m_context->graphicsQueueFamily = *graphicsFamily;
+    m_context->presentQueueFamily = *presentFamily;
+    break;
+  }
+
+  if (m_context->physicalDevice == VK_NULL_HANDLE) {
+    m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
+    Shutdown();
+    return false;
+  }
+
+  const float queuePriority = 1.0f;
+  std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
+                                            m_context->presentQueueFamily};
+  std::vector<VkDeviceQueueCreateInfo> queueInfos;
+  queueInfos.reserve(uniqueQueueFamilies.size());
+  for (uint32_t queueFamily : uniqueQueueFamilies) {
+    queueInfos.push_back(VkDeviceQueueCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .queueFamilyIndex = queueFamily,
+        .queueCount = 1,
+        .pQueuePriorities = &queuePriority,
+    });
+  }
+
+  const VkDeviceCreateInfo deviceInfo{
+      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
+      .pQueueCreateInfos = queueInfos.data(),
+      .enabledLayerCount = 0,
+      .ppEnabledLayerNames = nullptr,
+      .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
+      .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
+      .pEnabledFeatures = nullptr,
+  };
+  if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
+               m_lastError,
+               "vkCreateDevice")) {
+    Shutdown();
+    return false;
+  }
+
+  volkLoadDevice(m_context->device);
+  vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
+  vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
+
+  const VkCommandPoolCreateInfo commandPoolInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+      .queueFamilyIndex = m_context->graphicsQueueFamily,
+  };
+  if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
+                                   &m_context->commandPool),
+               m_lastError,
+               "vkCreateCommandPool")) {
+    Shutdown();
+    return false;
+  }
+
+  const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+                                             .pNext = nullptr,
+                                             .flags = 0};
+  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                 &m_context->imageAvailableSemaphore),
+               m_lastError,
+               "vkCreateSemaphore(imageAvailable)")) {
+    Shutdown();
+    return false;
+  }
+  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                 &m_context->renderFinishedSemaphore),
+               m_lastError,
+               "vkCreateSemaphore(renderFinished)")) {
+    Shutdown();
+    return false;
+  }
+
+  const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                                    .pNext = nullptr,
+                                    .flags = VK_FENCE_CREATE_SIGNALED_BIT};
+  if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
+               m_lastError,
+               "vkCreateFence")) {
+    Shutdown();
+    return false;
+  }
+
+  if (!RecreateSwapchain()) {
+    Shutdown();
+    return false;
+  }
+
+  return true;
+}
+
+void VulkanRenderBackend::Shutdown() {
+  if (!m_context)
+    return;
+
+  if (m_context->device != VK_NULL_HANDLE)
+    vkDeviceWaitIdle(m_context->device);
+
+  DestroySwapchain();
+
+  if (m_context->inFlightFence != VK_NULL_HANDLE)
+    vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
+  if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
+    vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
+  if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
+    vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
+  if (m_context->commandPool != VK_NULL_HANDLE)
+    vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
+  if (m_context->device != VK_NULL_HANDLE)
+    vkDestroyDevice(m_context->device, nullptr);
+  if (m_context->surface != VK_NULL_HANDLE)
+    vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
+  if (m_context->instance != VK_NULL_HANDLE)
+    vkDestroyInstance(m_context->instance, nullptr);
+
+  m_context.reset();
+  m_frameActive = false;
+  m_passActive = false;
+}
+
+void VulkanRenderBackend::DestroySwapchain() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  if (!m_context->commandBuffers.empty()) {
+    vkFreeCommandBuffers(m_context->device,
+                         m_context->commandPool,
+                         static_cast<uint32_t>(m_context->commandBuffers.size()),
+                         m_context->commandBuffers.data());
+    m_context->commandBuffers.clear();
+  }
+
+  for (VkImageView imageView : m_context->swapchainImageViews)
+    vkDestroyImageView(m_context->device, imageView, nullptr);
+  m_context->swapchainImageViews.clear();
+  m_context->swapchainImages.clear();
+  m_context->imageWasPresented.clear();
+
+  if (m_context->swapchain != VK_NULL_HANDLE) {
+    vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
+    m_context->swapchain = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::RecreateSwapchain() {
+  DestroySwapchain();
+
+  VkSurfaceCapabilitiesKHR surfaceCapabilities{};
+  if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
+                                                         m_context->surface,
+                                                         &surfaceCapabilities),
+               m_lastError,
+               "vkGetPhysicalDeviceSurfaceCapabilitiesKHR")) {
+    return false;
+  }
+
+  uint32_t surfaceFormatCount = 0;
+  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                       m_context->surface,
+                                       &surfaceFormatCount,
+                                       nullptr);
+  std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
+  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                       m_context->surface,
+                                       &surfaceFormatCount,
+                                       surfaceFormats.data());
+  VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
+  for (const auto& candidate : surfaceFormats) {
+    if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
+        candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+      chosenFormat = candidate;
+      break;
+    }
+  }
+  m_context->swapchainFormat = chosenFormat.format;
+
+  uint32_t presentModeCount = 0;
+  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                            m_context->surface,
+                                            &presentModeCount,
+                                            nullptr);
+  std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                            m_context->surface,
+                                            &presentModeCount,
+                                            presentModes.data());
+  VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+  for (VkPresentModeKHR presentMode : presentModes) {
+    if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
+      chosenPresentMode = presentMode;
+      break;
+    }
+  }
+
+  int framebufferWidth = 0;
+  int framebufferHeight = 0;
+  glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
+  framebufferWidth = std::max(framebufferWidth, 1);
+  framebufferHeight = std::max(framebufferHeight, 1);
+
+  if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
+    m_context->swapchainExtent = surfaceCapabilities.currentExtent;
+  } else {
+    m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
+                                                  surfaceCapabilities.minImageExtent.width,
+                                                  surfaceCapabilities.maxImageExtent.width);
+    m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
+                                                   surfaceCapabilities.minImageExtent.height,
+                                                   surfaceCapabilities.maxImageExtent.height);
+  }
+
+  uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
+  if (surfaceCapabilities.maxImageCount > 0)
+    imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
+
+  std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
+                                                m_context->presentQueueFamily};
+  const bool usesSeparatePresentQueue =
+      m_context->graphicsQueueFamily != m_context->presentQueueFamily;
+
+  const VkSwapchainCreateInfoKHR swapchainInfo{
+      .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+      .pNext = nullptr,
+      .flags = 0,
+      .surface = m_context->surface,
+      .minImageCount = imageCount,
+      .imageFormat = chosenFormat.format,
+      .imageColorSpace = chosenFormat.colorSpace,
+      .imageExtent = m_context->swapchainExtent,
+      .imageArrayLayers = 1,
+      .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+      .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
+                                                   : VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
+      .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
+      .preTransform = surfaceCapabilities.currentTransform,
+      .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+      .presentMode = chosenPresentMode,
+      .clipped = VK_TRUE,
+      .oldSwapchain = VK_NULL_HANDLE,
+  };
+  if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
+                                    &m_context->swapchain),
+               m_lastError,
+               "vkCreateSwapchainKHR")) {
+    return false;
+  }
+
+  uint32_t swapchainImageCount = 0;
+  vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
+  m_context->swapchainImages.resize(swapchainImageCount);
+  vkGetSwapchainImagesKHR(m_context->device,
+                          m_context->swapchain,
+                          &swapchainImageCount,
+                          m_context->swapchainImages.data());
+  m_context->swapchainImageViews.resize(swapchainImageCount);
+  m_context->imageWasPresented.assign(swapchainImageCount, false);
+
+  for (size_t i = 0; i < m_context->swapchainImages.size(); ++i) {
+    const VkImageViewCreateInfo imageViewInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = m_context->swapchainImages[i],
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = m_context->swapchainFormat,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    if (!CheckVk(vkCreateImageView(m_context->device,
+                                   &imageViewInfo,
+                                   nullptr,
+                                   &m_context->swapchainImageViews[i]),
+                 m_lastError,
+                 "vkCreateImageView")) {
+      return false;
+    }
+  }
+
+  m_context->commandBuffers.resize(swapchainImageCount);
+  const VkCommandBufferAllocateInfo commandBufferInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .commandPool = m_context->commandPool,
+      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = swapchainImageCount,
+  };
+  if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
+                                        &commandBufferInfo,
+                                        m_context->commandBuffers.data()),
+               m_lastError,
+               "vkAllocateCommandBuffers")) {
+    return false;
+  }
+
+  return true;
+}
+
+bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
+  VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
+  if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
+    return false;
+
+  const VkCommandBufferBeginInfo beginInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .pInheritanceInfo = nullptr,
+  };
+  if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
+               "vkBeginCommandBuffer")) {
+    return false;
+  }
+
+  if (frame.clearColorBuffer) {
+    const VkImageMemoryBarrier toTransfer{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = 0,
+        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                         ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                         : VK_IMAGE_LAYOUT_UNDEFINED,
+        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image = m_context->swapchainImages[m_context->activeImageIndex],
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    vkCmdPipelineBarrier(commandBuffer,
+                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         0,
+                         0,
+                         nullptr,
+                         0,
+                         nullptr,
+                         1,
+                         &toTransfer);
+
+    const VkClearColorValue clearColor = {{frame.clearColor.x,
+                                           frame.clearColor.y,
+                                           frame.clearColor.z,
+                                           frame.clearColor.w}};
+    const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkCmdClearColorImage(commandBuffer,
+                         m_context->swapchainImages[m_context->activeImageIndex],
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                         &clearColor,
+                         1,
+                         &clearRange);
+
+    const VkImageMemoryBarrier toPresent{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = 0,
+        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image = m_context->swapchainImages[m_context->activeImageIndex],
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    vkCmdPipelineBarrier(commandBuffer,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         0,
+                         0,
+                         nullptr,
+                         0,
+                         nullptr,
+                         1,
+                         &toPresent);
+  }
+
+  if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
+    return false;
+
+  m_context->frameCommandsRecorded = true;
+  return true;
+}
+
+void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
+  MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
+  MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
+  if (!IsInitialized() || m_frameActive)
+    return;
+
+  if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+               m_lastError,
+               "vkWaitForFences")) {
+    return;
+  }
+
+  VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                                 m_context->swapchain,
+                                                 UINT64_MAX,
+                                                 m_context->imageAvailableSemaphore,
+                                                 VK_NULL_HANDLE,
+                                                 &m_context->activeImageIndex);
+  if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR) {
+    MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+    acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                          m_context->swapchain,
+                                          UINT64_MAX,
+                                          m_context->imageAvailableSemaphore,
+                                          VK_NULL_HANDLE,
+                                          &m_context->activeImageIndex);
+  }
+  MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
+
+  MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
+                          m_lastError,
+                          "vkResetFences"),
+                  m_lastError.c_str());
+  MONOLITH_ASSERT(RecordFrameCommands(frame), m_lastError.c_str());
+
+  m_drawCalls = 0;
+  m_frameActive = true;
+}
+
+void VulkanRenderBackend::EndFrame() {
+  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
+  if (!m_frameActive)
+    return;
+
+  if (m_passActive)
+    EndPass();
+
+  if (m_context->frameCommandsRecorded) {
+    const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
+    const VkSubmitInfo submitInfo{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 1,
+        .pWaitSemaphores = &m_context->imageAvailableSemaphore,
+        .pWaitDstStageMask = waitStages,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
+        .signalSemaphoreCount = 1,
+        .pSignalSemaphores = &m_context->renderFinishedSemaphore,
+    };
+    MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
+                                          1,
+                                          &submitInfo,
+                                          m_context->inFlightFence),
+                            m_lastError,
+                            "vkQueueSubmit"),
+                    m_lastError.c_str());
+
+    const VkPresentInfoKHR presentInfo{
+        .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 1,
+        .pWaitSemaphores = &m_context->renderFinishedSemaphore,
+        .swapchainCount = 1,
+        .pSwapchains = &m_context->swapchain,
+        .pImageIndices = &m_context->activeImageIndex,
+        .pResults = nullptr,
+    };
+    const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
+    if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
+      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+    } else {
+      MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
+    }
+
+    m_context->imageWasPresented[m_context->activeImageIndex] = true;
+    m_context->frameCommandsRecorded = false;
+  }
+
+  m_frameActive = false;
+}
+
+void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
+  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
+  MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
+  if (!m_frameActive || m_passActive)
+    return;
+
+  m_activePassId = pass.id;
+  m_passActive = true;
+}
+
+void VulkanRenderBackend::EndPass() {
+  MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
+  if (!m_passActive)
+    return;
+  m_passActive = false;
+}
+
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+
+void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+
+void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+
+#else
+
+struct VulkanRenderBackend::Context {};
+
+VulkanRenderBackend::VulkanRenderBackend(void*) {
+  m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
+}
+
+VulkanRenderBackend::~VulkanRenderBackend() = default;
+
+RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
+  return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+}
+
+bool VulkanRenderBackend::IsInitialized() const {
+  return false;
+}
+
+bool VulkanRenderBackend::Initialize(void*) {
+  return false;
+}
+
+void VulkanRenderBackend::Shutdown() {}
+bool VulkanRenderBackend::RecreateSwapchain() { return false; }
+void VulkanRenderBackend::DestroySwapchain() {}
+bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig&) { return false; }
+void VulkanRenderBackend::BeginFrame(const RenderFrameConfig&) {}
+void VulkanRenderBackend::EndFrame() {}
+void VulkanRenderBackend::BeginPass(const RenderPassConfig&) {}
+void VulkanRenderBackend::EndPass() {}
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+
+#endif
+
+}  // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <optional>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -91,6 +92,14 @@ struct VulkanRenderBackend::Context {
   uint32_t activeImageIndex = 0;
   bool frameCommandsRecorded = false;
 };
+
+namespace {
+
+constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
+  return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+}
+
+}  // namespace
 
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
@@ -576,6 +585,13 @@ bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
   }
 
   if (frame.clearColorBuffer) {
+    if (!m_pendingOpaqueDraws.empty()) {
+      // Placeholder for the first opaque-scene submission slice: keep the current
+      // clear/present bootstrap, but make frame recording aware that opaque scene
+      // work was queued through the backend seam.
+      m_lastError.clear();
+    }
+
     const VkImageMemoryBarrier toTransfer{
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .pNext = nullptr,
@@ -677,8 +693,11 @@ void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
                           m_lastError,
                           "vkResetFences"),
                   m_lastError.c_str());
-  MONOLITH_ASSERT(RecordFrameCommands(frame), m_lastError.c_str());
 
+  m_activeFrame = frame;
+  m_activeView = {};
+  m_pendingOpaqueDraws.clear();
+  m_context->frameCommandsRecorded = false;
   m_drawCalls = 0;
   m_frameActive = true;
 }
@@ -690,6 +709,10 @@ void VulkanRenderBackend::EndFrame() {
 
   if (m_passActive)
     EndPass();
+
+  if (!m_context->frameCommandsRecorded) {
+    MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
+  }
 
   if (m_context->frameCommandsRecorded) {
     const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
@@ -734,6 +757,7 @@ void VulkanRenderBackend::EndFrame() {
   }
 
   m_frameActive = false;
+  m_pendingOpaqueDraws.clear();
 }
 
 void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
@@ -743,6 +767,7 @@ void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
     return;
 
   m_activePassId = pass.id;
+  m_activeView = pass.view;
   m_passActive = true;
 }
 
@@ -753,7 +778,13 @@ void VulkanRenderBackend::EndPass() {
   m_passActive = false;
 }
 
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
+  if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
+    return;
+
+  m_pendingOpaqueDraws.push_back(PendingOpaqueDraw{command.mesh, command.material, command.modelMatrix});
+  ++m_drawCalls;
+}
 
 void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
 

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "renderer/IRenderBackend.h"
 
@@ -42,7 +43,16 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroySwapchain();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
+  struct PendingOpaqueDraw {
+    const Mesh* mesh = nullptr;
+    const Material* material = nullptr;
+    Mat4 modelMatrix = Mat4::Identity();
+  };
+
   std::unique_ptr<Context> m_context;
+  RenderFrameConfig m_activeFrame;
+  RenderView m_activeView;
+  std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
   std::string m_lastError;
   RenderPassId m_activePassId = RenderPassId::OpaqueScene;
   int m_drawCalls = 0;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "renderer/IRenderBackend.h"
+
+namespace Monolith {
+
+class VulkanRenderBackend : public IRenderBackend {
+ public:
+  explicit VulkanRenderBackend(void* nativeWindowHandle);
+  ~VulkanRenderBackend() override;
+
+  VulkanRenderBackend(const VulkanRenderBackend&) = delete;
+  VulkanRenderBackend& operator=(const VulkanRenderBackend&) = delete;
+  VulkanRenderBackend(VulkanRenderBackend&&) = delete;
+  VulkanRenderBackend& operator=(VulkanRenderBackend&&) = delete;
+
+  void BeginFrame(const RenderFrameConfig& frame) override;
+  void EndFrame() override;
+  void BeginPass(const RenderPassConfig& pass) override;
+  void EndPass() override;
+
+  void DrawMesh(const MeshDrawCommand& command) override;
+  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override;
+  void DrawWireframe(const WireframeDrawCommand& command) override;
+
+  RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
+  RenderBackendCapabilities GetCapabilities() const override;
+  int GetDrawCallCount() const override { return m_drawCalls; }
+
+  bool IsInitialized() const;
+  const std::string& GetLastError() const { return m_lastError; }
+
+ private:
+  struct Context;
+
+  bool Initialize(void* nativeWindowHandle);
+  void Shutdown();
+  bool RecreateSwapchain();
+  void DestroySwapchain();
+  bool RecordFrameCommands(const RenderFrameConfig& frame);
+
+  std::unique_ptr<Context> m_context;
+  std::string m_lastError;
+  RenderPassId m_activePassId = RenderPassId::OpaqueScene;
+  int m_drawCalls = 0;
+  bool m_frameActive = false;
+  bool m_passActive = false;
+};
+
+}  // namespace Monolith

--- a/scene/STARTER_TEMPLATE.h
+++ b/scene/STARTER_TEMPLATE.h
@@ -40,8 +40,11 @@ class MyGameApp : public Monolith::Application {
   protected:
   // STEP 2: Setup (called once at startup).
   void OnInit() override {
+    Monolith::RenderBackendSelection backendSelection;
+    backendSelection.requested = Monolith::RenderBackendId::OpenGL;
+    backendSelection.nativeWindowHandle = GetWindow().GetNativeHandle();
     const Monolith::RenderBackendInitResult backendInit =
-        Monolith::Renderer::InitializeBackend({Monolith::RenderBackendId::OpenGL});
+        Monolith::Renderer::InitializeBackend(backendSelection);
     if (!backendInit.ok)
       throw std::runtime_error("Failed to initialize renderer backend: " + backendInit.error);
 

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -116,6 +116,9 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string starterTemplate = ReadTextFile(root / "scene" / "STARTER_TEMPLATE.h");
   REQUIRE(starterTemplate.find("RenderContext::BeginFrame") == std::string::npos);
   REQUIRE(starterTemplate.find("RenderContext::EndFrame") == std::string::npos);
+
+  const std::string editorLayer = ReadTextFile(root / "editor" / "EditorLayer.cpp");
+  REQUIRE(editorLayer.find("GetNativeId(") == std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -86,6 +86,22 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string renderer = ReadTextFile(root / "renderer" / "Renderer.cpp");
   REQUIRE(renderer.find("GetProgramID(") == std::string::npos);
 
+  const std::string meshHeader = ReadTextFile(root / "renderer" / "Mesh.h");
+  REQUIRE(meshHeader.find("m_vao") == std::string::npos);
+  REQUIRE(meshHeader.find("m_vbo") == std::string::npos);
+  REQUIRE(meshHeader.find("m_ebo") == std::string::npos);
+
+  const std::string shaderHeader = ReadTextFile(root / "renderer" / "Shader.h");
+  REQUIRE(shaderHeader.find("unsigned int m_program") == std::string::npos);
+
+  const std::string textureHeader = ReadTextFile(root / "renderer" / "Texture.h");
+  REQUIRE(textureHeader.find("unsigned int m_id") == std::string::npos);
+
+  const std::string skinnedMeshHeader = ReadTextFile(root / "renderer" / "SkinnedMesh.h");
+  REQUIRE(skinnedMeshHeader.find("m_vao") == std::string::npos);
+  REQUIRE(skinnedMeshHeader.find("m_vbo") == std::string::npos);
+  REQUIRE(skinnedMeshHeader.find("m_ebo") == std::string::npos);
+
   const std::string renderContext = ReadTextFile(root / "renderer" / "RenderContext.cpp");
   REQUIRE(renderContext.find("glViewport(") == std::string::npos);
   REQUIRE(renderContext.find("glad/glad.h") == std::string::npos);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+#if defined(MONOLITH_HAS_VULKAN)
+#include <GLFW/glfw3.h>
+#endif
+
 #include "math/Mat4.h"
 #include "renderer/IRenderBackend.h"
 #include "renderer/Material.h"
@@ -167,6 +171,55 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
   REQUIRE_FALSE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
 #endif
 }
+
+#if defined(MONOLITH_HAS_VULKAN)
+TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
+          "[renderer][foundation][vulkan][opaque]") {
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported()) {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
+  if (!window) {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan backend test");
+  }
+
+  RenderBackendSelection selection;
+  selection.requested = RenderBackendId::Vulkan;
+  selection.nativeWindowHandle = window;
+  const RenderBackendInitResult init = Renderer::InitializeBackend(selection);
+
+  if (!init.ok) {
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    FAIL(init.error);
+  }
+
+  Mesh mesh;
+  Material material;
+  Camera camera;
+
+  Renderer::BeginFrame({{}, "vulkan-opaque-scene"});
+  Renderer::BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-opaque-pass"});
+  Renderer::Submit(mesh, Mat4::Identity(), material);
+  Renderer::EndPass();
+  Renderer::EndFrame();
+
+  REQUIRE(Renderer::GetBackendId() == RenderBackendId::Vulkan);
+  REQUIRE(Renderer::GetDrawCallCount() == 1);
+
+  Renderer::ResetBackend();
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+#endif
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",
           "[renderer][foundation]") {

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -132,6 +132,10 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
 
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   REQUIRE(caps.supportsWireframeOverlay);
+  REQUIRE(caps.supportsOffscreenTargets);
+  REQUIRE(caps.supportsNativeTextureHandles);
+  REQUIRE(caps.supportsReadback);
+  REQUIRE(caps.supportsDebugHud);
   REQUIRE_FALSE(caps.supportsComputePasses);
 }
 
@@ -147,6 +151,14 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
   REQUIRE(init.error.find("window handle") != std::string::npos);
   REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
   REQUIRE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+
+  const RenderBackendCapabilities vulkanCaps =
+      GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  REQUIRE_FALSE(vulkanCaps.supportsWireframeOverlay);
+  REQUIRE_FALSE(vulkanCaps.supportsOffscreenTargets);
+  REQUIRE_FALSE(vulkanCaps.supportsNativeTextureHandles);
+  REQUIRE_FALSE(vulkanCaps.supportsReadback);
+  REQUIRE_FALSE(vulkanCaps.supportsDebugHud);
 #else
   REQUIRE_FALSE(init.ok);
   REQUIRE(init.selected == RenderBackendId::Vulkan);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -141,11 +141,19 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Vulkan});
 
+#if defined(MONOLITH_HAS_VULKAN)
+  REQUIRE_FALSE(init.ok);
+  REQUIRE(init.selected == RenderBackendId::Vulkan);
+  REQUIRE(init.error.find("window handle") != std::string::npos);
+  REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
+  REQUIRE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+#else
   REQUIRE_FALSE(init.ok);
   REQUIRE(init.selected == RenderBackendId::Vulkan);
   REQUIRE_FALSE(init.error.empty());
   REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
   REQUIRE_FALSE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+#endif
 }
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -15,6 +15,43 @@ if(NOT TARGET glfw)
     FetchContent_MakeAvailable(glfw)
 endif()
 
+# ---- Optional Vulkan headers + loader scaffolding ----
+if(MONOLITH_ENGINE_ENABLE_VULKAN)
+    if(NOT TARGET monolith_vulkan_headers)
+        FetchContent_Declare(
+            vulkan_headers
+            GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers.git
+            GIT_TAG        vulkan-sdk-1.4.341.0
+            GIT_SHALLOW    TRUE
+        )
+        FetchContent_Populate(vulkan_headers)
+
+        add_library(monolith_vulkan_headers INTERFACE)
+        target_include_directories(monolith_vulkan_headers INTERFACE
+            ${vulkan_headers_SOURCE_DIR}/include
+        )
+    endif()
+
+    if(NOT TARGET monolith_volk)
+        FetchContent_Declare(
+            volk
+            GIT_REPOSITORY https://github.com/zeux/volk.git
+            GIT_TAG        1.4.304
+            GIT_SHALLOW    TRUE
+        )
+        FetchContent_Populate(volk)
+
+        add_library(monolith_volk STATIC ${volk_SOURCE_DIR}/volk.c)
+        target_include_directories(monolith_volk PUBLIC ${volk_SOURCE_DIR})
+        target_link_libraries(monolith_volk PUBLIC monolith_vulkan_headers)
+        target_compile_definitions(monolith_volk PUBLIC VK_NO_PROTOTYPES)
+        target_compile_options(monolith_volk PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/W0>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+        )
+    endif()
+endif()
+
 # ---- glad (OpenGL 4.1 Core, pre-generated, committed) ----
 if(NOT TARGET glad)
     add_subdirectory(glad)


### PR DESCRIPTION
## Summary
- move mesh, shader, texture, and skinned-mesh OpenGL object ownership out of public headers and into private storage types
- preserve the current OpenGL rendering path through the same public methods while narrowing what higher-level code can see about backend payloads
- add architecture guards that keep raw OpenGL payload members out of engine-facing resource headers

## Motivation
- issue #121 requires renderer resources to stop exposing GL-native ownership directly before Vulkan backend work builds on them
- hiding payload members behind storage types gives the current OpenGL backend room to keep working while removing header-level coupling that would block multi-backend payload evolution

## Implementation Notes
- `Mesh`, `SkinnedMesh`, `Shader`, and `Texture` now keep backend payload state inside private storage objects owned only by the implementation files
- public APIs such as `Draw()`, `Bind()`, `IsValid()`, `GetProgramID()`, and `GetNativeId()` remain available so existing OpenGL/editor code keeps compiling
- `Texture::GetNativeId()` is intentionally kept as a temporary escape hatch until editor viewport/offscreen integration is moved behind backend-neutral handles in later issues

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_core test_renderer_foundation test_architecture_docs test_editor
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_core|test_renderer_foundation|test_architecture_docs|test_editor"
```

## Issue Links
- Refs #121
- Parent epic: #119

## Stack Notes
- base branch: `feat/122-backend-owned-render-context`
- stacked on top of PR #134, #133, #132, and root PR #118