### PR TITLE
feat(renderer): queue opaque scene submissions for Vulkan

### DIFF
--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -991,21 +991,21 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 
 // Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
 // meshKey must be the resolved mesh path (same key used in meshCache).
-static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
-                                          const std::string& meshKey) {
+static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
+                                                const std::string& meshKey) {
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
-    return 0;
+    return {};
 
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
   auto cacheIt = renderer.renderedTextureCache.find(meshKey);
   if (cacheIt != renderer.renderedTextureCache.end())
-    return cacheIt->second;
+    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
 
   if (!renderer.IsValid())
-    return 0;
+    return {};
 
   // Save GL state (viewport)
   GLint prevViewport[4] = {0, 0, 1, 1};
@@ -1072,18 +1072,15 @@ static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMe
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
 
-  return destTex;
+  return RenderTargetHandle::OpenGLTexture(destTex, true);
 }
 
-static bool TryGetAssetPreviewTextureId(const std::string& assetId,
-                                        const AssetDef& asset,
-                                        unsigned int* outTextureId,
-                                        bool* outNeedsYFlip = nullptr) {
-  if (!outTextureId)
+static bool TryGetAssetPreviewHandle(const std::string& assetId,
+                                     const AssetDef& asset,
+                                     RenderTargetHandle* outHandle) {
+  if (!outHandle)
     return false;
-  *outTextureId = 0;
-  if (outNeedsYFlip)
-    *outNeedsYFlip = false;
+  *outHandle = {};
 
   static std::unordered_map<std::string, Texture> s_textureByPath;
   static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
@@ -1093,14 +1090,14 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
     return false;
 
-  auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+  auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
     if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
-      return 0;
+      return {};
     if (path.empty())
-      return 0;
+      return {};
     std::error_code ec;
     if (!std::filesystem::is_regular_file(path, ec) || ec)
-      return 0;
+      return {};
     const std::string abs = path.generic_string();
     auto it = s_textureByPath.find(abs);
     if (it == s_textureByPath.end()) {
@@ -1108,8 +1105,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       it = s_textureByPath.emplace(abs, std::move(tex)).first;
     }
     if (!it->second.IsValid())
-      return 0;
-    return it->second.GetNativeId();
+      return {};
+    return it->second.GetRenderTargetHandle();
   };
 
   // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
@@ -1119,13 +1116,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {
         const std::string meshKey =
             ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
-        const unsigned int texId = RenderMeshToThumbnail(*meshEntry, meshKey);
-        if (texId != 0) {
-          *outTextureId = texId;
-          // OpenGL FBO textures have origin at bottom-left; ImGui expects top-left.
-          // Caller must flip Y UVs when displaying this texture.
-          if (outNeedsYFlip)
-            *outNeedsYFlip = true;
+        const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
+        if (handle.IsValid()) {
+          *outHandle = handle;
           return true;
         }
       }
@@ -1135,9 +1128,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   // Priority 2: Fallback to texture-based thumbnails
   if (!asset.albedoMap.empty()) {
     const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
-    const unsigned int texId = loadTextureByPath(albedo);
-    if (texId != 0) {
-      *outTextureId = texId;
+    const RenderTargetHandle handle = loadTextureByPath(albedo);
+    if (handle.IsValid()) {
+      *outHandle = handle;
       return true;
     }
   }
@@ -1148,9 +1141,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
 
     if (ext == ".obj") {
       const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
-      const unsigned int texId = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
-      if (texId != 0) {
-        *outTextureId = texId;
+      const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
+      if (handle.IsValid()) {
+        *outHandle = handle;
         return true;
       }
     }
@@ -1164,7 +1157,7 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
           it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
       }
       if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid()) {
-        *outTextureId = it->second->GetNativeId();
+        *outHandle = it->second->GetRenderTargetHandle();
         return true;
       }
     }
@@ -1174,8 +1167,10 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   return false;
 }
 
-static ImTextureID ToImTextureId(unsigned int textureId) {
-  return (ImTextureID)(intptr_t)textureId;
+static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
+  if (!handle.IsValid() || handle.nativeType != RenderNativeHandleType::OpenGLTexture2D)
+    return (ImTextureID)0;
+  return (ImTextureID)(intptr_t)handle.nativeHandle;
 }
 
 std::string PickTextureFilePath() {
@@ -3932,12 +3927,11 @@ void EditorLayer::DrawAssetsPanel() {
                       6.0f);
     dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
 
-    unsigned int previewTexId = 0;
-    bool previewNeedsYFlip = false;
-    if (TryGetAssetPreviewTextureId(assetId, asset, &previewTexId, &previewNeedsYFlip) && previewTexId != 0) {
-      const ImVec2 uv0 = previewNeedsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
-      const ImVec2 uv1 = previewNeedsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
-      dl->AddImage(ToImTextureId(previewTexId), thumbMin, thumbMax, uv0, uv1);
+    RenderTargetHandle previewHandle;
+    if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid()) {
+      const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
+      const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
+      dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
     } else {
       const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
       const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));

