### PR TITLE
refactor(editor): introduce backend-neutral preview handles

### DIFF
--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -991,21 +991,21 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 
 // Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
 // meshKey must be the resolved mesh path (same key used in meshCache).
-static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
-                                          const std::string& meshKey) {
+static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
+                                                const std::string& meshKey) {
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
-    return 0;
+    return {};
 
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
   auto cacheIt = renderer.renderedTextureCache.find(meshKey);
   if (cacheIt != renderer.renderedTextureCache.end())
-    return cacheIt->second;
+    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
 
   if (!renderer.IsValid())
-    return 0;
+    return {};
 
   // Save GL state (viewport)
   GLint prevViewport[4] = {0, 0, 1, 1};
@@ -1072,18 +1072,15 @@ static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMe
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
 
-  return destTex;
+  return RenderTargetHandle::OpenGLTexture(destTex, true);
 }
 
-static bool TryGetAssetPreviewTextureId(const std::string& assetId,
-                                        const AssetDef& asset,
-                                        unsigned int* outTextureId,
-                                        bool* outNeedsYFlip = nullptr) {
-  if (!outTextureId)
+static bool TryGetAssetPreviewHandle(const std::string& assetId,
+                                     const AssetDef& asset,
+                                     RenderTargetHandle* outHandle) {
+  if (!outHandle)
     return false;
-  *outTextureId = 0;
-  if (outNeedsYFlip)
-    *outNeedsYFlip = false;
+  *outHandle = {};
 
   static std::unordered_map<std::string, Texture> s_textureByPath;
   static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
@@ -1093,14 +1090,14 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
     return false;
 
-  auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+  auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
     if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
-      return 0;
+      return {};
     if (path.empty())
-      return 0;
+      return {};
     std::error_code ec;
     if (!std::filesystem::is_regular_file(path, ec) || ec)
-      return 0;
+      return {};
     const std::string abs = path.generic_string();
     auto it = s_textureByPath.find(abs);
     if (it == s_textureByPath.end()) {
@@ -1108,8 +1105,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       it = s_textureByPath.emplace(abs, std::move(tex)).first;
     }
     if (!it->second.IsValid())
-      return 0;
-    return it->second.GetNativeId();
+      return {};
+    return it->second.GetRenderTargetHandle();
   };
 
   // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
@@ -1119,13 +1116,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {
         const std::string meshKey =
             ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
-        const unsigned int texId = RenderMeshToThumbnail(*meshEntry, meshKey);
-        if (texId != 0) {
-          *outTextureId = texId;
-          // OpenGL FBO textures have origin at bottom-left; ImGui expects top-left.
-          // Caller must flip Y UVs when displaying this texture.
-          if (outNeedsYFlip)
-            *outNeedsYFlip = true;
+        const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
+        if (handle.IsValid()) {
+          *outHandle = handle;
           return true;
         }
       }
@@ -1135,9 +1128,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   // Priority 2: Fallback to texture-based thumbnails
   if (!asset.albedoMap.empty()) {
     const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
-    const unsigned int texId = loadTextureByPath(albedo);
-    if (texId != 0) {
-      *outTextureId = texId;
+    const RenderTargetHandle handle = loadTextureByPath(albedo);
+    if (handle.IsValid()) {
+      *outHandle = handle;
       return true;
     }
   }
@@ -1148,9 +1141,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
 
     if (ext == ".obj") {
       const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
-      const unsigned int texId = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
-      if (texId != 0) {
-        *outTextureId = texId;
+      const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
+      if (handle.IsValid()) {
+        *outHandle = handle;
         return true;
       }
     }
@@ -1164,7 +1157,7 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
           it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
       }
       if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid()) {
-        *outTextureId = it->second->GetNativeId();
+        *outHandle = it->second->GetRenderTargetHandle();
         return true;
       }
     }
@@ -1174,8 +1167,10 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   return false;
 }
 