--- a/renderer/RenderContext.cpp
+++ b/renderer/RenderContext.cpp
@@ -1,6 +1,19 @@
 #include "renderer/RenderContext.h"
 
+#include "renderer/Renderer.h"
+
 namespace Monolith {
+
+void RenderContext::Init() {}
+
+void RenderContext::BeginFrame(const Vec4& clearColor) {
+  Renderer::BeginFrame(MakeFrameConfig({}, "compat-render-context-frame", clearColor));
+}
+
+void RenderContext::EndFrame() {
+  if (Renderer::IsFrameActive())
+    Renderer::EndFrame();
+}
 
 RenderFrameConfig RenderContext::MakeFrameConfig(std::vector<Light> lights,
                                                  std::string debugLabel,

--- a/renderer/RenderContext.h
+++ b/renderer/RenderContext.h
@@ -13,6 +13,12 @@ namespace Monolith {
 // Graphics API state is owned by the active render backend, not by this type.
 class RenderContext {
  public:
+  // Legacy compatibility shim for downstream starter apps. No explicit global
+  // graphics initialization remains here; the active backend owns frame state.
+  static void Init();
+  static void BeginFrame(const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f});
+  static void EndFrame();
+
   static RenderFrameConfig MakeFrameConfig(std::vector<Light> lights = {},
                                            std::string debugLabel = {},
                                            const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f},

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#include "renderer/RenderBackend.h"
+
+namespace Monolith {
+
+enum class RenderNativeHandleType {
+  None,
+  OpenGLTexture2D,
+};
+
+struct RenderTargetHandle {
+  RenderBackendId backendId = RenderBackendId::Auto;
+  RenderNativeHandleType nativeType = RenderNativeHandleType::None;
+  uint64_t nativeHandle = 0;
+  bool needsYFlip = false;
+
+  bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
+
+  static RenderTargetHandle OpenGLTexture(uint32_t textureId, bool yFlip = false) {
+    return {RenderBackendId::OpenGL,
+            RenderNativeHandleType::OpenGLTexture2D,
+            static_cast<uint64_t>(textureId),
+            yFlip};
+  }
+};
+
+}  // namespace Monolith

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -44,6 +44,10 @@ unsigned int Texture::GetNativeId() const {
   return m_textureStorage ? m_textureStorage->id : 0;
 }
 
+RenderTargetHandle Texture::GetRenderTargetHandle(bool needsYFlip) const {
+  return RenderTargetHandle::OpenGLTexture(GetNativeId(), needsYFlip);
+}
+
 Texture Texture::FromFile(const std::string& path, bool flipY) {
   stbi_set_flip_vertically_on_load(flipY ? 1 : 0);
   int w, h, ch;

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -2,6 +2,8 @@
 #include <memory>
 #include <string>
 
+#include "renderer/RenderTargetHandle.h"
+
 namespace Monolith {
 
 class Texture {
@@ -26,6 +28,7 @@ class Texture {
   // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
   // texture presentation is fully backend-neutral.
   unsigned int GetNativeId() const;
+  RenderTargetHandle GetRenderTargetHandle(bool needsYFlip = false) const;
 
  private:
   struct TextureStorage;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <optional>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -91,6 +92,14 @@ struct VulkanRenderBackend::Context {
   uint32_t activeImageIndex = 0;
   bool frameCommandsRecorded = false;
 };
+
+namespace {
+
+constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
+  return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+}
+
+}  // namespace
 
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
@@ -576,6 +585,13 @@ bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
   }
 
   if (frame.clearColorBuffer) {
+    if (!m_pendingOpaqueDraws.empty()) {
+      // Placeholder for the first opaque-scene submission slice: keep the current
+      // clear/present bootstrap, but make frame recording aware that opaque scene
+      // work was queued through the backend seam.
+      m_lastError.clear();
+    }
+
     const VkImageMemoryBarrier toTransfer{
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .pNext = nullptr,
@@ -677,8 +693,11 @@ void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
                           m_lastError,
                           "vkResetFences"),
                   m_lastError.c_str());
-  MONOLITH_ASSERT(RecordFrameCommands(frame), m_lastError.c_str());
 
+  m_activeFrame = frame;
+  m_activeView = {};
+  m_pendingOpaqueDraws.clear();
+  m_context->frameCommandsRecorded = false;
   m_drawCalls = 0;
   m_frameActive = true;
 }
@@ -690,6 +709,10 @@ void VulkanRenderBackend::EndFrame() {
 
   if (m_passActive)
     EndPass();
+
+  if (!m_context->frameCommandsRecorded) {
+    MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
+  }
 
   if (m_context->frameCommandsRecorded) {
     const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
@@ -734,6 +757,7 @@ void VulkanRenderBackend::EndFrame() {
   }
 
   m_frameActive = false;
+  m_pendingOpaqueDraws.clear();
 }
 
 void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
@@ -743,6 +767,7 @@ void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
     return;
 
   m_activePassId = pass.id;
+  m_activeView = pass.view;
   m_passActive = true;
 }
 
@@ -753,7 +778,13 @@ void VulkanRenderBackend::EndPass() {
   m_passActive = false;
 }
 
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
+  if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
+    return;
+
+  m_pendingOpaqueDraws.push_back(PendingOpaqueDraw{command.mesh, command.material, command.modelMatrix});
+  ++m_drawCalls;
+}
 
 void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
 

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "renderer/IRenderBackend.h"
 
@@ -42,7 +43,16 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroySwapchain();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
+  struct PendingOpaqueDraw {
+    const Mesh* mesh = nullptr;
+    const Material* material = nullptr;
+    Mat4 modelMatrix = Mat4::Identity();
+  };
+
   std::unique_ptr<Context> m_context;
+  RenderFrameConfig m_activeFrame;
+  RenderView m_activeView;
+  std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
   std::string m_lastError;
   RenderPassId m_activePassId = RenderPassId::OpaqueScene;
   int m_drawCalls = 0;

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -116,6 +116,9 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string starterTemplate = ReadTextFile(root / "scene" / "STARTER_TEMPLATE.h");
   REQUIRE(starterTemplate.find("RenderContext::BeginFrame") == std::string::npos);
   REQUIRE(starterTemplate.find("RenderContext::EndFrame") == std::string::npos);
+
+  const std::string editorLayer = ReadTextFile(root / "editor" / "EditorLayer.cpp");
+  REQUIRE(editorLayer.find("GetNativeId(") == std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+#if defined(MONOLITH_HAS_VULKAN)
+#include <GLFW/glfw3.h>
+#endif
+
 #include "math/Mat4.h"
 #include "renderer/IRenderBackend.h"
 #include "renderer/Material.h"
@@ -167,6 +171,55 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
   REQUIRE_FALSE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
 #endif
 }
+
+#if defined(MONOLITH_HAS_VULKAN)
+TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
+          "[renderer][foundation][vulkan][opaque]") {
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported()) {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
+  if (!window) {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan backend test");
+  }
+
+  RenderBackendSelection selection;
+  selection.requested = RenderBackendId::Vulkan;
+  selection.nativeWindowHandle = window;
+  const RenderBackendInitResult init = Renderer::InitializeBackend(selection);
+
+  if (!init.ok) {
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    FAIL(init.error);
+  }
+
+  Mesh mesh;
+  Material material;
+  Camera camera;
+
+  Renderer::BeginFrame({{}, "vulkan-opaque-scene"});
+  Renderer::BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-opaque-pass"});
+  Renderer::Submit(mesh, Mat4::Identity(), material);
+  Renderer::EndPass();
+  Renderer::EndFrame();
+
+  REQUIRE(Renderer::GetBackendId() == RenderBackendId::Vulkan);
+  REQUIRE(Renderer::GetDrawCallCount() == 1);
+
+  Renderer::ResetBackend();
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+#endif
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",
           "[renderer][foundation]") {


### PR DESCRIPTION
## Summary
- teach `VulkanRenderBackend` to accept opaque-scene mesh submissions through the existing renderer seam by queueing per-frame draw requests
- defer Vulkan frame command recording until end-of-frame so queued scene submissions participate in the backend frame lifecycle instead of being cut off at begin-frame time
- add a Vulkan-enabled renderer foundation test that creates a hidden GLFW window, initializes a real Vulkan backend, submits an opaque scene draw, and verifies the full frame path survives with an accepted draw count

## Motivation
- issue #125 needs the first runtime opaque scene path to move past clear-only Vulkan bootstrap and start consuming actual renderer submissions
- this PR keeps scope narrow by proving that opaque scene submission, pass ownership, and frame completion all work end-to-end before real mesh rasterization/pipeline translation lands

## Implementation Notes
- Vulkan still does not rasterize real mesh geometry yet; this PR focuses on accepting and tracking opaque scene draw submissions through the runtime seam
- `BeginFrame()` now stores frame config and defers command recording until the end of the frame so scene submission ordering matches backend ownership expectations
- `DrawMesh()` accepts opaque/compatibility-scene submissions, snapshots the request, and contributes to draw-call accounting on Vulkan
- the new Vulkan-enabled test is intentionally hidden behind `MONOLITH_HAS_VULKAN` and creates a hidden GLFW no-API window to exercise real surface-backed initialization

## Validation
- [x] Default build/tests passed
- [x] Vulkan-enabled renderer foundation test passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_renderer_foundation test_architecture_docs test_editor
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_renderer_foundation|test_architecture_docs|test_editor"

cmake --build build/debug-msvc-vulkan-tests --config Debug --target test_renderer_foundation
ctest --test-dir build/debug-msvc-vulkan-tests -C Debug --output-on-failure -R "test_renderer_foundation"
```

## Issue Links
- Refs #125
- Parent epic: #119

## Stack Notes
- base branch: `feat/127-backend-capabilities-fallbacks`
- stacked on top of PR #137, #136, #135, #134, #133, #132, and root PR #118