-static ImTextureID ToImTextureId(unsigned int textureId) {
-  return (ImTextureID)(intptr_t)textureId;
+static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
+  if (!handle.IsValid() || handle.nativeType != RenderNativeHandleType::OpenGLTexture2D)
+    return (ImTextureID)0;
+  return (ImTextureID)(intptr_t)handle.nativeHandle;
 }
 
 std::string PickTextureFilePath() {
@@ -3932,12 +3927,11 @@ void EditorLayer::DrawAssetsPanel() {
                       6.0f);
     dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
 
-    unsigned int previewTexId = 0;
-    bool previewNeedsYFlip = false;
-    if (TryGetAssetPreviewTextureId(assetId, asset, &previewTexId, &previewNeedsYFlip) && previewTexId != 0) {
-      const ImVec2 uv0 = previewNeedsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
-      const ImVec2 uv1 = previewNeedsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
-      dl->AddImage(ToImTextureId(previewTexId), thumbMin, thumbMax, uv0, uv1);
+    RenderTargetHandle previewHandle;
+    if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid()) {
+      const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
+      const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
+      dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
     } else {
       const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
       const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#include "renderer/RenderBackend.h"
+
+namespace Monolith {
+
+enum class RenderNativeHandleType {
+  None,
+  OpenGLTexture2D,
+};
+
+struct RenderTargetHandle {
+  RenderBackendId backendId = RenderBackendId::Auto;
+  RenderNativeHandleType nativeType = RenderNativeHandleType::None;
+  uint64_t nativeHandle = 0;
+  bool needsYFlip = false;
+
+  bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
+
+  static RenderTargetHandle OpenGLTexture(uint32_t textureId, bool yFlip = false) {
+    return {RenderBackendId::OpenGL,
+            RenderNativeHandleType::OpenGLTexture2D,
+            static_cast<uint64_t>(textureId),
+            yFlip};
+  }
+};
+
+}  // namespace Monolith

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -44,6 +44,10 @@ unsigned int Texture::GetNativeId() const {
   return m_textureStorage ? m_textureStorage->id : 0;
 }
 
+RenderTargetHandle Texture::GetRenderTargetHandle(bool needsYFlip) const {
+  return RenderTargetHandle::OpenGLTexture(GetNativeId(), needsYFlip);
+}
+
 Texture Texture::FromFile(const std::string& path, bool flipY) {
   stbi_set_flip_vertically_on_load(flipY ? 1 : 0);
   int w, h, ch;

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -2,6 +2,8 @@
 #include <memory>
 #include <string>
 
+#include "renderer/RenderTargetHandle.h"
+
 namespace Monolith {
 
 class Texture {
@@ -26,6 +28,7 @@ class Texture {
   // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
   // texture presentation is fully backend-neutral.
   unsigned int GetNativeId() const;
+  RenderTargetHandle GetRenderTargetHandle(bool needsYFlip = false) const;
 
  private:
   struct TextureStorage;

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -116,6 +116,9 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string starterTemplate = ReadTextFile(root / "scene" / "STARTER_TEMPLATE.h");
   REQUIRE(starterTemplate.find("RenderContext::BeginFrame") == std::string::npos);
   REQUIRE(starterTemplate.find("RenderContext::EndFrame") == std::string::npos);
+
+  const std::string editorLayer = ReadTextFile(root / "editor" / "EditorLayer.cpp");
+  REQUIRE(editorLayer.find("GetNativeId(") == std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {


### PR DESCRIPTION
## Summary
- add a backend-tagged `RenderTargetHandle` abstraction so editor preview flows can carry render-target metadata without exposing raw OpenGL texture ids as their public currency
- update editor asset preview code to consume render-target handles, including Y-flip metadata, while keeping the existing OpenGL thumbnail path working at the edge
- add an architecture guard that blocks new `EditorLayer` dependencies on `Texture::GetNativeId()`

## Motivation
- issue #124 requires an offscreen/render-target abstraction before editor and ImGui integration can become backend-neutral
- the current preview path still relied on raw OpenGL texture ids, which would make future Vulkan viewport/thumbnail work leak API details back into editor code

## Implementation Notes
- this is a narrow first slice: the handle abstraction is introduced for asset preview/thumbnail presentation, not yet the full offscreen system
- `Texture::GetRenderTargetHandle()` wraps the temporary OpenGL-native escape hatch so higher-level preview code now deals in backend-tagged handles
- `EditorLayer` now uses `RenderTargetHandle` plus `needsYFlip` metadata when drawing preview images, and no longer calls `GetNativeId()` directly

## Validation
- [x] Default targeted tests passed
- [x] Vulkan-enabled targeted tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_architecture_docs test_editor
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_architecture_docs|test_editor|test_renderer_foundation"

cmake --build build/debug-msvc-vulkan-tests --config Debug --target test_architecture_docs test_renderer_foundation
ctest --test-dir build/debug-msvc-vulkan-tests -C Debug --output-on-failure -R "test_architecture_docs|test_renderer_foundation"
```

## Issue Links
- Refs #124
- Parent epic: #119

## Stack Notes
- base branch: `feat/125-vulkan-opaque-scene-path`
- stacked on top of PR #138, #137, #136, #135, #134, #133, #132, and root PR #118