### PR TITLE
docs(renderer): align Vulkan parity architecture plan

### DIFF
--- a/docs/architecture/vulkan-backend-integration-and-backend-parity.md
+++ b/docs/architecture/vulkan-backend-integration-and-backend-parity.md
@@ -100,14 +100,68 @@ Hidden no-ops are not acceptable unless the fallback is documented and test-cove
 
 The current renderer capability model already tracks a small set of backend features. Vulkan parity work is expected to extend that model so higher-level systems can make explicit decisions about at least:
 
+- debug draw support
 - wireframe overlay support
 - debug label support
 - offscreen target support
+- native texture handle support
 - readback / screenshot support
+- depth-readback support
 - editor viewport support
 - debug HUD feature availability
 
+The current parity stack has already established explicit capability gates for:
+
+- debug draw
+- wireframe overlay
+- offscreen target usage in editor preview flows
+- native texture handle usage in editor preview flows
+- screenshot/readback
+- depth-readback-dependent DebugHUD behavior
+- ImGui backend selection support
+
 This document does not require all of those fields to be added in one PR. It requires the final parity work to move toward explicit capability checks instead of backend-specific branching in editor or scene code.
+
+## Current Implemented Foundation State
+
+The current stacked implementation toward this epic now provides:
+
+- backend-aware window/bootstrap ownership split
+- backend-owned frame output control
+- hidden OpenGL payload storage behind resource implementations
+- opt-in Vulkan dependency scaffolding (`Vulkan-Headers` + `volk`)
+- minimal Vulkan backend bootstrap with instance/device/surface/swapchain/clear/present
+- opaque-scene submission acceptance through the Vulkan backend seam
+- backend-neutral preview handle abstraction for editor thumbnail paths
+- editor ImGui backend routing through an explicit backend shim
+- capability-gated debug draw, screenshot/readback, and DebugHUD depth-readback behavior
+
+This means the architecture discussion is no longer purely aspirational. Follow-up work should now focus on turning these seams into fuller parity rather than reintroducing OpenGL assumptions into the engine-facing layers.
+
+## Remaining Work After The Current Stack
+
+The largest remaining gaps after the current implementation stack are:
+
+- real Vulkan mesh/material/pipeline translation beyond accepted opaque-scene submissions
+- backend-neutral editor viewport rendering rather than seam-only backend routing
+- full offscreen render-target ownership beyond preview handles
+- backend-owned screenshot/readback implementations rather than capability-gated OpenGL-only behavior
+- broader parity CI once Vulkan coverage is stable enough for hosted runners
+
+These gaps should be treated as explicit backlog, not silent capability drift.
+
+## Validation Strategy
+
+The living validation contract for this epic now lives in:
+
+- `docs/development/backend-parity-validation-matrix.md`
+
+That matrix complements this architecture document by defining:
+
+- required default-build contract tests
+- Vulkan-enabled smoke coverage
+- required command lines for parity-related PRs
+- current known validation gaps
 
 ## Acceptance Criteria For Closing The Scope Phase
 

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -14,68 +14,77 @@
 #include <imgui_impl_vulkan.h>
 #endif
 
-namespace Monolith::Editor {
+namespace Monolith::Editor
+{
 
-namespace {
+  namespace
+  {
 
 #if defined(MONOLITH_HAS_VULKAN)
-struct VulkanImGuiState {
-  VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
-  bool initialized = false;
-};
+    struct VulkanImGuiState
+    {
+      VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+      bool initialized = false;
+      uint32_t minImageCount = 0;
+    };
 
-VulkanImGuiState g_vulkanImGuiState;
+    VulkanImGuiState g_vulkanImGuiState;
 
-VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device) {
-  const VkDescriptorPoolSize poolSizes[] = {
-      {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
-      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
-      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
-      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
-      {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
-  };
+    VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device)
+    {
+      const VkDescriptorPoolSize poolSizes[] = {
+          {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
+          {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
+          {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
+          {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
+          {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
+      };
 
-  const VkDescriptorPoolCreateInfo poolInfo{
-      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-      .maxSets = 512,
-      .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
-      .pPoolSizes = poolSizes,
-  };
+      const VkDescriptorPoolCreateInfo poolInfo{
+          .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+          .maxSets = 512,
+          .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
+          .pPoolSizes = poolSizes,
+      };
 
-  VkDescriptorPool pool = VK_NULL_HANDLE;
-  if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
-    return VK_NULL_HANDLE;
-  return pool;
-}
+      VkDescriptorPool pool = VK_NULL_HANDLE;
+      if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
+        return VK_NULL_HANDLE;
+      return pool;
+    }
 
-void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
-  if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
-    return;
-  vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
-  g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
-}
+    void DestroyVulkanImGuiDescriptorPool(VkDevice device)
+    {
+      if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+        return;
+      vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
+      g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
+    }
 
-void RenderVulkanImGuiDrawDataCallback(void* userData, void* commandBufferHandle) {
-  if (userData == nullptr || commandBufferHandle == nullptr)
-    return;
+    void RenderVulkanImGuiDrawDataCallback(void *userData, void *commandBufferHandle)
+    {
+      if (userData == nullptr || commandBufferHandle == nullptr)
+        return;
 
-  ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData*>(userData),
-                                  reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
-}
+      ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData *>(userData),
+                                      reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+    }
 #endif
 
-}  // namespace
+  } // namespace
 
-bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
-  switch (backendId) {
+  bool IsSupportedEditorImGuiBackend(RenderBackendId backendId)
+  {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       return true;
@@ -85,32 +94,35 @@ bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
 #else
       return false;
 #endif
+    }
+
+    return false;
   }
 
-  return false;
-}
+  bool InitEditorImGuiBackend(GLFWwindow *window, RenderBackendId backendId)
+  {
+    if (!window || !IsSupportedEditorImGuiBackend(backendId))
+      return false;
 
-bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
-  if (!window || !IsSupportedEditorImGuiBackend(backendId))
-    return false;
-
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplGlfw_InitForOpenGL(window, true);
       ImGui_ImplOpenGL3_Init("#version 410");
       return true;
-    case RenderBackendId::Vulkan: {
+    case RenderBackendId::Vulkan:
+    {
 #if defined(MONOLITH_HAS_VULKAN)
-      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
       if (!backend)
         return false;
 
-      void* instanceHandle = nullptr;
-      void* physicalDeviceHandle = nullptr;
-      void* deviceHandle = nullptr;
-      void* queueHandle = nullptr;
-      void* renderPassHandle = nullptr;
+      void *instanceHandle = nullptr;
+      void *physicalDeviceHandle = nullptr;
+      void *deviceHandle = nullptr;
+      void *queueHandle = nullptr;
+      void *renderPassHandle = nullptr;
       uint32_t queueFamily = 0;
       uint32_t imageCount = 0;
       if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
@@ -119,18 +131,21 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
                                               &queueFamily,
                                               &queueHandle,
                                               &renderPassHandle,
-                                              &imageCount)) {
+                                              &imageCount))
+      {
         return false;
       }
 
       const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
-      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE) {
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+      {
         g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
       }
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
         return false;
 
-      if (!ImGui_ImplGlfw_InitForVulkan(window, true)) {
+      if (!ImGui_ImplGlfw_InitForVulkan(window, true))
+      {
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
@@ -149,34 +164,39 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
       initInfo.Subpass = 0;
       initInfo.UseDynamicRendering = false;
 
-      if (!ImGui_ImplVulkan_Init(&initInfo)) {
+      if (!ImGui_ImplVulkan_Init(&initInfo))
+      {
         ImGui_ImplGlfw_Shutdown();
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
 
       g_vulkanImGuiState.initialized = true;
+      g_vulkanImGuiState.minImageCount = initInfo.MinImageCount;
       return true;
 #else
       return false;
 #endif
     }
+    }
+
+    return false;
   }
 
-  return false;
-}
+  void ShutdownEditorImGuiBackend(RenderBackendId backendId)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId))
+      return;
 
-void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
-  if (!IsSupportedEditorImGuiBackend(backendId))
-    return;
-
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_Shutdown();
       ImGui_ImplGlfw_Shutdown();
       return;
-    case RenderBackendId::Vulkan: {
+    case RenderBackendId::Vulkan:
+    {
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
@@ -184,31 +204,36 @@ void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
       ImGui_ImplVulkan_Shutdown();
       ImGui_ImplGlfw_Shutdown();
       g_vulkanImGuiState.initialized = false;
+      g_vulkanImGuiState.minImageCount = 0;
 
-      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
-      if (backend) {
-        void* deviceHandle = nullptr;
+      auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
+      if (backend)
+      {
+        void *deviceHandle = nullptr;
         if (backend->TryGetImGuiVulkanInitData(nullptr,
-                                              nullptr,
-                                              &deviceHandle,
-                                              nullptr,
-                                              nullptr,
-                                              nullptr,
-                                              nullptr)) {
+                                               nullptr,
+                                               &deviceHandle,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr))
+        {
           DestroyVulkanImGuiDescriptorPool(reinterpret_cast<VkDevice>(deviceHandle));
         }
       }
 #endif
       return;
     }
+    }
   }
-}
 
-void BeginEditorImGuiFrame(RenderBackendId backendId) {
-  if (!IsSupportedEditorImGuiBackend(backendId))
-    return;
+  void BeginEditorImGuiFrame(RenderBackendId backendId)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId))
+      return;
 
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_NewFrame();
@@ -218,18 +243,41 @@ void BeginEditorImGuiFrame(RenderBackendId backendId) {
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
+
+      if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
+      {
+        uint32_t imageCount = 0;
+        if (backend->TryGetImGuiVulkanInitData(nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               &imageCount))
+        {
+          const uint32_t minImageCount = std::max(2u, imageCount);
+          if (minImageCount != g_vulkanImGuiState.minImageCount)
+          {
+            ImGui_ImplVulkan_SetMinImageCount(minImageCount);
+            g_vulkanImGuiState.minImageCount = minImageCount;
+          }
+        }
+      }
+
       ImGui_ImplVulkan_NewFrame();
       ImGui_ImplGlfw_NewFrame();
 #endif
       return;
+    }
   }
-}
 
-void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) {
-  if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
-    return;
+  void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData *drawData)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
+      return;
 
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_RenderDrawData(drawData);
@@ -238,12 +286,13 @@ void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) 
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
-      if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
+      if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
+      {
         backend->QueueOverlayRenderCallback(&RenderVulkanImGuiDrawDataCallback, drawData);
       }
 #endif
       return;
+    }
   }
-}
 
-}  // namespace Monolith::Editor
+} // namespace Monolith::Editor

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -24,6 +24,7 @@ namespace Monolith::Editor
     struct VulkanImGuiState
     {
       VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+      VkRenderPass renderPass = VK_NULL_HANDLE;
       bool initialized = false;
       uint32_t minImageCount = 0;
     };
@@ -77,6 +78,52 @@ namespace Monolith::Editor
       ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData *>(userData),
                                       reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
     }
+
+    bool TryBuildVulkanImGuiInitInfo(VulkanRenderBackend *backend,
+                                     ImGui_ImplVulkan_InitInfo *outInitInfo,
+                                     uint32_t *outMinImageCount,
+                                     VkRenderPass *outRenderPass)
+    {
+      if (!backend || !outInitInfo || !outMinImageCount || !outRenderPass)
+        return false;
+
+      void *instanceHandle = nullptr;
+      void *physicalDeviceHandle = nullptr;
+      void *deviceHandle = nullptr;
+      void *queueHandle = nullptr;
+      void *renderPassHandle = nullptr;
+      uint32_t queueFamily = 0;
+      uint32_t imageCount = 0;
+      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
+                                              &physicalDeviceHandle,
+                                              &deviceHandle,
+                                              &queueFamily,
+                                              &queueHandle,
+                                              &renderPassHandle,
+                                              &imageCount))
+      {
+        return false;
+      }
+
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
+      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
+      initInfo.Device = reinterpret_cast<VkDevice>(deviceHandle);
+      initInfo.QueueFamily = queueFamily;
+      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
+      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
+      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
+      initInfo.MinImageCount = std::max(2u, imageCount);
+      initInfo.ImageCount = std::max(2u, imageCount);
+      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+      initInfo.Subpass = 0;
+      initInfo.UseDynamicRendering = false;
+
+      *outInitInfo = initInfo;
+      *outMinImageCount = initInfo.MinImageCount;
+      *outRenderPass = initInfo.RenderPass;
+      return true;
+    }
 #endif
 
   } // namespace
@@ -118,25 +165,13 @@ namespace Monolith::Editor
       if (!backend)
         return false;
 
-      void *instanceHandle = nullptr;
-      void *physicalDeviceHandle = nullptr;
-      void *deviceHandle = nullptr;
-      void *queueHandle = nullptr;
-      void *renderPassHandle = nullptr;
-      uint32_t queueFamily = 0;
-      uint32_t imageCount = 0;
-      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
-                                              &physicalDeviceHandle,
-                                              &deviceHandle,
-                                              &queueFamily,
-                                              &queueHandle,
-                                              &renderPassHandle,
-                                              &imageCount))
-      {
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      uint32_t minImageCount = 0;
+      VkRenderPass renderPass = VK_NULL_HANDLE;
+      if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
         return false;
-      }
 
-      const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
+      const VkDevice device = initInfo.Device;
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
       {
         g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
@@ -144,25 +179,14 @@ namespace Monolith::Editor
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
         return false;
 
+      if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
+        return false;
+
       if (!ImGui_ImplGlfw_InitForVulkan(window, true))
       {
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
-
-      ImGui_ImplVulkan_InitInfo initInfo{};
-      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
-      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
-      initInfo.Device = device;
-      initInfo.QueueFamily = queueFamily;
-      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
-      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
-      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
-      initInfo.MinImageCount = std::max(2u, imageCount);
-      initInfo.ImageCount = std::max(2u, imageCount);
-      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
-      initInfo.Subpass = 0;
-      initInfo.UseDynamicRendering = false;
 
       if (!ImGui_ImplVulkan_Init(&initInfo))
       {
@@ -172,7 +196,8 @@ namespace Monolith::Editor
       }
 
       g_vulkanImGuiState.initialized = true;
-      g_vulkanImGuiState.minImageCount = initInfo.MinImageCount;
+  g_vulkanImGuiState.minImageCount = minImageCount;
+  g_vulkanImGuiState.renderPass = renderPass;
       return true;
 #else
       return false;
@@ -205,6 +230,7 @@ namespace Monolith::Editor
       ImGui_ImplGlfw_Shutdown();
       g_vulkanImGuiState.initialized = false;
       g_vulkanImGuiState.minImageCount = 0;
+      g_vulkanImGuiState.renderPass = VK_NULL_HANDLE;
 
       auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
       if (backend)
@@ -246,21 +272,29 @@ namespace Monolith::Editor
 
       if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
       {
-        uint32_t imageCount = 0;
-        if (backend->TryGetImGuiVulkanInitData(nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               &imageCount))
+        ImGui_ImplVulkan_InitInfo initInfo{};
+        uint32_t minImageCount = 0;
+        VkRenderPass renderPass = VK_NULL_HANDLE;
+        if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
+          return;
+
+        if (renderPass != g_vulkanImGuiState.renderPass)
         {
-          const uint32_t minImageCount = std::max(2u, imageCount);
-          if (minImageCount != g_vulkanImGuiState.minImageCount)
+          ImGui_ImplVulkan_Shutdown();
+          if (!ImGui_ImplVulkan_Init(&initInfo))
           {
-            ImGui_ImplVulkan_SetMinImageCount(minImageCount);
-            g_vulkanImGuiState.minImageCount = minImageCount;
+            g_vulkanImGuiState.initialized = false;
+            g_vulkanImGuiState.minImageCount = 0;
+            g_vulkanImGuiState.renderPass = VK_NULL_HANDLE;
+            return;
           }
+          g_vulkanImGuiState.renderPass = renderPass;
+          g_vulkanImGuiState.minImageCount = minImageCount;
+        }
+        else if (minImageCount != g_vulkanImGuiState.minImageCount)
+        {
+          ImGui_ImplVulkan_SetMinImageCount(minImageCount);
+          g_vulkanImGuiState.minImageCount = minImageCount;
         }
       }
 
@@ -285,6 +319,8 @@ namespace Monolith::Editor
     case RenderBackendId::Vulkan:
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
+        return;
+      if (!Renderer::IsFrameActive())
         return;
       if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
       {

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -196,8 +196,8 @@ namespace Monolith::Editor
       }
 
       g_vulkanImGuiState.initialized = true;
-  g_vulkanImGuiState.minImageCount = minImageCount;
-  g_vulkanImGuiState.renderPass = renderPass;
+      g_vulkanImGuiState.minImageCount = minImageCount;
+      g_vulkanImGuiState.renderPass = renderPass;
       return true;
 #else
       return false;

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -1,11 +1,70 @@
 #include "editor/EditorImGuiBackend.h"
 
+#include <algorithm>
+
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 
+#include "renderer/Renderer.h"
+#include "renderer/VulkanRenderBackend.h"
+
+#if defined(MONOLITH_HAS_VULKAN)
+#include <imgui_impl_vulkan.h>
+#endif
+
 namespace Monolith::Editor {
+
+namespace {
+
+#if defined(MONOLITH_HAS_VULKAN)
+struct VulkanImGuiState {
+  VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+  bool initialized = false;
+};
+
+VulkanImGuiState g_vulkanImGuiState;
+
+VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device) {
+  const VkDescriptorPoolSize poolSizes[] = {
+      {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
+      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
+      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
+      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
+      {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
+  };
+
+  const VkDescriptorPoolCreateInfo poolInfo{
+      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+      .maxSets = 512,
+      .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
+      .pPoolSizes = poolSizes,
+  };
+
+  VkDescriptorPool pool = VK_NULL_HANDLE;
+  if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
+    return VK_NULL_HANDLE;
+  return pool;
+}
+
+void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
+  if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+    return;
+  vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
+  g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
+}
+#endif
+
+}  // namespace
 
 bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
   switch (backendId) {
@@ -13,7 +72,11 @@ bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
     case RenderBackendId::OpenGL:
       return true;
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      return true;
+#else
       return false;
+#endif
   }
 
   return false;
@@ -23,32 +86,165 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
   if (!window || !IsSupportedEditorImGuiBackend(backendId))
     return false;
 
-  ImGui_ImplGlfw_InitForOpenGL(window, true);
-  ImGui_ImplOpenGL3_Init("#version 410");
-  return true;
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplGlfw_InitForOpenGL(window, true);
+      ImGui_ImplOpenGL3_Init("#version 410");
+      return true;
+    case RenderBackendId::Vulkan: {
+#if defined(MONOLITH_HAS_VULKAN)
+      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      if (!backend)
+        return false;
+
+      void* instanceHandle = nullptr;
+      void* physicalDeviceHandle = nullptr;
+      void* deviceHandle = nullptr;
+      void* queueHandle = nullptr;
+      void* renderPassHandle = nullptr;
+      uint32_t queueFamily = 0;
+      uint32_t imageCount = 0;
+      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
+                                              &physicalDeviceHandle,
+                                              &deviceHandle,
+                                              &queueFamily,
+                                              &queueHandle,
+                                              &renderPassHandle,
+                                              &imageCount)) {
+        return false;
+      }
+
+      const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE) {
+        g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
+      }
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+        return false;
+
+      if (!ImGui_ImplGlfw_InitForVulkan(window, true)) {
+        DestroyVulkanImGuiDescriptorPool(device);
+        return false;
+      }
+
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
+      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
+      initInfo.Device = device;
+      initInfo.QueueFamily = queueFamily;
+      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
+      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
+      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
+      initInfo.MinImageCount = std::max(2u, imageCount);
+      initInfo.ImageCount = std::max(2u, imageCount);
+      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+      initInfo.Subpass = 0;
+      initInfo.UseDynamicRendering = false;
+
+      if (!ImGui_ImplVulkan_Init(&initInfo)) {
+        ImGui_ImplGlfw_Shutdown();
+        DestroyVulkanImGuiDescriptorPool(device);
+        return false;
+      }
+
+      g_vulkanImGuiState.initialized = true;
+      return true;
+#else
+      return false;
+#endif
+    }
+  }
+
+  return false;
 }
 
 void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
   if (!IsSupportedEditorImGuiBackend(backendId))
     return;
 
-  ImGui_ImplOpenGL3_Shutdown();
-  ImGui_ImplGlfw_Shutdown();
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_Shutdown();
+      ImGui_ImplGlfw_Shutdown();
+      return;
+    case RenderBackendId::Vulkan: {
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+
+      ImGui_ImplVulkan_Shutdown();
+      ImGui_ImplGlfw_Shutdown();
+      g_vulkanImGuiState.initialized = false;
+
+      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      if (backend) {
+        void* deviceHandle = nullptr;
+        if (backend->TryGetImGuiVulkanInitData(nullptr,
+                                              nullptr,
+                                              &deviceHandle,
+                                              nullptr,
+                                              nullptr,
+                                              nullptr,
+                                              nullptr)) {
+          DestroyVulkanImGuiDescriptorPool(reinterpret_cast<VkDevice>(deviceHandle));
+        }
+      }
+#endif
+      return;
+    }
+  }
 }
 
 void BeginEditorImGuiFrame(RenderBackendId backendId) {
   if (!IsSupportedEditorImGuiBackend(backendId))
     return;
 
-  ImGui_ImplOpenGL3_NewFrame();
-  ImGui_ImplGlfw_NewFrame();
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_NewFrame();
+      ImGui_ImplGlfw_NewFrame();
+      return;
+    case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+      ImGui_ImplVulkan_NewFrame();
+      ImGui_ImplGlfw_NewFrame();
+#endif
+      return;
+  }
 }
 
 void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) {
   if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
     return;
 
-  ImGui_ImplOpenGL3_RenderDrawData(drawData);
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_RenderDrawData(drawData);
+      return;
+    case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+
+      // Vulkan draw data submission requires an active recording command buffer.
+      if (!Renderer::IsPassActive())
+        return;
+
+      if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
+        void* commandBufferHandle = backend->GetActiveCommandBufferHandle();
+        if (commandBufferHandle != nullptr) {
+          ImGui_ImplVulkan_RenderDrawData(drawData,
+                                          reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+        }
+      }
+#endif
+      return;
+  }
 }
 
 }  // namespace Monolith::Editor

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -62,6 +62,14 @@ void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
   vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
   g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
 }
+
+void RenderVulkanImGuiDrawDataCallback(void* userData, void* commandBufferHandle) {
+  if (userData == nullptr || commandBufferHandle == nullptr)
+    return;
+
+  ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData*>(userData),
+                                  reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+}
 #endif
 
 }  // namespace
@@ -230,17 +238,8 @@ void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) 
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
-
-      // Vulkan draw data submission requires an active recording command buffer.
-      if (!Renderer::IsPassActive())
-        return;
-
       if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
-        void* commandBufferHandle = backend->GetActiveCommandBufferHandle();
-        if (commandBufferHandle != nullptr) {
-          ImGui_ImplVulkan_RenderDrawData(drawData,
-                                          reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
-        }
+        backend->QueueOverlayRenderCallback(&RenderVulkanImGuiDrawDataCallback, drawData);
       }
 #endif
       return;

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -64,6 +64,10 @@ RenderBackendCapabilities Renderer::GetBackendCapabilities() {
   return ActiveBackend()->GetCapabilities();
 }
 
+IRenderBackend* Renderer::GetBackendForInterop() {
+  return ActiveBackend();
+}
+
 bool Renderer::IsBackendSupported(RenderBackendId backendId) {
   return Monolith::IsRenderBackendSupported(backendId);
 }

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -5,152 +5,174 @@
 #include "core/Assert.h"
 #include "renderer/RenderBackendFactory.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-namespace {
+  namespace
+  {
 
-std::unique_ptr<IRenderBackend> CreateDefaultOwnedBackend() {
-  RenderBackendCreateResult createResult = CreateRenderBackend({});
-  MONOLITH_ASSERT(createResult.backend != nullptr,
-                  "Failed to create the default OpenGL render backend");
-  return std::move(createResult.backend);
-}
+    std::unique_ptr<IRenderBackend> CreateDefaultOwnedBackend()
+    {
+      RenderBackendCreateResult createResult = CreateRenderBackend({});
+      MONOLITH_ASSERT(createResult.backend != nullptr,
+                      "Failed to create the default OpenGL render backend");
+      return std::move(createResult.backend);
+    }
 
-std::unique_ptr<IRenderBackend> g_ownedBackend = CreateDefaultOwnedBackend();
-IRenderBackend* g_backend = g_ownedBackend.get();
+    std::unique_ptr<IRenderBackend> g_ownedBackend = CreateDefaultOwnedBackend();
+    IRenderBackend *g_backend = g_ownedBackend.get();
 
-IRenderBackend* ResetToDefaultBackend() {
-  g_ownedBackend = CreateDefaultOwnedBackend();
-  g_backend = g_ownedBackend.get();
-  return g_backend;
-}
+    IRenderBackend *ResetToDefaultBackend()
+    {
+      g_ownedBackend = CreateDefaultOwnedBackend();
+      g_backend = g_ownedBackend.get();
+      return g_backend;
+    }
 
-}  // namespace
+  } // namespace
 
-bool Renderer::s_frameActive = false;
-bool Renderer::s_passActive = false;
+  bool Renderer::s_frameActive = false;
+  bool Renderer::s_passActive = false;
 
-IRenderBackend* Renderer::ActiveBackend() {
-  MONOLITH_ASSERT(g_backend != nullptr, "Renderer backend pointer should never be null");
-  return g_backend;
-}
+  IRenderBackend *Renderer::ActiveBackend()
+  {
+    MONOLITH_ASSERT(g_backend != nullptr, "Renderer backend pointer should never be null");
+    return g_backend;
+  }
 
-RenderBackendInitResult Renderer::InitializeBackend(const RenderBackendSelection& selection) {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot initialize render backend while a frame or pass is active");
+  RenderBackendInitResult Renderer::InitializeBackend(const RenderBackendSelection &selection)
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot initialize render backend while a frame or pass is active");
 
-  RenderBackendInitResult out;
-  out.requested = selection.requested;
+    RenderBackendInitResult out;
+    out.requested = selection.requested;
 
-  RenderBackendCreateResult createResult = CreateRenderBackend(selection);
-  out.selected = createResult.selected;
-  out.error = std::move(createResult.error);
-  if (!createResult.backend)
+    RenderBackendCreateResult createResult = CreateRenderBackend(selection);
+    out.selected = createResult.selected;
+    out.error = std::move(createResult.error);
+    if (!createResult.backend)
+      return out;
+
+    g_ownedBackend = std::move(createResult.backend);
+    g_backend = g_ownedBackend.get();
+    out.ok = true;
+    out.selected = g_backend->GetBackendId();
+    out.capabilities = g_backend->GetCapabilities();
     return out;
+  }
 
-  g_ownedBackend = std::move(createResult.backend);
-  g_backend = g_ownedBackend.get();
-  out.ok = true;
-  out.selected = g_backend->GetBackendId();
-  out.capabilities = g_backend->GetCapabilities();
-  return out;
-}
+  RenderBackendId Renderer::GetBackendId()
+  {
+    return ActiveBackend()->GetBackendId();
+  }
 
-RenderBackendId Renderer::GetBackendId() {
-  return ActiveBackend()->GetBackendId();
-}
+  RenderBackendCapabilities Renderer::GetBackendCapabilities()
+  {
+    return ActiveBackend()->GetCapabilities();
+  }
 
-RenderBackendCapabilities Renderer::GetBackendCapabilities() {
-  return ActiveBackend()->GetCapabilities();
-}
+  IRenderBackend *Renderer::GetBackendForInterop()
+  {
+    return ActiveBackend();
+  }
 
-IRenderBackend* Renderer::GetBackendForInterop() {
-  return ActiveBackend();
-}
+  bool Renderer::IsBackendSupported(RenderBackendId backendId)
+  {
+    return Monolith::IsRenderBackendSupported(backendId);
+  }
 
-bool Renderer::IsBackendSupported(RenderBackendId backendId) {
-  return Monolith::IsRenderBackendSupported(backendId);
-}
+  void Renderer::UseBackend(IRenderBackend *backend)
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot swap render backend while a frame or pass is active");
+    g_ownedBackend.reset();
+    g_backend = backend ? backend : ResetToDefaultBackend();
+  }
 
-void Renderer::UseBackend(IRenderBackend* backend) {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot swap render backend while a frame or pass is active");
-  g_ownedBackend.reset();
-  g_backend = backend ? backend : ResetToDefaultBackend();
-}
+  void Renderer::ResetBackend()
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot reset render backend while a frame or pass is active");
+    ResetToDefaultBackend();
+  }
 
-void Renderer::ResetBackend() {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot reset render backend while a frame or pass is active");
-  ResetToDefaultBackend();
-}
+  void Renderer::BeginFrame(const RenderFrameConfig &frame)
+  {
+    MONOLITH_ASSERT(!s_frameActive, "Renderer::BeginFrame called while a frame is already active");
 
-void Renderer::BeginFrame(const RenderFrameConfig& frame) {
-  MONOLITH_ASSERT(!s_frameActive, "Renderer::BeginFrame called while a frame is already active");
+    ActiveBackend()->BeginFrame(frame);
+    s_frameActive = true;
+  }
 
-  ActiveBackend()->BeginFrame(frame);
-  s_frameActive = true;
-}
+  void Renderer::EndFrame()
+  {
+    MONOLITH_ASSERT(s_frameActive, "Renderer::EndFrame called without an active frame");
+    if (!s_frameActive)
+      return;
 
-void Renderer::EndFrame() {
-  MONOLITH_ASSERT(s_frameActive, "Renderer::EndFrame called without an active frame");
-  if (!s_frameActive)
-    return;
+    if (s_passActive)
+      EndPass();
 
-  if (s_passActive)
-    EndPass();
+    ActiveBackend()->EndFrame();
+    s_frameActive = false;
+  }
 
-  ActiveBackend()->EndFrame();
-  s_frameActive = false;
-}
+  void Renderer::BeginPass(const RenderPassConfig &pass)
+  {
+    MONOLITH_ASSERT(s_frameActive, "Renderer::BeginPass called without an active frame");
+    MONOLITH_ASSERT(!s_passActive, "Renderer::BeginPass called while another pass is still active");
+    if (!s_frameActive || s_passActive)
+      return;
 
-void Renderer::BeginPass(const RenderPassConfig& pass) {
-  MONOLITH_ASSERT(s_frameActive, "Renderer::BeginPass called without an active frame");
-  MONOLITH_ASSERT(!s_passActive, "Renderer::BeginPass called while another pass is still active");
-  if (!s_frameActive || s_passActive)
-    return;
+    ActiveBackend()->BeginPass(pass);
+    s_passActive = true;
+  }
 
-  ActiveBackend()->BeginPass(pass);
-  s_passActive = true;
-}
+  void Renderer::EndPass()
+  {
+    MONOLITH_ASSERT(s_passActive, "Renderer::EndPass called without an active pass");
+    if (!s_passActive)
+      return;
 
-void Renderer::EndPass() {
-  MONOLITH_ASSERT(s_passActive, "Renderer::EndPass called without an active pass");
-  if (!s_passActive)
-    return;
+    ActiveBackend()->EndPass();
+    s_passActive = false;
+  }
 
-  ActiveBackend()->EndPass();
-  s_passActive = false;
-}
+  bool Renderer::IsFrameActive()
+  {
+    return s_frameActive;
+  }
 
-bool Renderer::IsFrameActive() {
-  return s_frameActive;
-}
+  bool Renderer::IsPassActive()
+  {
+    return s_passActive;
+  }
 
-bool Renderer::IsPassActive() {
-  return s_passActive;
-}
+  void Renderer::Submit(const Mesh &mesh, const Mat4 &modelMatrix, Material &material)
+  {
+    ActiveBackend()->DrawMesh(MeshDrawCommand{&mesh, &material, modelMatrix});
+  }
 
-void Renderer::Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material) {
-  ActiveBackend()->DrawMesh(MeshDrawCommand{&mesh, &material, modelMatrix});
-}
+  void Renderer::SubmitSkinned(const SkinnedMesh &mesh,
+                               const Mat4 &modelMatrix,
+                               Material &material,
+                               const std::vector<Mat4> &boneMatrices)
+  {
+    ActiveBackend()->DrawSkinnedMesh(
+        SkinnedMeshDrawCommand{&mesh, &material, modelMatrix, &boneMatrices});
+  }
 
-void Renderer::SubmitSkinned(const SkinnedMesh& mesh,
-                              const Mat4& modelMatrix,
-                              Material& material,
-                              const std::vector<Mat4>& boneMatrices) {
-  ActiveBackend()->DrawSkinnedMesh(
-      SkinnedMeshDrawCommand{&mesh, &material, modelMatrix, &boneMatrices});
-}
+  void Renderer::SubmitWireframe(
+      const Mesh &mesh, const Mat4 &model, Shader &shader, float r, float g, float b)
+  {
+    ActiveBackend()->DrawWireframe(
+        WireframeDrawCommand{&mesh, &shader, model, {r, g, b, 1.0f}});
+  }
 
-void Renderer::SubmitWireframe(
-    const Mesh& mesh, const Mat4& model, Shader& shader, float r, float g, float b) {
-  ActiveBackend()->DrawWireframe(
-      WireframeDrawCommand{&mesh, &shader, model, {r, g, b, 1.0f}});
-}
+  int Renderer::GetDrawCallCount()
+  {
+    return ActiveBackend()->GetDrawCallCount();
+  }
 
-int Renderer::GetDrawCallCount() {
-  return ActiveBackend()->GetDrawCallCount();
-}
-
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -7,56 +7,58 @@
 #include "renderer/IRenderBackend.h"
 #include "renderer/RenderTypes.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-class Mesh;
-class Shader;
-class Material;
-class SkinnedMesh;
+  class Mesh;
+  class Shader;
+  class Material;
+  class SkinnedMesh;
 
-class Renderer {
- public:
-  static RenderBackendInitResult InitializeBackend(const RenderBackendSelection& selection = {});
-  static RenderBackendId GetBackendId();
-  static RenderBackendCapabilities GetBackendCapabilities();
-  static bool IsBackendSupported(RenderBackendId backendId);
-  static IRenderBackend* GetBackendForInterop();
+  class Renderer
+  {
+  public:
+    static RenderBackendInitResult InitializeBackend(const RenderBackendSelection &selection = {});
+    static RenderBackendId GetBackendId();
+    static RenderBackendCapabilities GetBackendCapabilities();
+    static bool IsBackendSupported(RenderBackendId backendId);
+    static IRenderBackend *GetBackendForInterop();
 
-  // Test seam: temporarily override the active backend with an externally owned implementation.
-  static void UseBackend(IRenderBackend* backend);
-  static void ResetBackend();
+    // Test seam: temporarily override the active backend with an externally owned implementation.
+    static void UseBackend(IRenderBackend *backend);
+    static void ResetBackend();
 
-  static void BeginFrame(const RenderFrameConfig& frame);
-  static void EndFrame();
-  static void BeginPass(const RenderPassConfig& pass);
-  static void EndPass();
-  static bool IsFrameActive();
-  static bool IsPassActive();
+    static void BeginFrame(const RenderFrameConfig &frame);
+    static void EndFrame();
+    static void BeginPass(const RenderPassConfig &pass);
+    static void EndPass();
+    static bool IsFrameActive();
+    static bool IsPassActive();
 
-  // Submit a mesh for rendering with a given model matrix and material
-  static void Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material);
+    // Submit a mesh for rendering with a given model matrix and material
+    static void Submit(const Mesh &mesh, const Mat4 &modelMatrix, Material &material);
 
-  // Submit a skinned mesh — uploads boneMatrices to u_boneMatrices[0..N] via SetMat4Array.
-  static void SubmitSkinned(const SkinnedMesh& mesh,
-                             const Mat4& modelMatrix,
-                             Material& material,
-                             const std::vector<Mat4>& boneMatrices);
+    // Submit a skinned mesh — uploads boneMatrices to u_boneMatrices[0..N] via SetMat4Array.
+    static void SubmitSkinned(const SkinnedMesh &mesh,
+                              const Mat4 &modelMatrix,
+                              Material &material,
+                              const std::vector<Mat4> &boneMatrices);
 
-  // Submit a mesh in wireframe mode using a plain color
-  static void SubmitWireframe(const Mesh& mesh,
-                              const Mat4& modelMatrix,
-                              Shader& shader,
-                              float r = 0.2f,
-                              float g = 0.8f,
-                              float b = 0.2f);
+    // Submit a mesh in wireframe mode using a plain color
+    static void SubmitWireframe(const Mesh &mesh,
+                                const Mat4 &modelMatrix,
+                                Shader &shader,
+                                float r = 0.2f,
+                                float g = 0.8f,
+                                float b = 0.2f);
 
-  static int GetDrawCallCount();
+    static int GetDrawCallCount();
 
- private:
-  static IRenderBackend* ActiveBackend();
+  private:
+    static IRenderBackend *ActiveBackend();
 
-  static bool s_frameActive;
-  static bool s_passActive;
-};
+    static bool s_frameActive;
+    static bool s_passActive;
+  };
 
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -20,6 +20,7 @@ class Renderer {
   static RenderBackendId GetBackendId();
   static RenderBackendCapabilities GetBackendCapabilities();
   static bool IsBackendSupported(RenderBackendId backendId);
+  static IRenderBackend* GetBackendForInterop();
 
   // Test seam: temporarily override the active backend with an externally owned implementation.
   static void UseBackend(IRenderBackend* backend);

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <fstream>
 #include <limits>
 #include <optional>
 #include <set>
@@ -18,1093 +19,1495 @@
 #include <GLFW/glfw3.h>
 #endif
 
-namespace Monolith {
+namespace Monolith
+{
 
 #if defined(MONOLITH_HAS_VULKAN)
 
-namespace {
+  namespace
+  {
 
-constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
+    constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
 
-const char* VkResultName(VkResult result) {
-  switch (result) {
-    case VK_SUCCESS:
-      return "VK_SUCCESS";
-    case VK_NOT_READY:
-      return "VK_NOT_READY";
-    case VK_TIMEOUT:
-      return "VK_TIMEOUT";
-    case VK_EVENT_SET:
-      return "VK_EVENT_SET";
-    case VK_EVENT_RESET:
-      return "VK_EVENT_RESET";
-    case VK_INCOMPLETE:
-      return "VK_INCOMPLETE";
-    case VK_ERROR_OUT_OF_HOST_MEMORY:
-      return "VK_ERROR_OUT_OF_HOST_MEMORY";
-    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-      return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
-    case VK_ERROR_INITIALIZATION_FAILED:
-      return "VK_ERROR_INITIALIZATION_FAILED";
-    case VK_ERROR_DEVICE_LOST:
-      return "VK_ERROR_DEVICE_LOST";
-    case VK_ERROR_SURFACE_LOST_KHR:
-      return "VK_ERROR_SURFACE_LOST_KHR";
-    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
-      return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
-    case VK_SUBOPTIMAL_KHR:
-      return "VK_SUBOPTIMAL_KHR";
-    case VK_ERROR_OUT_OF_DATE_KHR:
-      return "VK_ERROR_OUT_OF_DATE_KHR";
-    default:
-      return "VK_ERROR_UNKNOWN";
-  }
-}
-
-bool CheckVk(VkResult result, std::string& outError, const char* context) {
-  if (result == VK_SUCCESS)
-    return true;
-  outError = std::string(context) + " failed: " + VkResultName(result);
-  return false;
-}
-
-}  // namespace
-
-struct VulkanRenderBackend::Context {
-  GLFWwindow* window = nullptr;
-  VkInstance instance = VK_NULL_HANDLE;
-  VkSurfaceKHR surface = VK_NULL_HANDLE;
-  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
-  VkDevice device = VK_NULL_HANDLE;
-  VkQueue graphicsQueue = VK_NULL_HANDLE;
-  VkQueue presentQueue = VK_NULL_HANDLE;
-  uint32_t graphicsQueueFamily = kInvalidQueueFamily;
-  uint32_t presentQueueFamily = kInvalidQueueFamily;
-  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
-  VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
-  VkExtent2D swapchainExtent = {1, 1};
-  VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
-  VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
-  VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
-  std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
-  std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
-  bool opaqueShaderPipelineScaffoldReady = false;
-  bool opaqueGraphicsPipelineScaffoldReady = false;
-  std::vector<VkImage> swapchainImages;
-  std::vector<VkImageView> swapchainImageViews;
-  std::vector<VkFramebuffer> opaqueFramebuffers;
-  std::vector<VkCommandBuffer> commandBuffers;
-  std::vector<bool> imageWasPresented;
-  VkCommandPool commandPool = VK_NULL_HANDLE;
-  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
-  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
-  VkFence inFlightFence = VK_NULL_HANDLE;
-  uint32_t activeImageIndex = 0;
-  bool frameCommandsRecorded = false;
-};
-
-namespace {
-
-constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
-  return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
-}
-
-}  // namespace
-
-VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
-    const Material& material) {
-  TranslatedMaterialState translated;
-  translated.baseColor = material.color;
-  translated.roughness = material.roughness;
-  translated.metallic = material.metallic;
-  translated.uvScale = material.uvScale;
-  translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
-  translated.usesCustomShader = material.shader && material.shader->IsValid();
-  return translated;
-}
-
-int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
-  return mesh.GetIndexCount();
-}
-
-VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
-    const TranslatedMaterialState& materialState) {
-  OpaquePipelineKey key;
-  key.usesAlbedoMap = materialState.usesAlbedoMap;
-  key.usesCustomShader = materialState.usesCustomShader;
-  key.writesDepth = true;
-  key.depthTestEnabled = true;
-  return key;
-}
-
-VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
-  Initialize(nativeWindowHandle);
-}
-
-VulkanRenderBackend::~VulkanRenderBackend() {
-  Shutdown();
-}
-
-RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
-  RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
-  caps.supportsDebugDraw = false;
-  caps.supportsDebugLabels = false;
-  caps.supportsOffscreenTargets = false;
-  caps.supportsNativeTextureHandles = false;
-  caps.supportsReadback = false;
-  caps.supportsDepthReadback = false;
-  caps.supportsDebugHud = false;
-  caps.supportsComputePasses = false;
-  caps.supportsGpuTimestamps = false;
-  caps.supportsBindlessResources = false;
-  return caps;
-}
-
-bool VulkanRenderBackend::IsInitialized() const {
-  return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
-}
-
-bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
-  return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
-         m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-         m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
-         !m_context->opaqueFramebuffers.empty();
-}
-
-bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
-  return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
-}
-
-bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
-  return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
-}
-
-bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const {
-  return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
-}
-
-bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
-  m_lastError.clear();
-  if (!nativeWindowHandle) {
-    m_lastError = "Vulkan backend requires a native GLFW window handle.";
-    return false;
-  }
-
-  if (!glfwVulkanSupported()) {
-    m_lastError = "GLFW reports that Vulkan is not supported on this system.";
-    return false;
-  }
-
-  if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
-    return false;
-
-  m_context = std::make_unique<Context>();
-  m_context->window = static_cast<GLFWwindow*>(nativeWindowHandle);
-
-  uint32_t extensionCount = 0;
-  const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
-  if (!glfwExtensions || extensionCount == 0) {
-    m_lastError = "GLFW did not provide required Vulkan instance extensions.";
-    Shutdown();
-    return false;
-  }
-
-  const VkApplicationInfo appInfo{
-      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
-      .pNext = nullptr,
-      .pApplicationName = "MonolithEngine",
-      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
-      .pEngineName = "MonolithEngine",
-      .engineVersion = VK_MAKE_VERSION(0, 1, 0),
-      .apiVersion = VK_API_VERSION_1_1,
-  };
-
-  std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
-  const VkInstanceCreateInfo instanceInfo{
-      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .pApplicationInfo = &appInfo,
-      .enabledLayerCount = 0,
-      .ppEnabledLayerNames = nullptr,
-      .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
-      .ppEnabledExtensionNames = instanceExtensions.data(),
-  };
-  if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
-               "vkCreateInstance")) {
-    Shutdown();
-    return false;
-  }
-
-  volkLoadInstance(m_context->instance);
-
-  if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
-                                       &m_context->surface),
-               m_lastError,
-               "glfwCreateWindowSurface")) {
-    Shutdown();
-    return false;
-  }
-
-  uint32_t physicalDeviceCount = 0;
-  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
-               m_lastError,
-               "vkEnumeratePhysicalDevices(count)")) {
-    Shutdown();
-    return false;
-  }
-  if (physicalDeviceCount == 0) {
-    m_lastError = "No Vulkan physical devices were found.";
-    Shutdown();
-    return false;
-  }
-
-  std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
-                                          physicalDevices.data()),
-               m_lastError,
-               "vkEnumeratePhysicalDevices")) {
-    Shutdown();
-    return false;
-  }
-
-  const std::array<const char*, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
-  for (VkPhysicalDevice device : physicalDevices) {
-    uint32_t queueFamilyCount = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
-    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
-
-    std::optional<uint32_t> graphicsFamily;
-    std::optional<uint32_t> presentFamily;
-    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
-      if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
-        graphicsFamily = i;
-
-      VkBool32 presentSupported = VK_FALSE;
-      vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
-      if (presentSupported == VK_TRUE)
-        presentFamily = i;
+    const char *VkResultName(VkResult result)
+    {
+      switch (result)
+      {
+      case VK_SUCCESS:
+        return "VK_SUCCESS";
+      case VK_NOT_READY:
+        return "VK_NOT_READY";
+      case VK_TIMEOUT:
+        return "VK_TIMEOUT";
+      case VK_EVENT_SET:
+        return "VK_EVENT_SET";
+      case VK_EVENT_RESET:
+        return "VK_EVENT_RESET";
+      case VK_INCOMPLETE:
+        return "VK_INCOMPLETE";
+      case VK_ERROR_OUT_OF_HOST_MEMORY:
+        return "VK_ERROR_OUT_OF_HOST_MEMORY";
+      case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+        return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+      case VK_ERROR_INITIALIZATION_FAILED:
+        return "VK_ERROR_INITIALIZATION_FAILED";
+      case VK_ERROR_DEVICE_LOST:
+        return "VK_ERROR_DEVICE_LOST";
+      case VK_ERROR_SURFACE_LOST_KHR:
+        return "VK_ERROR_SURFACE_LOST_KHR";
+      case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+        return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+      case VK_SUBOPTIMAL_KHR:
+        return "VK_SUBOPTIMAL_KHR";
+      case VK_ERROR_OUT_OF_DATE_KHR:
+        return "VK_ERROR_OUT_OF_DATE_KHR";
+      default:
+        return "VK_ERROR_UNKNOWN";
+      }
     }
 
-    if (!graphicsFamily || !presentFamily)
-      continue;
+    bool CheckVk(VkResult result, std::string &outError, const char *context)
+    {
+      if (result == VK_SUCCESS)
+        return true;
+      outError = std::string(context) + " failed: " + VkResultName(result);
+      return false;
+    }
 
-    uint32_t extensionCountAvailable = 0;
-    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
-    std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
-    vkEnumerateDeviceExtensionProperties(device,
+    std::vector<char> ReadBinaryFile(const std::string &filePath)
+    {
+      std::ifstream stream(filePath, std::ios::binary | std::ios::ate);
+      if (!stream)
+        return {};
+
+      const std::streamsize fileSize = stream.tellg();
+      if (fileSize <= 0)
+        return {};
+
+      std::vector<char> bytes(static_cast<size_t>(fileSize));
+      stream.seekg(0, std::ios::beg);
+      if (!stream.read(bytes.data(), fileSize))
+        return {};
+      return bytes;
+    }
+
+    bool TryCreateShaderModule(VkDevice device,
+                               const std::vector<char> &spirvBytes,
+                               VkShaderModule *outShaderModule,
+                               std::string &outError,
+                               const char *context)
+    {
+      if (!outShaderModule)
+        return false;
+      *outShaderModule = VK_NULL_HANDLE;
+
+      if (spirvBytes.empty())
+        return false;
+      if ((spirvBytes.size() % sizeof(uint32_t)) != 0)
+      {
+        outError = std::string(context) + " failed: SPIR-V bytecode size is not a multiple of 4.";
+        return false;
+      }
+
+      const VkShaderModuleCreateInfo shaderModuleInfo{
+          .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .codeSize = spirvBytes.size(),
+          .pCode = reinterpret_cast<const uint32_t *>(spirvBytes.data()),
+      };
+      return CheckVk(vkCreateShaderModule(device, &shaderModuleInfo, nullptr, outShaderModule),
+                     outError,
+                     context);
+    }
+
+  } // namespace
+
+  struct VulkanRenderBackend::Context
+  {
+    GLFWwindow *window = nullptr;
+    VkInstance instance = VK_NULL_HANDLE;
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+    VkQueue graphicsQueue = VK_NULL_HANDLE;
+    VkQueue presentQueue = VK_NULL_HANDLE;
+    uint32_t graphicsQueueFamily = kInvalidQueueFamily;
+    uint32_t presentQueueFamily = kInvalidQueueFamily;
+    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+    VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+    VkExtent2D swapchainExtent = {1, 1};
+    VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
+    VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
+    VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+    std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
+    std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
+    VkShaderModule opaqueVertexShaderModule = VK_NULL_HANDLE;
+    VkShaderModule opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    VkPipeline opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    bool opaqueShaderPipelineScaffoldReady = false;
+    bool opaqueGraphicsPipelineScaffoldReady = false;
+    bool opaqueGraphicsPipelineExecutable = false;
+    std::vector<VkImage> swapchainImages;
+    std::vector<VkImageView> swapchainImageViews;
+    std::vector<VkFramebuffer> opaqueFramebuffers;
+    std::vector<VkCommandBuffer> commandBuffers;
+    std::vector<bool> imageWasPresented;
+    VkCommandPool commandPool = VK_NULL_HANDLE;
+    VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+    VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+    VkFence inFlightFence = VK_NULL_HANDLE;
+    uint32_t activeImageIndex = 0;
+    bool frameCommandsRecorded = false;
+  };
+
+  namespace
+  {
+
+    constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId)
+    {
+      return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+    }
+
+  } // namespace
+
+  VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
+      const Material &material)
+  {
+    TranslatedMaterialState translated;
+    translated.baseColor = material.color;
+    translated.roughness = material.roughness;
+    translated.metallic = material.metallic;
+    translated.uvScale = material.uvScale;
+    translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
+    translated.usesCustomShader = material.shader && material.shader->IsValid();
+    return translated;
+  }
+
+  int VulkanRenderBackend::ResolveIndexCount(const Mesh &mesh)
+  {
+    return mesh.GetIndexCount();
+  }
+
+  VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
+      const TranslatedMaterialState &materialState)
+  {
+    OpaquePipelineKey key;
+    key.usesAlbedoMap = materialState.usesAlbedoMap;
+    key.usesCustomShader = materialState.usesCustomShader;
+    key.writesDepth = true;
+    key.depthTestEnabled = true;
+    return key;
+  }
+
+  VulkanRenderBackend::VulkanRenderBackend(void *nativeWindowHandle)
+  {
+    Initialize(nativeWindowHandle);
+  }
+
+  VulkanRenderBackend::~VulkanRenderBackend()
+  {
+    Shutdown();
+  }
+
+  RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const
+  {
+    RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+    caps.supportsDebugDraw = false;
+    caps.supportsDebugLabels = false;
+    caps.supportsOffscreenTargets = false;
+    caps.supportsNativeTextureHandles = false;
+    caps.supportsReadback = false;
+    caps.supportsDepthReadback = false;
+    caps.supportsDebugHud = false;
+    caps.supportsComputePasses = false;
+    caps.supportsGpuTimestamps = false;
+    caps.supportsBindlessResources = false;
+    return caps;
+  }
+
+  bool VulkanRenderBackend::IsInitialized() const
+  {
+    return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueRasterScaffold() const
+  {
+    return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+           m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+           m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
+           !m_context->opaqueFramebuffers.empty();
+  }
+
+  bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const
+  {
+    return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const
+  {
+    return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const
+  {
+    return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
+  }
+
+  bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
+  {
+    m_lastError.clear();
+    if (!nativeWindowHandle)
+    {
+      m_lastError = "Vulkan backend requires a native GLFW window handle.";
+      return false;
+    }
+
+    if (!glfwVulkanSupported())
+    {
+      m_lastError = "GLFW reports that Vulkan is not supported on this system.";
+      return false;
+    }
+
+    if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
+      return false;
+
+    m_context = std::make_unique<Context>();
+    m_context->window = static_cast<GLFWwindow *>(nativeWindowHandle);
+
+    uint32_t extensionCount = 0;
+    const char **glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
+    if (!glfwExtensions || extensionCount == 0)
+    {
+      m_lastError = "GLFW did not provide required Vulkan instance extensions.";
+      Shutdown();
+      return false;
+    }
+
+    const VkApplicationInfo appInfo{
+        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pNext = nullptr,
+        .pApplicationName = "MonolithEngine",
+        .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+        .pEngineName = "MonolithEngine",
+        .engineVersion = VK_MAKE_VERSION(0, 1, 0),
+        .apiVersion = VK_API_VERSION_1_1,
+    };
+
+    std::vector<const char *> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
+    const VkInstanceCreateInfo instanceInfo{
+        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .pApplicationInfo = &appInfo,
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
+        .ppEnabledExtensionNames = instanceExtensions.data(),
+    };
+    if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
+                 "vkCreateInstance"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    volkLoadInstance(m_context->instance);
+
+    if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
+                                         &m_context->surface),
+                 m_lastError,
+                 "glfwCreateWindowSurface"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    uint32_t physicalDeviceCount = 0;
+    if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
+                 m_lastError,
+                 "vkEnumeratePhysicalDevices(count)"))
+    {
+      Shutdown();
+      return false;
+    }
+    if (physicalDeviceCount == 0)
+    {
+      m_lastError = "No Vulkan physical devices were found.";
+      Shutdown();
+      return false;
+    }
+
+    std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+    if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
+                                            physicalDevices.data()),
+                 m_lastError,
+                 "vkEnumeratePhysicalDevices"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const std::array<const char *, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+    for (VkPhysicalDevice device : physicalDevices)
+    {
+      uint32_t queueFamilyCount = 0;
+      vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+      std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+      vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+      std::optional<uint32_t> graphicsFamily;
+      std::optional<uint32_t> presentFamily;
+      for (uint32_t i = 0; i < queueFamilyCount; ++i)
+      {
+        if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+          graphicsFamily = i;
+
+        VkBool32 presentSupported = VK_FALSE;
+        vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
+        if (presentSupported == VK_TRUE)
+          presentFamily = i;
+      }
+
+      if (!graphicsFamily || !presentFamily)
+        continue;
+
+      uint32_t extensionCountAvailable = 0;
+      vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
+      std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
+      vkEnumerateDeviceExtensionProperties(device,
+                                           nullptr,
+                                           &extensionCountAvailable,
+                                           extensions.data());
+      std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
+                                              requiredDeviceExtensions.end());
+      for (const auto &extension : extensions)
+        missingExtensions.erase(extension.extensionName);
+      if (!missingExtensions.empty())
+        continue;
+
+      uint32_t surfaceFormatCount = 0;
+      vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+      uint32_t presentModeCount = 0;
+      vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+                                                m_context->surface,
+                                                &presentModeCount,
+                                                nullptr);
+      if (surfaceFormatCount == 0 || presentModeCount == 0)
+        continue;
+
+      m_context->physicalDevice = device;
+      m_context->graphicsQueueFamily = *graphicsFamily;
+      m_context->presentQueueFamily = *presentFamily;
+      break;
+    }
+
+    if (m_context->physicalDevice == VK_NULL_HANDLE)
+    {
+      m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
+      Shutdown();
+      return false;
+    }
+
+    const float queuePriority = 1.0f;
+    std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
+                                              m_context->presentQueueFamily};
+    std::vector<VkDeviceQueueCreateInfo> queueInfos;
+    queueInfos.reserve(uniqueQueueFamilies.size());
+    for (uint32_t queueFamily : uniqueQueueFamilies)
+    {
+      queueInfos.push_back(VkDeviceQueueCreateInfo{
+          .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .queueFamilyIndex = queueFamily,
+          .queueCount = 1,
+          .pQueuePriorities = &queuePriority,
+      });
+    }
+
+    const VkDeviceCreateInfo deviceInfo{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
+        .pQueueCreateInfos = queueInfos.data(),
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
+        .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
+        .pEnabledFeatures = nullptr,
+    };
+    if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
+                 m_lastError,
+                 "vkCreateDevice"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    volkLoadDevice(m_context->device);
+    vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
+    vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
+
+    const VkCommandPoolCreateInfo commandPoolInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+        .queueFamilyIndex = m_context->graphicsQueueFamily,
+    };
+    if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
+                                     &m_context->commandPool),
+                 m_lastError,
+                 "vkCreateCommandPool"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+                                              .pNext = nullptr,
+                                              .flags = 0};
+    if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                   &m_context->imageAvailableSemaphore),
+                 m_lastError,
+                 "vkCreateSemaphore(imageAvailable)"))
+    {
+      Shutdown();
+      return false;
+    }
+    if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                   &m_context->renderFinishedSemaphore),
+                 m_lastError,
+                 "vkCreateSemaphore(renderFinished)"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                                      .pNext = nullptr,
+                                      .flags = VK_FENCE_CREATE_SIGNALED_BIT};
+    if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
+                 m_lastError,
+                 "vkCreateFence"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 0,
+        .pSetLayouts = nullptr,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
+    if (!CheckVk(vkCreatePipelineLayout(m_context->device,
+                                        &pipelineLayoutInfo,
+                                        nullptr,
+                                        &m_context->opaquePipelineLayout),
+                 m_lastError,
+                 "vkCreatePipelineLayout"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!CreateOpaquePipelineCreationScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!CreateOpaqueShaderPipelineScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!RecreateSwapchain())
+    {
+      Shutdown();
+      return false;
+    }
+
+    return true;
+  }
+
+  void VulkanRenderBackend::Shutdown()
+  {
+    if (!m_context)
+      return;
+
+    if (m_context->device != VK_NULL_HANDLE)
+      vkDeviceWaitIdle(m_context->device);
+
+    DestroyOpaqueGraphicsPipelineScaffold();
+    DestroySwapchain();
+
+    DestroyOpaqueShaderPipelineScaffold();
+    DestroyOpaquePipelineCreationScaffold();
+
+    if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
+      vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
+
+    if (m_context->inFlightFence != VK_NULL_HANDLE)
+      vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
+    if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
+      vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
+    if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
+      vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
+    if (m_context->commandPool != VK_NULL_HANDLE)
+      vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
+    if (m_context->device != VK_NULL_HANDLE)
+      vkDestroyDevice(m_context->device, nullptr);
+    if (m_context->surface != VK_NULL_HANDLE)
+      vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
+    if (m_context->instance != VK_NULL_HANDLE)
+      vkDestroyInstance(m_context->instance, nullptr);
+
+    m_context.reset();
+    m_frameActive = false;
+    m_passActive = false;
+  }
+
+  void VulkanRenderBackend::DestroySwapchain()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    DestroyOpaqueRasterScaffold();
+
+    if (!m_context->commandBuffers.empty())
+    {
+      vkFreeCommandBuffers(m_context->device,
+                           m_context->commandPool,
+                           static_cast<uint32_t>(m_context->commandBuffers.size()),
+                           m_context->commandBuffers.data());
+      m_context->commandBuffers.clear();
+    }
+
+    for (VkImageView imageView : m_context->swapchainImageViews)
+      vkDestroyImageView(m_context->device, imageView, nullptr);
+    m_context->swapchainImageViews.clear();
+    m_context->swapchainImages.clear();
+    m_context->imageWasPresented.clear();
+
+    if (m_context->swapchain != VK_NULL_HANDLE)
+    {
+      vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
+      m_context->swapchain = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueRasterScaffold()
+  {
+    const VkAttachmentDescription colorAttachment{
+        .flags = 0,
+        .format = m_context->swapchainFormat,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+        .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+        .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    };
+    const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    const VkSubpassDescription subpass{
+        .flags = 0,
+        .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+        .inputAttachmentCount = 0,
+        .pInputAttachments = nullptr,
+        .colorAttachmentCount = 1,
+        .pColorAttachments = &colorAttachmentRef,
+        .pResolveAttachments = nullptr,
+        .pDepthStencilAttachment = nullptr,
+        .preserveAttachmentCount = 0,
+        .pPreserveAttachments = nullptr,
+    };
+    const VkSubpassDependency dependency{
+        .srcSubpass = VK_SUBPASS_EXTERNAL,
+        .dstSubpass = 0,
+        .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .srcAccessMask = 0,
+        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .dependencyFlags = 0,
+    };
+    const VkRenderPassCreateInfo renderPassInfo{
+        .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .attachmentCount = 1,
+        .pAttachments = &colorAttachment,
+        .subpassCount = 1,
+        .pSubpasses = &subpass,
+        .dependencyCount = 1,
+        .pDependencies = &dependency,
+    };
+    if (!CheckVk(vkCreateRenderPass(m_context->device,
+                                    &renderPassInfo,
+                                    nullptr,
+                                    &m_context->opaqueRenderPass),
+                 m_lastError,
+                 "vkCreateRenderPass"))
+    {
+      return false;
+    }
+
+    m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
+    for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i)
+    {
+      const VkImageView attachment = m_context->swapchainImageViews[i];
+      const VkFramebufferCreateInfo framebufferInfo{
+          .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .renderPass = m_context->opaqueRenderPass,
+          .attachmentCount = 1,
+          .pAttachments = &attachment,
+          .width = m_context->swapchainExtent.width,
+          .height = m_context->swapchainExtent.height,
+          .layers = 1,
+      };
+      if (!CheckVk(vkCreateFramebuffer(m_context->device,
+                                       &framebufferInfo,
+                                       nullptr,
+                                       &m_context->opaqueFramebuffers[i]),
+                   m_lastError,
+                   "vkCreateFramebuffer"))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueRasterScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers)
+    {
+      if (framebuffer != VK_NULL_HANDLE)
+        vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
+    }
+    m_context->opaqueFramebuffers.clear();
+
+    if (m_context->opaqueRenderPass != VK_NULL_HANDLE)
+    {
+      vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
+      m_context->opaqueRenderPass = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold()
+  {
+    const VkPipelineCacheCreateInfo pipelineCacheInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .initialDataSize = 0,
+        .pInitialData = nullptr,
+    };
+    return CheckVk(vkCreatePipelineCache(m_context->device,
+                                         &pipelineCacheInfo,
                                          nullptr,
-                                         &extensionCountAvailable,
-                                         extensions.data());
-    std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
-                                            requiredDeviceExtensions.end());
-    for (const auto& extension : extensions)
-      missingExtensions.erase(extension.extensionName);
-    if (!missingExtensions.empty())
-      continue;
+                                         &m_context->opaquePipelineCache),
+                   m_lastError,
+                   "vkCreatePipelineCache");
+  }
+
+  void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaquePipelineCache != VK_NULL_HANDLE)
+    {
+      vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
+      m_context->opaquePipelineCache = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold()
+  {
+    const auto tryLoadShaderModule = [&](const std::array<std::string, 2> &candidatePaths,
+                                         VkShaderModule *outModule,
+                                         const char *context)
+    {
+      for (const std::string &path : candidatePaths)
+      {
+        const std::vector<char> bytes = ReadBinaryFile(path);
+        if (bytes.empty())
+          continue;
+        if (TryCreateShaderModule(m_context->device, bytes, outModule, m_lastError, context))
+          return true;
+        return false;
+      }
+      return false;
+    };
+
+    m_context->opaqueVertexShaderModule = VK_NULL_HANDLE;
+    m_context->opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    m_context->opaqueShaderStages = {};
+
+    const bool vertexShaderLoaded = tryLoadShaderModule(
+        {"assets/shaders/vulkan/opaque_scene.vert.spv", "renderer/shaders/vulkan/opaque_scene.vert.spv"},
+        &m_context->opaqueVertexShaderModule,
+        "vkCreateShaderModule(vertex)");
+    const bool fragmentShaderLoaded = tryLoadShaderModule(
+        {"assets/shaders/vulkan/opaque_scene.frag.spv", "renderer/shaders/vulkan/opaque_scene.frag.spv"},
+        &m_context->opaqueFragmentShaderModule,
+        "vkCreateShaderModule(fragment)");
+
+    m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = VK_SHADER_STAGE_VERTEX_BIT,
+        .module = m_context->opaqueVertexShaderModule,
+        .pName = m_context->opaqueShaderEntryNames[0].c_str(),
+        .pSpecializationInfo = nullptr,
+    };
+    m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+        .module = m_context->opaqueFragmentShaderModule,
+        .pName = m_context->opaqueShaderEntryNames[1].c_str(),
+        .pSpecializationInfo = nullptr,
+    };
+
+    if ((!vertexShaderLoaded || !fragmentShaderLoaded) && m_lastError.empty())
+    {
+      m_lastError =
+          "Vulkan opaque shader modules are not available yet. Expected precompiled SPIR-V files at "
+          "assets/shaders/vulkan/opaque_scene.{vert,frag}.spv or "
+          "renderer/shaders/vulkan/opaque_scene.{vert,frag}.spv";
+    }
+
+    m_context->opaqueShaderPipelineScaffoldReady =
+        m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+        m_context->opaquePipelineCache != VK_NULL_HANDLE &&
+        m_context->opaqueShaderStages[0].pName != nullptr &&
+        m_context->opaqueShaderStages[1].pName != nullptr;
+    return m_context->opaqueShaderPipelineScaffoldReady;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaqueVertexShaderModule != VK_NULL_HANDLE)
+    {
+      vkDestroyShaderModule(m_context->device, m_context->opaqueVertexShaderModule, nullptr);
+      m_context->opaqueVertexShaderModule = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueFragmentShaderModule != VK_NULL_HANDLE)
+    {
+      vkDestroyShaderModule(m_context->device, m_context->opaqueFragmentShaderModule, nullptr);
+      m_context->opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueShaderStages = {};
+    m_context->opaqueShaderPipelineScaffoldReady = false;
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold()
+  {
+    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
+    {
+      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
+      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueGraphicsPipelineScaffoldReady =
+        m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
+    m_context->opaqueGraphicsPipelineExecutable = false;
+    if (!m_context->opaqueGraphicsPipelineScaffoldReady)
+    {
+      m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
+      return false;
+    }
+
+    if (m_context->opaqueShaderStages[0].module == VK_NULL_HANDLE ||
+        m_context->opaqueShaderStages[1].module == VK_NULL_HANDLE)
+    {
+      return true;
+    }
+
+    const VkPipelineVertexInputStateCreateInfo vertexInputState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .vertexBindingDescriptionCount = 0,
+        .pVertexBindingDescriptions = nullptr,
+        .vertexAttributeDescriptionCount = 0,
+        .pVertexAttributeDescriptions = nullptr,
+    };
+    const VkPipelineInputAssemblyStateCreateInfo inputAssemblyState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+        .primitiveRestartEnable = VK_FALSE,
+    };
+    const VkPipelineViewportStateCreateInfo viewportState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .viewportCount = 1,
+        .pViewports = nullptr,
+        .scissorCount = 1,
+        .pScissors = nullptr,
+    };
+    const VkPipelineRasterizationStateCreateInfo rasterizationState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .depthClampEnable = VK_FALSE,
+        .rasterizerDiscardEnable = VK_FALSE,
+        .polygonMode = VK_POLYGON_MODE_FILL,
+        .cullMode = VK_CULL_MODE_NONE,
+        .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+        .depthBiasEnable = VK_FALSE,
+        .depthBiasConstantFactor = 0.0f,
+        .depthBiasClamp = 0.0f,
+        .depthBiasSlopeFactor = 0.0f,
+        .lineWidth = 1.0f,
+    };
+    const VkPipelineMultisampleStateCreateInfo multisampleState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+        .sampleShadingEnable = VK_FALSE,
+        .minSampleShading = 1.0f,
+        .pSampleMask = nullptr,
+        .alphaToCoverageEnable = VK_FALSE,
+        .alphaToOneEnable = VK_FALSE,
+    };
+    const VkPipelineColorBlendAttachmentState colorBlendAttachment{
+        .blendEnable = VK_FALSE,
+        .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+        .dstColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .colorBlendOp = VK_BLEND_OP_ADD,
+        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .alphaBlendOp = VK_BLEND_OP_ADD,
+        .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+    };
+    const VkPipelineColorBlendStateCreateInfo colorBlendState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .logicOpEnable = VK_FALSE,
+        .logicOp = VK_LOGIC_OP_COPY,
+        .attachmentCount = 1,
+        .pAttachments = &colorBlendAttachment,
+        .blendConstants = {0.0f, 0.0f, 0.0f, 0.0f},
+    };
+    const std::array<VkDynamicState, 2> dynamicStates = {VK_DYNAMIC_STATE_VIEWPORT,
+                                                         VK_DYNAMIC_STATE_SCISSOR};
+    const VkPipelineDynamicStateCreateInfo dynamicState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .dynamicStateCount = static_cast<uint32_t>(dynamicStates.size()),
+        .pDynamicStates = dynamicStates.data(),
+    };
+    const VkGraphicsPipelineCreateInfo pipelineInfo{
+        .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stageCount = static_cast<uint32_t>(m_context->opaqueShaderStages.size()),
+        .pStages = m_context->opaqueShaderStages.data(),
+        .pVertexInputState = &vertexInputState,
+        .pInputAssemblyState = &inputAssemblyState,
+        .pTessellationState = nullptr,
+        .pViewportState = &viewportState,
+        .pRasterizationState = &rasterizationState,
+        .pMultisampleState = &multisampleState,
+        .pDepthStencilState = nullptr,
+        .pColorBlendState = &colorBlendState,
+        .pDynamicState = &dynamicState,
+        .layout = m_context->opaquePipelineLayout,
+        .renderPass = m_context->opaqueRenderPass,
+        .subpass = 0,
+        .basePipelineHandle = VK_NULL_HANDLE,
+        .basePipelineIndex = -1,
+    };
+    if (!CheckVk(vkCreateGraphicsPipelines(m_context->device,
+                                           m_context->opaquePipelineCache,
+                                           1,
+                                           &pipelineInfo,
+                                           nullptr,
+                                           &m_context->opaqueGraphicsPipeline),
+                 m_lastError,
+                 "vkCreateGraphicsPipelines(opaque)"))
+    {
+      return false;
+    }
+
+    m_context->opaqueGraphicsPipelineExecutable = true;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
+    {
+      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
+      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueGraphicsPipelineExecutable = false;
+    m_context->opaqueGraphicsPipelineScaffoldReady = false;
+  }
+
+  bool VulkanRenderBackend::RecreateSwapchain()
+  {
+    DestroyOpaqueGraphicsPipelineScaffold();
+    DestroySwapchain();
+
+    VkSurfaceCapabilitiesKHR surfaceCapabilities{};
+    if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
+                                                           m_context->surface,
+                                                           &surfaceCapabilities),
+                 m_lastError,
+                 "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"))
+    {
+      return false;
+    }
 
     uint32_t surfaceFormatCount = 0;
-    vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                         m_context->surface,
+                                         &surfaceFormatCount,
+                                         nullptr);
+    std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                         m_context->surface,
+                                         &surfaceFormatCount,
+                                         surfaceFormats.data());
+    VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
+    for (const auto &candidate : surfaceFormats)
+    {
+      if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
+          candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+      {
+        chosenFormat = candidate;
+        break;
+      }
+    }
+    m_context->swapchainFormat = chosenFormat.format;
+
     uint32_t presentModeCount = 0;
-    vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+    vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
                                               m_context->surface,
                                               &presentModeCount,
                                               nullptr);
-    if (surfaceFormatCount == 0 || presentModeCount == 0)
-      continue;
+    std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+    vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                              m_context->surface,
+                                              &presentModeCount,
+                                              presentModes.data());
+    VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+    for (VkPresentModeKHR presentMode : presentModes)
+    {
+      if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR)
+      {
+        chosenPresentMode = presentMode;
+        break;
+      }
+    }
 
-    m_context->physicalDevice = device;
-    m_context->graphicsQueueFamily = *graphicsFamily;
-    m_context->presentQueueFamily = *presentFamily;
-    break;
-  }
+    int framebufferWidth = 0;
+    int framebufferHeight = 0;
+    glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
+    framebufferWidth = std::max(framebufferWidth, 1);
+    framebufferHeight = std::max(framebufferHeight, 1);
 
-  if (m_context->physicalDevice == VK_NULL_HANDLE) {
-    m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
-    Shutdown();
-    return false;
-  }
+    if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max())
+    {
+      m_context->swapchainExtent = surfaceCapabilities.currentExtent;
+    }
+    else
+    {
+      m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
+                                                    surfaceCapabilities.minImageExtent.width,
+                                                    surfaceCapabilities.maxImageExtent.width);
+      m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
+                                                     surfaceCapabilities.minImageExtent.height,
+                                                     surfaceCapabilities.maxImageExtent.height);
+    }
 
-  const float queuePriority = 1.0f;
-  std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
-                                            m_context->presentQueueFamily};
-  std::vector<VkDeviceQueueCreateInfo> queueInfos;
-  queueInfos.reserve(uniqueQueueFamilies.size());
-  for (uint32_t queueFamily : uniqueQueueFamilies) {
-    queueInfos.push_back(VkDeviceQueueCreateInfo{
-        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+    uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
+    if (surfaceCapabilities.maxImageCount > 0)
+      imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
+
+    std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
+                                                  m_context->presentQueueFamily};
+    const bool usesSeparatePresentQueue =
+        m_context->graphicsQueueFamily != m_context->presentQueueFamily;
+
+    const VkSwapchainCreateInfoKHR swapchainInfo{
+        .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
         .pNext = nullptr,
         .flags = 0,
-        .queueFamilyIndex = queueFamily,
-        .queueCount = 1,
-        .pQueuePriorities = &queuePriority,
-    });
-  }
-
-  const VkDeviceCreateInfo deviceInfo{
-      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
-      .pQueueCreateInfos = queueInfos.data(),
-      .enabledLayerCount = 0,
-      .ppEnabledLayerNames = nullptr,
-      .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
-      .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
-      .pEnabledFeatures = nullptr,
-  };
-  if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
-               m_lastError,
-               "vkCreateDevice")) {
-    Shutdown();
-    return false;
-  }
-
-  volkLoadDevice(m_context->device);
-  vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
-  vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
-
-  const VkCommandPoolCreateInfo commandPoolInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-      .queueFamilyIndex = m_context->graphicsQueueFamily,
-  };
-  if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
-                                   &m_context->commandPool),
-               m_lastError,
-               "vkCreateCommandPool")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
-                                             .pNext = nullptr,
-                                             .flags = 0};
-  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
-                                 &m_context->imageAvailableSemaphore),
-               m_lastError,
-               "vkCreateSemaphore(imageAvailable)")) {
-    Shutdown();
-    return false;
-  }
-  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
-                                 &m_context->renderFinishedSemaphore),
-               m_lastError,
-               "vkCreateSemaphore(renderFinished)")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-                                    .pNext = nullptr,
-                                    .flags = VK_FENCE_CREATE_SIGNALED_BIT};
-  if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
-               m_lastError,
-               "vkCreateFence")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .setLayoutCount = 0,
-      .pSetLayouts = nullptr,
-      .pushConstantRangeCount = 0,
-      .pPushConstantRanges = nullptr,
-  };
-  if (!CheckVk(vkCreatePipelineLayout(m_context->device,
-                                      &pipelineLayoutInfo,
-                                      nullptr,
-                                      &m_context->opaquePipelineLayout),
-               m_lastError,
-               "vkCreatePipelineLayout")) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaquePipelineCreationScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaqueShaderPipelineScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!RecreateSwapchain()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaqueGraphicsPipelineScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  return true;
-}
-
-void VulkanRenderBackend::Shutdown() {
-  if (!m_context)
-    return;
-
-  if (m_context->device != VK_NULL_HANDLE)
-    vkDeviceWaitIdle(m_context->device);
-
-  DestroySwapchain();
-
-  DestroyOpaqueGraphicsPipelineScaffold();
-  DestroyOpaqueShaderPipelineScaffold();
-  DestroyOpaquePipelineCreationScaffold();
-
-  if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
-    vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
-
-  if (m_context->inFlightFence != VK_NULL_HANDLE)
-    vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
-  if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
-    vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
-  if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
-    vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
-  if (m_context->commandPool != VK_NULL_HANDLE)
-    vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
-  if (m_context->device != VK_NULL_HANDLE)
-    vkDestroyDevice(m_context->device, nullptr);
-  if (m_context->surface != VK_NULL_HANDLE)
-    vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
-  if (m_context->instance != VK_NULL_HANDLE)
-    vkDestroyInstance(m_context->instance, nullptr);
-
-  m_context.reset();
-  m_frameActive = false;
-  m_passActive = false;
-}
-
-void VulkanRenderBackend::DestroySwapchain() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  DestroyOpaqueRasterScaffold();
-
-  if (!m_context->commandBuffers.empty()) {
-    vkFreeCommandBuffers(m_context->device,
-                         m_context->commandPool,
-                         static_cast<uint32_t>(m_context->commandBuffers.size()),
-                         m_context->commandBuffers.data());
-    m_context->commandBuffers.clear();
-  }
-
-  for (VkImageView imageView : m_context->swapchainImageViews)
-    vkDestroyImageView(m_context->device, imageView, nullptr);
-  m_context->swapchainImageViews.clear();
-  m_context->swapchainImages.clear();
-  m_context->imageWasPresented.clear();
-
-  if (m_context->swapchain != VK_NULL_HANDLE) {
-    vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
-    m_context->swapchain = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaqueRasterScaffold() {
-  const VkAttachmentDescription colorAttachment{
-      .flags = 0,
-      .format = m_context->swapchainFormat,
-      .samples = VK_SAMPLE_COUNT_1_BIT,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-      .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-      .initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-      .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-  };
-  const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  const VkSubpassDescription subpass{
-      .flags = 0,
-      .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
-      .inputAttachmentCount = 0,
-      .pInputAttachments = nullptr,
-      .colorAttachmentCount = 1,
-      .pColorAttachments = &colorAttachmentRef,
-      .pResolveAttachments = nullptr,
-      .pDepthStencilAttachment = nullptr,
-      .preserveAttachmentCount = 0,
-      .pPreserveAttachments = nullptr,
-  };
-  const VkSubpassDependency dependency{
-      .srcSubpass = VK_SUBPASS_EXTERNAL,
-      .dstSubpass = 0,
-      .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-      .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-      .srcAccessMask = 0,
-      .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-      .dependencyFlags = 0,
-  };
-  const VkRenderPassCreateInfo renderPassInfo{
-      .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .attachmentCount = 1,
-      .pAttachments = &colorAttachment,
-      .subpassCount = 1,
-      .pSubpasses = &subpass,
-      .dependencyCount = 1,
-      .pDependencies = &dependency,
-  };
-  if (!CheckVk(vkCreateRenderPass(m_context->device,
-                                  &renderPassInfo,
-                                  nullptr,
-                                  &m_context->opaqueRenderPass),
-               m_lastError,
-               "vkCreateRenderPass")) {
-    return false;
-  }
-
-  m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
-  for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i) {
-    const VkImageView attachment = m_context->swapchainImageViews[i];
-    const VkFramebufferCreateInfo framebufferInfo{
-        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-        .renderPass = m_context->opaqueRenderPass,
-        .attachmentCount = 1,
-        .pAttachments = &attachment,
-        .width = m_context->swapchainExtent.width,
-        .height = m_context->swapchainExtent.height,
-        .layers = 1,
+        .surface = m_context->surface,
+        .minImageCount = imageCount,
+        .imageFormat = chosenFormat.format,
+        .imageColorSpace = chosenFormat.colorSpace,
+        .imageExtent = m_context->swapchainExtent,
+        .imageArrayLayers = 1,
+        .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
+                                                     : VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
+        .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
+        .preTransform = surfaceCapabilities.currentTransform,
+        .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+        .presentMode = chosenPresentMode,
+        .clipped = VK_TRUE,
+        .oldSwapchain = VK_NULL_HANDLE,
     };
-    if (!CheckVk(vkCreateFramebuffer(m_context->device,
-                                     &framebufferInfo,
+    if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
+                                      &m_context->swapchain),
+                 m_lastError,
+                 "vkCreateSwapchainKHR"))
+    {
+      return false;
+    }
+
+    uint32_t swapchainImageCount = 0;
+    vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
+    m_context->swapchainImages.resize(swapchainImageCount);
+    vkGetSwapchainImagesKHR(m_context->device,
+                            m_context->swapchain,
+                            &swapchainImageCount,
+                            m_context->swapchainImages.data());
+    m_context->swapchainImageViews.resize(swapchainImageCount);
+    m_context->imageWasPresented.assign(swapchainImageCount, false);
+
+    for (size_t i = 0; i < m_context->swapchainImages.size(); ++i)
+    {
+      const VkImageViewCreateInfo imageViewInfo{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .image = m_context->swapchainImages[i],
+          .viewType = VK_IMAGE_VIEW_TYPE_2D,
+          .format = m_context->swapchainFormat,
+          .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY},
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      if (!CheckVk(vkCreateImageView(m_context->device,
+                                     &imageViewInfo,
                                      nullptr,
-                                     &m_context->opaqueFramebuffers[i]),
+                                     &m_context->swapchainImageViews[i]),
+                   m_lastError,
+                   "vkCreateImageView"))
+      {
+        return false;
+      }
+    }
+
+    m_context->commandBuffers.resize(swapchainImageCount);
+    const VkCommandBufferAllocateInfo commandBufferInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .commandPool = m_context->commandPool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = swapchainImageCount,
+    };
+    if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
+                                          &commandBufferInfo,
+                                          m_context->commandBuffers.data()),
                  m_lastError,
-                 "vkCreateFramebuffer")) {
+                 "vkAllocateCommandBuffers"))
+    {
       return false;
     }
+
+    if (!CreateOpaqueRasterScaffold())
+      return false;
+
+    if (m_context->opaqueShaderPipelineScaffoldReady && !CreateOpaqueGraphicsPipelineScaffold())
+      return false;
+
+    return true;
   }
 
-  return true;
-}
+  bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig &frame)
+  {
+    VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
+    if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
+      return false;
 
-void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers) {
-    if (framebuffer != VK_NULL_HANDLE)
-      vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
-  }
-  m_context->opaqueFramebuffers.clear();
-
-  if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
-    vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
-    m_context->opaqueRenderPass = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold() {
-  const VkPipelineCacheCreateInfo pipelineCacheInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .initialDataSize = 0,
-      .pInitialData = nullptr,
-  };
-  return CheckVk(vkCreatePipelineCache(m_context->device,
-                                       &pipelineCacheInfo,
-                                       nullptr,
-                                       &m_context->opaquePipelineCache),
-                 m_lastError,
-                 "vkCreatePipelineCache");
-}
-
-void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  if (m_context->opaquePipelineCache != VK_NULL_HANDLE) {
-    vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
-    m_context->opaquePipelineCache = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
-  m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .stage = VK_SHADER_STAGE_VERTEX_BIT,
-      .module = VK_NULL_HANDLE,
-      .pName = m_context->opaqueShaderEntryNames[0].c_str(),
-      .pSpecializationInfo = nullptr,
-  };
-  m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
-      .module = VK_NULL_HANDLE,
-      .pName = m_context->opaqueShaderEntryNames[1].c_str(),
-      .pSpecializationInfo = nullptr,
-  };
-
-  m_context->opaqueShaderPipelineScaffoldReady =
-      m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-      m_context->opaquePipelineCache != VK_NULL_HANDLE &&
-      m_context->opaqueShaderStages[0].pName != nullptr &&
-      m_context->opaqueShaderStages[1].pName != nullptr;
-  return m_context->opaqueShaderPipelineScaffoldReady;
-}
-
-void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
-  if (!m_context)
-    return;
-  m_context->opaqueShaderStages = {};
-  m_context->opaqueShaderPipelineScaffoldReady = false;
-}
-
-bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold() {
-  m_context->opaqueGraphicsPipelineScaffoldReady =
-      m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
-  if (!m_context->opaqueGraphicsPipelineScaffoldReady) {
-    m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
-  }
-  return m_context->opaqueGraphicsPipelineScaffoldReady;
-}
-
-void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold() {
-  if (!m_context)
-    return;
-  m_context->opaqueGraphicsPipelineScaffoldReady = false;
-}
-
-bool VulkanRenderBackend::RecreateSwapchain() {
-  DestroySwapchain();
-
-  VkSurfaceCapabilitiesKHR surfaceCapabilities{};
-  if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
-                                                         m_context->surface,
-                                                         &surfaceCapabilities),
-               m_lastError,
-               "vkGetPhysicalDeviceSurfaceCapabilitiesKHR")) {
-    return false;
-  }
-
-  uint32_t surfaceFormatCount = 0;
-  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
-                                       m_context->surface,
-                                       &surfaceFormatCount,
-                                       nullptr);
-  std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
-  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
-                                       m_context->surface,
-                                       &surfaceFormatCount,
-                                       surfaceFormats.data());
-  VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
-  for (const auto& candidate : surfaceFormats) {
-    if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
-        candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
-      chosenFormat = candidate;
-      break;
-    }
-  }
-  m_context->swapchainFormat = chosenFormat.format;
-
-  uint32_t presentModeCount = 0;
-  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
-                                            m_context->surface,
-                                            &presentModeCount,
-                                            nullptr);
-  std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
-                                            m_context->surface,
-                                            &presentModeCount,
-                                            presentModes.data());
-  VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
-  for (VkPresentModeKHR presentMode : presentModes) {
-    if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
-      chosenPresentMode = presentMode;
-      break;
-    }
-  }
-
-  int framebufferWidth = 0;
-  int framebufferHeight = 0;
-  glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
-  framebufferWidth = std::max(framebufferWidth, 1);
-  framebufferHeight = std::max(framebufferHeight, 1);
-
-  if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
-    m_context->swapchainExtent = surfaceCapabilities.currentExtent;
-  } else {
-    m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
-                                                  surfaceCapabilities.minImageExtent.width,
-                                                  surfaceCapabilities.maxImageExtent.width);
-    m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
-                                                   surfaceCapabilities.minImageExtent.height,
-                                                   surfaceCapabilities.maxImageExtent.height);
-  }
-
-  uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
-  if (surfaceCapabilities.maxImageCount > 0)
-    imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
-
-  std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
-                                                m_context->presentQueueFamily};
-  const bool usesSeparatePresentQueue =
-      m_context->graphicsQueueFamily != m_context->presentQueueFamily;
-
-  const VkSwapchainCreateInfoKHR swapchainInfo{
-      .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
-      .pNext = nullptr,
-      .flags = 0,
-      .surface = m_context->surface,
-      .minImageCount = imageCount,
-      .imageFormat = chosenFormat.format,
-      .imageColorSpace = chosenFormat.colorSpace,
-      .imageExtent = m_context->swapchainExtent,
-      .imageArrayLayers = 1,
-      .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-      .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
-                                                   : VK_SHARING_MODE_EXCLUSIVE,
-      .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
-      .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
-      .preTransform = surfaceCapabilities.currentTransform,
-      .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
-      .presentMode = chosenPresentMode,
-      .clipped = VK_TRUE,
-      .oldSwapchain = VK_NULL_HANDLE,
-  };
-  if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
-                                    &m_context->swapchain),
-               m_lastError,
-               "vkCreateSwapchainKHR")) {
-    return false;
-  }
-
-  uint32_t swapchainImageCount = 0;
-  vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
-  m_context->swapchainImages.resize(swapchainImageCount);
-  vkGetSwapchainImagesKHR(m_context->device,
-                          m_context->swapchain,
-                          &swapchainImageCount,
-                          m_context->swapchainImages.data());
-  m_context->swapchainImageViews.resize(swapchainImageCount);
-  m_context->imageWasPresented.assign(swapchainImageCount, false);
-
-  for (size_t i = 0; i < m_context->swapchainImages.size(); ++i) {
-    const VkImageViewCreateInfo imageViewInfo{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+    const VkCommandBufferBeginInfo beginInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .image = m_context->swapchainImages[i],
-        .viewType = VK_IMAGE_VIEW_TYPE_2D,
-        .format = m_context->swapchainFormat,
-        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY},
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        .pInheritanceInfo = nullptr,
     };
-    if (!CheckVk(vkCreateImageView(m_context->device,
-                                   &imageViewInfo,
-                                   nullptr,
-                                   &m_context->swapchainImageViews[i]),
-                 m_lastError,
-                 "vkCreateImageView")) {
+    if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
+                 "vkBeginCommandBuffer"))
+    {
       return false;
     }
-  }
 
-  m_context->commandBuffers.resize(swapchainImageCount);
-  const VkCommandBufferAllocateInfo commandBufferInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-      .pNext = nullptr,
-      .commandPool = m_context->commandPool,
-      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-      .commandBufferCount = swapchainImageCount,
-  };
-  if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
-                                        &commandBufferInfo,
-                                        m_context->commandBuffers.data()),
-               m_lastError,
-               "vkAllocateCommandBuffers")) {
-    return false;
-  }
-
-  if (!CreateOpaqueRasterScaffold())
-    return false;
-
-  return true;
-}
-
-bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
-  VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
-  if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
-    return false;
-
-  const VkCommandBufferBeginInfo beginInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .pInheritanceInfo = nullptr,
-  };
-  if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
-               "vkBeginCommandBuffer")) {
-    return false;
-  }
-
-  if (frame.clearColorBuffer) {
-    if (!m_pendingOpaqueDraws.empty()) {
-      // Placeholder for the first opaque-scene submission slice: keep the current
-      // clear/present bootstrap, but make frame recording aware that opaque scene
-      // work was queued through the backend seam.
-      m_lastError.clear();
+    const bool hasQueuedOpaqueDraws = !m_pendingOpaqueDraws.empty();
+    const bool hasExecutableOpaquePipeline =
+        m_context->opaqueGraphicsPipelineExecutable &&
+        m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
+    if (hasQueuedOpaqueDraws && !hasExecutableOpaquePipeline)
+    {
+      m_lastError =
+          "Opaque scene draw submissions are queued, but Vulkan draw execution is not ready: "
+          "shader modules and graphics pipeline are still scaffold-only. Pending draws: " +
+          std::to_string(m_pendingOpaqueDraws.size());
     }
 
-    const VkImageMemoryBarrier toTransfer{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        .pNext = nullptr,
-        .srcAccessMask = 0,
-        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
-                         ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-                         : VK_IMAGE_LAYOUT_UNDEFINED,
-        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .image = m_context->swapchainImages[m_context->activeImageIndex],
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-    };
-    vkCmdPipelineBarrier(commandBuffer,
-                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                         VK_PIPELINE_STAGE_TRANSFER_BIT,
-                         0,
-                         0,
-                         nullptr,
-                         0,
-                         nullptr,
-                         1,
-                         &toTransfer);
+    if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
+    {
+      const VkImageMemoryBarrier toColorAttachment{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = 0,
+          .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+          .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                           ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                           : VK_IMAGE_LAYOUT_UNDEFINED,
+          .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toColorAttachment);
 
-    const VkClearColorValue clearColor = {{frame.clearColor.x,
-                                           frame.clearColor.y,
-                                           frame.clearColor.z,
-                                           frame.clearColor.w}};
-    const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vkCmdClearColorImage(commandBuffer,
-                         m_context->swapchainImages[m_context->activeImageIndex],
-                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                         &clearColor,
-                         1,
-                         &clearRange);
+      const VkClearValue clearValue = {
+          .color = {{frame.clearColor.x, frame.clearColor.y, frame.clearColor.z, frame.clearColor.w}}};
+      const VkRenderPassBeginInfo renderPassBeginInfo{
+          .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+          .pNext = nullptr,
+          .renderPass = m_context->opaqueRenderPass,
+          .framebuffer = m_context->opaqueFramebuffers[m_context->activeImageIndex],
+          .renderArea = {{0, 0}, m_context->swapchainExtent},
+          .clearValueCount = 1,
+          .pClearValues = &clearValue,
+      };
+      vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
-    const VkImageMemoryBarrier toPresent{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        .pNext = nullptr,
-        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .dstAccessMask = 0,
-        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .image = m_context->swapchainImages[m_context->activeImageIndex],
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-    };
-    vkCmdPipelineBarrier(commandBuffer,
-                         VK_PIPELINE_STAGE_TRANSFER_BIT,
-                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                         0,
-                         0,
-                         nullptr,
-                         0,
-                         nullptr,
-                         1,
-                         &toPresent);
+      const VkViewport viewport{
+          .x = 0.0f,
+          .y = 0.0f,
+          .width = static_cast<float>(m_context->swapchainExtent.width),
+          .height = static_cast<float>(m_context->swapchainExtent.height),
+          .minDepth = 0.0f,
+          .maxDepth = 1.0f,
+      };
+      const VkRect2D scissor{{0, 0}, m_context->swapchainExtent};
+      vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
+      vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
+      vkCmdBindPipeline(commandBuffer,
+                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                        m_context->opaqueGraphicsPipeline);
+
+      for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+      {
+        if (draw.indexCount <= 0)
+          continue;
+        vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+      }
+
+      vkCmdEndRenderPass(commandBuffer);
+    }
+    else if (frame.clearColorBuffer)
+    {
+      const VkImageMemoryBarrier toTransfer{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = 0,
+          .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+          .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                           ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                           : VK_IMAGE_LAYOUT_UNDEFINED,
+          .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toTransfer);
+
+      const VkClearColorValue clearColor = {{frame.clearColor.x,
+                                             frame.clearColor.y,
+                                             frame.clearColor.z,
+                                             frame.clearColor.w}};
+      const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+      vkCmdClearColorImage(commandBuffer,
+                           m_context->swapchainImages[m_context->activeImageIndex],
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           &clearColor,
+                           1,
+                           &clearRange);
+
+      const VkImageMemoryBarrier toPresent{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+          .dstAccessMask = 0,
+          .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+          .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toPresent);
+    }
+
+    if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
+      return false;
+
+    m_context->frameCommandsRecorded = true;
+    return true;
   }
 
-  if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
-    return false;
+  void VulkanRenderBackend::BeginFrame(const RenderFrameConfig &frame)
+  {
+    MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
+    MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
+    if (!IsInitialized() || m_frameActive)
+      return;
 
-  m_context->frameCommandsRecorded = true;
-  return true;
-}
+    m_lastError.clear();
 
-void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
-  MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
-  MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
-  if (!IsInitialized() || m_frameActive)
-    return;
+    if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+                 m_lastError,
+                 "vkWaitForFences"))
+    {
+      return;
+    }
 
-  if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
-               m_lastError,
-               "vkWaitForFences")) {
-    return;
-  }
+    VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                                   m_context->swapchain,
+                                                   UINT64_MAX,
+                                                   m_context->imageAvailableSemaphore,
+                                                   VK_NULL_HANDLE,
+                                                   &m_context->activeImageIndex);
+    if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR)
+    {
+      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+      acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                            m_context->swapchain,
+                                            UINT64_MAX,
+                                            m_context->imageAvailableSemaphore,
+                                            VK_NULL_HANDLE,
+                                            &m_context->activeImageIndex);
+    }
+    MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
 
-  VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
-                                                 m_context->swapchain,
-                                                 UINT64_MAX,
-                                                 m_context->imageAvailableSemaphore,
-                                                 VK_NULL_HANDLE,
-                                                 &m_context->activeImageIndex);
-  if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR) {
-    MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
-    acquireResult = vkAcquireNextImageKHR(m_context->device,
-                                          m_context->swapchain,
-                                          UINT64_MAX,
-                                          m_context->imageAvailableSemaphore,
-                                          VK_NULL_HANDLE,
-                                          &m_context->activeImageIndex);
-  }
-  MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
-
-  MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
-                          m_lastError,
-                          "vkResetFences"),
-                  m_lastError.c_str());
-
-  m_activeFrame = frame;
-  m_activeView = {};
-  m_pendingOpaqueDraws.clear();
-  m_context->frameCommandsRecorded = false;
-  m_drawCalls = 0;
-  m_frameActive = true;
-}
-
-void VulkanRenderBackend::EndFrame() {
-  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
-  if (!m_frameActive)
-    return;
-
-  if (m_passActive)
-    EndPass();
-
-  if (!m_context->frameCommandsRecorded) {
-    MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
-  }
-
-  if (m_context->frameCommandsRecorded) {
-    const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
-    const VkSubmitInfo submitInfo{
-        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-        .pNext = nullptr,
-        .waitSemaphoreCount = 1,
-        .pWaitSemaphores = &m_context->imageAvailableSemaphore,
-        .pWaitDstStageMask = waitStages,
-        .commandBufferCount = 1,
-        .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
-        .signalSemaphoreCount = 1,
-        .pSignalSemaphores = &m_context->renderFinishedSemaphore,
-    };
-    MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
-                                          1,
-                                          &submitInfo,
-                                          m_context->inFlightFence),
+    MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
                             m_lastError,
-                            "vkQueueSubmit"),
+                            "vkResetFences"),
                     m_lastError.c_str());
 
-    const VkPresentInfoKHR presentInfo{
-        .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-        .pNext = nullptr,
-        .waitSemaphoreCount = 1,
-        .pWaitSemaphores = &m_context->renderFinishedSemaphore,
-        .swapchainCount = 1,
-        .pSwapchains = &m_context->swapchain,
-        .pImageIndices = &m_context->activeImageIndex,
-        .pResults = nullptr,
-    };
-    const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
-    if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
-      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
-    } else {
-      MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
-    }
-
-    m_context->imageWasPresented[m_context->activeImageIndex] = true;
+    m_activeFrame = frame;
+    m_activeView = {};
+    m_pendingOpaqueDraws.clear();
     m_context->frameCommandsRecorded = false;
+    m_drawCalls = 0;
+    m_frameActive = true;
   }
 
-  m_frameActive = false;
-  m_pendingOpaqueDraws.clear();
-}
+  void VulkanRenderBackend::EndFrame()
+  {
+    MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
+    if (!m_frameActive)
+      return;
 
-void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
-  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
-  MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
-  if (!m_frameActive || m_passActive)
-    return;
+    if (m_passActive)
+      EndPass();
 
-  m_activePassId = pass.id;
-  m_activeView = pass.view;
-  m_passActive = true;
-}
+    if (!m_context->frameCommandsRecorded)
+    {
+      MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
+    }
 
-void VulkanRenderBackend::EndPass() {
-  MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
-  if (!m_passActive)
-    return;
-  m_passActive = false;
-}
+    if (m_context->frameCommandsRecorded)
+    {
+      const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_ALL_COMMANDS_BIT};
+      const VkSubmitInfo submitInfo{
+          .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+          .pNext = nullptr,
+          .waitSemaphoreCount = 1,
+          .pWaitSemaphores = &m_context->imageAvailableSemaphore,
+          .pWaitDstStageMask = waitStages,
+          .commandBufferCount = 1,
+          .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
+          .signalSemaphoreCount = 1,
+          .pSignalSemaphores = &m_context->renderFinishedSemaphore,
+      };
+      MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
+                                            1,
+                                            &submitInfo,
+                                            m_context->inFlightFence),
+                              m_lastError,
+                              "vkQueueSubmit"),
+                      m_lastError.c_str());
 
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
-  if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
-    return;
+      const VkPresentInfoKHR presentInfo{
+          .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+          .pNext = nullptr,
+          .waitSemaphoreCount = 1,
+          .pWaitSemaphores = &m_context->renderFinishedSemaphore,
+          .swapchainCount = 1,
+          .pSwapchains = &m_context->swapchain,
+          .pImageIndices = &m_context->activeImageIndex,
+          .pResults = nullptr,
+      };
+      const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
+      if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR)
+      {
+        MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+      }
+      else
+      {
+        MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
+      }
 
-  m_pendingOpaqueDraws.push_back(
-      PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
-                        command.modelMatrix,
-                        TranslateMaterialState(*command.material),
-                        {}});
-  m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
-  ++m_drawCalls;
-}
+      m_context->imageWasPresented[m_context->activeImageIndex] = true;
+      m_context->frameCommandsRecorded = false;
+    }
 
-void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+    m_frameActive = false;
+    m_pendingOpaqueDraws.clear();
+  }
 
-void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+  void VulkanRenderBackend::BeginPass(const RenderPassConfig &pass)
+  {
+    MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
+    MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
+    if (!m_frameActive || m_passActive)
+      return;
+
+    m_activePassId = pass.id;
+    m_activeView = pass.view;
+    m_passActive = true;
+  }
+
+  void VulkanRenderBackend::EndPass()
+  {
+    MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
+    if (!m_passActive)
+      return;
+    m_passActive = false;
+  }
+
+  void VulkanRenderBackend::DrawMesh(const MeshDrawCommand &command)
+  {
+    if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
+      return;
+
+    m_pendingOpaqueDraws.push_back(
+        PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
+                          command.modelMatrix,
+                          TranslateMaterialState(*command.material),
+                          {}});
+    m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
+    ++m_drawCalls;
+  }
+
+  void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand &) {}
+
+  void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand &) {}
 
 #else
 
-struct VulkanRenderBackend::Context {};
+  struct VulkanRenderBackend::Context
+  {
+  };
 
-VulkanRenderBackend::VulkanRenderBackend(void*) {
-  m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
-}
+  VulkanRenderBackend::VulkanRenderBackend(void *)
+  {
+    m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
+  }
 
-VulkanRenderBackend::~VulkanRenderBackend() = default;
+  VulkanRenderBackend::~VulkanRenderBackend() = default;
 
-RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
-  return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
-}
+  RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const
+  {
+    return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  }
 
-bool VulkanRenderBackend::IsInitialized() const {
-  return false;
-}
+  bool VulkanRenderBackend::IsInitialized() const
+  {
+    return false;
+  }
 
-bool VulkanRenderBackend::Initialize(void*) {
-  return false;
-}
+  bool VulkanRenderBackend::Initialize(void *)
+  {
+    return false;
+  }
 
-void VulkanRenderBackend::Shutdown() {}
-bool VulkanRenderBackend::RecreateSwapchain() { return false; }
-void VulkanRenderBackend::DestroySwapchain() {}
-bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig&) { return false; }
-void VulkanRenderBackend::BeginFrame(const RenderFrameConfig&) {}
-void VulkanRenderBackend::EndFrame() {}
-void VulkanRenderBackend::BeginPass(const RenderPassConfig&) {}
-void VulkanRenderBackend::EndPass() {}
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
-void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
-void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+  void VulkanRenderBackend::Shutdown() {}
+  bool VulkanRenderBackend::RecreateSwapchain() { return false; }
+  void VulkanRenderBackend::DestroySwapchain() {}
+  bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig &) { return false; }
+  void VulkanRenderBackend::BeginFrame(const RenderFrameConfig &) {}
+  void VulkanRenderBackend::EndFrame() {}
+  void VulkanRenderBackend::BeginPass(const RenderPassConfig &) {}
+  void VulkanRenderBackend::EndPass() {}
+  void VulkanRenderBackend::DrawMesh(const MeshDrawCommand &) {}
+  void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand &) {}
+  void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand &) {}
 
 #endif
 
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 
 #include "core/Assert.h"
+#include "renderer/Material.h"
+#include "renderer/Mesh.h"
 
 #if defined(MONOLITH_HAS_VULKAN)
 #include <volk.h>
@@ -100,6 +102,22 @@ constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
 }
 
 }  // namespace
+
+VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
+    const Material& material) {
+  TranslatedMaterialState translated;
+  translated.baseColor = material.color;
+  translated.roughness = material.roughness;
+  translated.metallic = material.metallic;
+  translated.uvScale = material.uvScale;
+  translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
+  translated.usesCustomShader = material.shader && material.shader->IsValid();
+  return translated;
+}
+
+int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
+  return mesh.GetIndexCount();
+}
 
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
@@ -784,7 +802,10 @@ void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
   if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
     return;
 
-  m_pendingOpaqueDraws.push_back(PendingOpaqueDraw{command.mesh, command.material, command.modelMatrix});
+  m_pendingOpaqueDraws.push_back(
+      PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
+                        command.modelMatrix,
+                        TranslateMaterialState(*command.material)});
   ++m_drawCalls;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -302,6 +302,22 @@ namespace Monolith
   void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback callback,
                                                        void *userData)
   {
+    if (!m_frameActive)
+    {
+      m_pendingOverlayRenderCallback = nullptr;
+      m_pendingOverlayRenderUserData = nullptr;
+      m_lastError =
+          "Vulkan overlay render callbacks must be queued during an active frame.";
+      return;
+    }
+
+    if (!callback || !userData)
+    {
+      m_pendingOverlayRenderCallback = nullptr;
+      m_pendingOverlayRenderUserData = nullptr;
+      return;
+    }
+
     m_pendingOverlayRenderCallback = callback;
     m_pendingOverlayRenderUserData = userData;
   }

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -119,6 +119,16 @@ int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
   return mesh.GetIndexCount();
 }
 
+VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
+    const TranslatedMaterialState& materialState) {
+  OpaquePipelineKey key;
+  key.usesAlbedoMap = materialState.usesAlbedoMap;
+  key.usesCustomShader = materialState.usesCustomShader;
+  key.writesDepth = true;
+  key.depthTestEnabled = true;
+  return key;
+}
+
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
 }
@@ -805,7 +815,9 @@ void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
   m_pendingOpaqueDraws.push_back(
       PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
                         command.modelMatrix,
-                        TranslateMaterialState(*command.material)});
+                        TranslateMaterialState(*command.material),
+                        {}});
+  m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
   ++m_drawCalls;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -86,6 +86,8 @@ struct VulkanRenderBackend::Context {
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+  std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
+  std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
   bool opaqueShaderPipelineScaffoldReady = false;
   bool opaqueGraphicsPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
@@ -633,14 +635,37 @@ void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
 }
 
 bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
-  m_context->opaqueShaderPipelineScaffoldReady = m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-                                                 m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .stage = VK_SHADER_STAGE_VERTEX_BIT,
+      .module = VK_NULL_HANDLE,
+      .pName = m_context->opaqueShaderEntryNames[0].c_str(),
+      .pSpecializationInfo = nullptr,
+  };
+  m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+      .module = VK_NULL_HANDLE,
+      .pName = m_context->opaqueShaderEntryNames[1].c_str(),
+      .pSpecializationInfo = nullptr,
+  };
+
+  m_context->opaqueShaderPipelineScaffoldReady =
+      m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+      m_context->opaquePipelineCache != VK_NULL_HANDLE &&
+      m_context->opaqueShaderStages[0].pName != nullptr &&
+      m_context->opaqueShaderStages[1].pName != nullptr;
   return m_context->opaqueShaderPipelineScaffoldReady;
 }
 
 void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
   if (!m_context)
     return;
+  m_context->opaqueShaderStages = {};
   m_context->opaqueShaderPipelineScaffoldReady = false;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -254,6 +254,51 @@ namespace Monolith
     return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
   }
 
+  bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **outInstance,
+                                                      void **outPhysicalDevice,
+                                                      void **outDevice,
+                                                      uint32_t *outQueueFamily,
+                                                      void **outQueue,
+                                                      void **outRenderPass,
+                                                      uint32_t *outImageCount) const
+  {
+    if (!IsInitialized() || !m_context)
+      return false;
+
+    if (outInstance)
+      *outInstance = reinterpret_cast<void *>(m_context->instance);
+    if (outPhysicalDevice)
+      *outPhysicalDevice = reinterpret_cast<void *>(m_context->physicalDevice);
+    if (outDevice)
+      *outDevice = reinterpret_cast<void *>(m_context->device);
+    if (outQueueFamily)
+      *outQueueFamily = m_context->graphicsQueueFamily;
+    if (outQueue)
+      *outQueue = reinterpret_cast<void *>(m_context->graphicsQueue);
+    if (outRenderPass)
+      *outRenderPass = reinterpret_cast<void *>(m_context->opaqueRenderPass);
+    if (outImageCount)
+      *outImageCount = static_cast<uint32_t>(m_context->swapchainImages.size());
+
+    return m_context->instance != VK_NULL_HANDLE &&
+           m_context->physicalDevice != VK_NULL_HANDLE &&
+           m_context->device != VK_NULL_HANDLE &&
+           m_context->graphicsQueue != VK_NULL_HANDLE &&
+           m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+           !m_context->swapchainImages.empty();
+  }
+
+  void *VulkanRenderBackend::GetActiveCommandBufferHandle() const
+  {
+    if (!m_context || m_context->commandBuffers.empty() ||
+        m_context->activeImageIndex >= m_context->commandBuffers.size())
+    {
+      return nullptr;
+    }
+
+    return reinterpret_cast<void *>(m_context->commandBuffers[m_context->activeImageIndex]);
+  }
+
   bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
   {
     m_lastError.clear();
@@ -1489,6 +1534,22 @@ namespace Monolith
   bool VulkanRenderBackend::IsInitialized() const
   {
     return false;
+  }
+
+  bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **,
+                                                      void **,
+                                                      void **,
+                                                      uint32_t *,
+                                                      void **,
+                                                      void **,
+                                                      uint32_t *) const
+  {
+    return false;
+  }
+
+  void *VulkanRenderBackend::GetActiveCommandBufferHandle() const
+  {
+    return nullptr;
   }
 
   bool VulkanRenderBackend::Initialize(void *)

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -87,6 +87,7 @@ struct VulkanRenderBackend::Context {
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
   bool opaqueShaderPipelineScaffoldReady = false;
+  bool opaqueGraphicsPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -174,6 +175,10 @@ bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
 
 bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
   return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
+}
+
+bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const {
+  return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -434,6 +439,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaqueGraphicsPipelineScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   return true;
 }
 
@@ -446,6 +456,7 @@ void VulkanRenderBackend::Shutdown() {
 
   DestroySwapchain();
 
+  DestroyOpaqueGraphicsPipelineScaffold();
   DestroyOpaqueShaderPipelineScaffold();
   DestroyOpaquePipelineCreationScaffold();
 
@@ -631,6 +642,21 @@ void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
   if (!m_context)
     return;
   m_context->opaqueShaderPipelineScaffoldReady = false;
+}
+
+bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold() {
+  m_context->opaqueGraphicsPipelineScaffoldReady =
+      m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
+  if (!m_context->opaqueGraphicsPipelineScaffoldReady) {
+    m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
+  }
+  return m_context->opaqueGraphicsPipelineScaffoldReady;
+}
+
+void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold() {
+  if (!m_context)
+    return;
+  m_context->opaqueGraphicsPipelineScaffoldReady = false;
 }
 
 bool VulkanRenderBackend::RecreateSwapchain() {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -86,6 +86,7 @@ struct VulkanRenderBackend::Context {
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+  bool opaqueShaderPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -169,6 +170,10 @@ bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
 
 bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
   return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
+  return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -419,6 +424,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaqueShaderPipelineScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -436,6 +446,7 @@ void VulkanRenderBackend::Shutdown() {
 
   DestroySwapchain();
 
+  DestroyOpaqueShaderPipelineScaffold();
   DestroyOpaquePipelineCreationScaffold();
 
   if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
@@ -608,6 +619,18 @@ void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
     vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
     m_context->opaquePipelineCache = VK_NULL_HANDLE;
   }
+}
+
+bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
+  m_context->opaqueShaderPipelineScaffoldReady = m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+                                                 m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  return m_context->opaqueShaderPipelineScaffoldReady;
+}
+
+void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
+  if (!m_context)
+    return;
+  m_context->opaqueShaderPipelineScaffoldReady = false;
 }
 
 bool VulkanRenderBackend::RecreateSwapchain() {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -83,8 +83,11 @@ struct VulkanRenderBackend::Context {
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
   VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkExtent2D swapchainExtent = {1, 1};
+  VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
+  VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
+  std::vector<VkFramebuffer> opaqueFramebuffers;
   std::vector<VkCommandBuffer> commandBuffers;
   std::vector<bool> imageWasPresented;
   VkCommandPool commandPool = VK_NULL_HANDLE;
@@ -154,6 +157,13 @@ RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
 
 bool VulkanRenderBackend::IsInitialized() const {
   return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
+  return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+         m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+         m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
+         !m_context->opaqueFramebuffers.empty();
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -380,6 +390,25 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .setLayoutCount = 0,
+      .pSetLayouts = nullptr,
+      .pushConstantRangeCount = 0,
+      .pPushConstantRanges = nullptr,
+  };
+  if (!CheckVk(vkCreatePipelineLayout(m_context->device,
+                                      &pipelineLayoutInfo,
+                                      nullptr,
+                                      &m_context->opaquePipelineLayout),
+               m_lastError,
+               "vkCreatePipelineLayout")) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -396,6 +425,9 @@ void VulkanRenderBackend::Shutdown() {
     vkDeviceWaitIdle(m_context->device);
 
   DestroySwapchain();
+
+  if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
+    vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
 
   if (m_context->inFlightFence != VK_NULL_HANDLE)
     vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
@@ -421,6 +453,8 @@ void VulkanRenderBackend::DestroySwapchain() {
   if (!m_context || m_context->device == VK_NULL_HANDLE)
     return;
 
+  DestroyOpaqueRasterScaffold();
+
   if (!m_context->commandBuffers.empty()) {
     vkFreeCommandBuffers(m_context->device,
                          m_context->commandPool,
@@ -438,6 +472,103 @@ void VulkanRenderBackend::DestroySwapchain() {
   if (m_context->swapchain != VK_NULL_HANDLE) {
     vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
     m_context->swapchain = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::CreateOpaqueRasterScaffold() {
+  const VkAttachmentDescription colorAttachment{
+      .flags = 0,
+      .format = m_context->swapchainFormat,
+      .samples = VK_SAMPLE_COUNT_1_BIT,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+      .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+  };
+  const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  const VkSubpassDescription subpass{
+      .flags = 0,
+      .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+      .inputAttachmentCount = 0,
+      .pInputAttachments = nullptr,
+      .colorAttachmentCount = 1,
+      .pColorAttachments = &colorAttachmentRef,
+      .pResolveAttachments = nullptr,
+      .pDepthStencilAttachment = nullptr,
+      .preserveAttachmentCount = 0,
+      .pPreserveAttachments = nullptr,
+  };
+  const VkSubpassDependency dependency{
+      .srcSubpass = VK_SUBPASS_EXTERNAL,
+      .dstSubpass = 0,
+      .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+      .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+      .srcAccessMask = 0,
+      .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+      .dependencyFlags = 0,
+  };
+  const VkRenderPassCreateInfo renderPassInfo{
+      .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .attachmentCount = 1,
+      .pAttachments = &colorAttachment,
+      .subpassCount = 1,
+      .pSubpasses = &subpass,
+      .dependencyCount = 1,
+      .pDependencies = &dependency,
+  };
+  if (!CheckVk(vkCreateRenderPass(m_context->device,
+                                  &renderPassInfo,
+                                  nullptr,
+                                  &m_context->opaqueRenderPass),
+               m_lastError,
+               "vkCreateRenderPass")) {
+    return false;
+  }
+
+  m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
+  for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i) {
+    const VkImageView attachment = m_context->swapchainImageViews[i];
+    const VkFramebufferCreateInfo framebufferInfo{
+        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .renderPass = m_context->opaqueRenderPass,
+        .attachmentCount = 1,
+        .pAttachments = &attachment,
+        .width = m_context->swapchainExtent.width,
+        .height = m_context->swapchainExtent.height,
+        .layers = 1,
+    };
+    if (!CheckVk(vkCreateFramebuffer(m_context->device,
+                                     &framebufferInfo,
+                                     nullptr,
+                                     &m_context->opaqueFramebuffers[i]),
+                 m_lastError,
+                 "vkCreateFramebuffer")) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers) {
+    if (framebuffer != VK_NULL_HANDLE)
+      vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
+  }
+  m_context->opaqueFramebuffers.clear();
+
+  if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
+    vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
+    m_context->opaqueRenderPass = VK_NULL_HANDLE;
   }
 }
 
@@ -594,6 +725,9 @@ bool VulkanRenderBackend::RecreateSwapchain() {
                "vkAllocateCommandBuffers")) {
     return false;
   }
+
+  if (!CreateOpaqueRasterScaffold())
+    return false;
 
   return true;
 }

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -299,6 +299,13 @@ namespace Monolith
     return reinterpret_cast<void *>(m_context->commandBuffers[m_context->activeImageIndex]);
   }
 
+  void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback callback,
+                                                       void *userData)
+  {
+    m_pendingOverlayRenderCallback = callback;
+    m_pendingOverlayRenderUserData = userData;
+  }
+
   bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
   {
     m_lastError.clear();
@@ -1219,6 +1226,7 @@ namespace Monolith
     }
 
     const bool hasQueuedOpaqueDraws = !m_pendingOpaqueDraws.empty();
+    const bool hasQueuedOverlayRender = m_pendingOverlayRenderCallback != nullptr;
     const bool hasExecutableOpaquePipeline =
         m_context->opaqueGraphicsPipelineExecutable &&
         m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
@@ -1230,7 +1238,7 @@ namespace Monolith
           std::to_string(m_pendingOpaqueDraws.size());
     }
 
-    if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
+    if (hasQueuedOpaqueDraws || hasQueuedOverlayRender)
     {
       const VkImageMemoryBarrier toColorAttachment{
           .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -1281,15 +1289,24 @@ namespace Monolith
       const VkRect2D scissor{{0, 0}, m_context->swapchainExtent};
       vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
       vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
-      vkCmdBindPipeline(commandBuffer,
-                        VK_PIPELINE_BIND_POINT_GRAPHICS,
-                        m_context->opaqueGraphicsPipeline);
-
-      for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+      if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
       {
-        if (draw.indexCount <= 0)
-          continue;
-        vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+        vkCmdBindPipeline(commandBuffer,
+                          VK_PIPELINE_BIND_POINT_GRAPHICS,
+                          m_context->opaqueGraphicsPipeline);
+
+        for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+        {
+          if (draw.indexCount <= 0)
+            continue;
+          vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+        }
+      }
+
+      if (hasQueuedOverlayRender)
+      {
+        m_pendingOverlayRenderCallback(m_pendingOverlayRenderUserData,
+                                       reinterpret_cast<void *>(commandBuffer));
       }
 
       vkCmdEndRenderPass(commandBuffer);
@@ -1473,6 +1490,8 @@ namespace Monolith
 
     m_frameActive = false;
     m_pendingOpaqueDraws.clear();
+    m_pendingOverlayRenderCallback = nullptr;
+    m_pendingOverlayRenderUserData = nullptr;
   }
 
   void VulkanRenderBackend::BeginPass(const RenderPassConfig &pass)
@@ -1551,6 +1570,8 @@ namespace Monolith
   {
     return nullptr;
   }
+
+  void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback, void *) {}
 
   bool VulkanRenderBackend::Initialize(void *)
   {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -85,6 +85,7 @@ struct VulkanRenderBackend::Context {
   VkExtent2D swapchainExtent = {1, 1};
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
+  VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -164,6 +165,10 @@ bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
          m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
          m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
          !m_context->opaqueFramebuffers.empty();
+}
+
+bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
+  return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -409,6 +414,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaquePipelineCreationScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -425,6 +435,8 @@ void VulkanRenderBackend::Shutdown() {
     vkDeviceWaitIdle(m_context->device);
 
   DestroySwapchain();
+
+  DestroyOpaquePipelineCreationScaffold();
 
   if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
     vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
@@ -569,6 +581,32 @@ void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
   if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
     vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
     m_context->opaqueRenderPass = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold() {
+  const VkPipelineCacheCreateInfo pipelineCacheInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .initialDataSize = 0,
+      .pInitialData = nullptr,
+  };
+  return CheckVk(vkCreatePipelineCache(m_context->device,
+                                       &pipelineCacheInfo,
+                                       nullptr,
+                                       &m_context->opaquePipelineCache),
+                 m_lastError,
+                 "vkCreatePipelineCache");
+}
+
+void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  if (m_context->opaquePipelineCache != VK_NULL_HANDLE) {
+    vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
+    m_context->opaquePipelineCache = VK_NULL_HANDLE;
   }
 }
 

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -33,6 +33,7 @@ class VulkanRenderBackend : public IRenderBackend {
 
   bool IsInitialized() const;
   bool HasOpaqueRasterScaffold() const;
+  bool HasOpaquePipelineCreationScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -64,6 +65,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroySwapchain();
   bool CreateOpaqueRasterScaffold();
   void DestroyOpaqueRasterScaffold();
+  bool CreateOpaquePipelineCreationScaffold();
+  void DestroyOpaquePipelineCreationScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -34,6 +34,18 @@ class VulkanRenderBackend : public IRenderBackend {
   bool IsInitialized() const;
   const std::string& GetLastError() const { return m_lastError; }
 
+  struct TranslatedMaterialState {
+    Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
+    float roughness = 0.5f;
+    float metallic = 0.0f;
+    float uvScale = 1.0f;
+    bool usesAlbedoMap = false;
+    bool usesCustomShader = false;
+  };
+
+  static TranslatedMaterialState TranslateMaterialState(const Material& material);
+  static int ResolveIndexCount(const Mesh& mesh);
+
  private:
   struct Context;
 
@@ -44,9 +56,9 @@ class VulkanRenderBackend : public IRenderBackend {
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {
-    const Mesh* mesh = nullptr;
-    const Material* material = nullptr;
+    int indexCount = 0;
     Mat4 modelMatrix = Mat4::Identity();
+    TranslatedMaterialState material;
   };
 
   std::unique_ptr<Context> m_context;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -6,104 +6,109 @@
 
 #include "renderer/IRenderBackend.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-class VulkanRenderBackend : public IRenderBackend {
- public:
-  using OverlayRenderCallback = void (*)(void* userData, void* commandBufferHandle);
+  class VulkanRenderBackend : public IRenderBackend
+  {
+  public:
+    using OverlayRenderCallback = void (*)(void *userData, void *commandBufferHandle);
 
-  explicit VulkanRenderBackend(void* nativeWindowHandle);
-  ~VulkanRenderBackend() override;
+    explicit VulkanRenderBackend(void *nativeWindowHandle);
+    ~VulkanRenderBackend() override;
 
-  VulkanRenderBackend(const VulkanRenderBackend&) = delete;
-  VulkanRenderBackend& operator=(const VulkanRenderBackend&) = delete;
-  VulkanRenderBackend(VulkanRenderBackend&&) = delete;
-  VulkanRenderBackend& operator=(VulkanRenderBackend&&) = delete;
+    VulkanRenderBackend(const VulkanRenderBackend &) = delete;
+    VulkanRenderBackend &operator=(const VulkanRenderBackend &) = delete;
+    VulkanRenderBackend(VulkanRenderBackend &&) = delete;
+    VulkanRenderBackend &operator=(VulkanRenderBackend &&) = delete;
 
-  void BeginFrame(const RenderFrameConfig& frame) override;
-  void EndFrame() override;
-  void BeginPass(const RenderPassConfig& pass) override;
-  void EndPass() override;
+    void BeginFrame(const RenderFrameConfig &frame) override;
+    void EndFrame() override;
+    void BeginPass(const RenderPassConfig &pass) override;
+    void EndPass() override;
 
-  void DrawMesh(const MeshDrawCommand& command) override;
-  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override;
-  void DrawWireframe(const WireframeDrawCommand& command) override;
+    void DrawMesh(const MeshDrawCommand &command) override;
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &command) override;
+    void DrawWireframe(const WireframeDrawCommand &command) override;
 
-  RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
-  RenderBackendCapabilities GetCapabilities() const override;
-  int GetDrawCallCount() const override { return m_drawCalls; }
+    RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
+    RenderBackendCapabilities GetCapabilities() const override;
+    int GetDrawCallCount() const override { return m_drawCalls; }
 
-  bool IsInitialized() const;
-  bool HasOpaqueRasterScaffold() const;
-  bool HasOpaquePipelineCreationScaffold() const;
-  bool HasOpaqueShaderPipelineScaffold() const;
-  bool HasOpaqueGraphicsPipelineScaffold() const;
-  bool TryGetImGuiVulkanInitData(void** outInstance,
-                                 void** outPhysicalDevice,
-                                 void** outDevice,
-                                 uint32_t* outQueueFamily,
-                                 void** outQueue,
-                                 void** outRenderPass,
-                                 uint32_t* outImageCount) const;
-  void* GetActiveCommandBufferHandle() const;
-  void QueueOverlayRenderCallback(OverlayRenderCallback callback, void* userData);
-  const std::string& GetLastError() const { return m_lastError; }
+    bool IsInitialized() const;
+    bool HasOpaqueRasterScaffold() const;
+    bool HasOpaquePipelineCreationScaffold() const;
+    bool HasOpaqueShaderPipelineScaffold() const;
+    bool HasOpaqueGraphicsPipelineScaffold() const;
+    bool TryGetImGuiVulkanInitData(void **outInstance,
+                                   void **outPhysicalDevice,
+                                   void **outDevice,
+                                   uint32_t *outQueueFamily,
+                                   void **outQueue,
+                                   void **outRenderPass,
+                                   uint32_t *outImageCount) const;
+    void *GetActiveCommandBufferHandle() const;
+    void QueueOverlayRenderCallback(OverlayRenderCallback callback, void *userData);
+    const std::string &GetLastError() const { return m_lastError; }
 
-  struct TranslatedMaterialState {
-    Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
-    float roughness = 0.5f;
-    float metallic = 0.0f;
-    float uvScale = 1.0f;
-    bool usesAlbedoMap = false;
-    bool usesCustomShader = false;
+    struct TranslatedMaterialState
+    {
+      Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
+      float roughness = 0.5f;
+      float metallic = 0.0f;
+      float uvScale = 1.0f;
+      bool usesAlbedoMap = false;
+      bool usesCustomShader = false;
+    };
+
+    struct OpaquePipelineKey
+    {
+      bool usesAlbedoMap = false;
+      bool usesCustomShader = false;
+      bool writesDepth = true;
+      bool depthTestEnabled = true;
+    };
+
+    static TranslatedMaterialState TranslateMaterialState(const Material &material);
+    static int ResolveIndexCount(const Mesh &mesh);
+    static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState &materialState);
+
+  private:
+    struct Context;
+
+    bool Initialize(void *nativeWindowHandle);
+    void Shutdown();
+    bool RecreateSwapchain();
+    void DestroySwapchain();
+    bool CreateOpaqueRasterScaffold();
+    void DestroyOpaqueRasterScaffold();
+    bool CreateOpaquePipelineCreationScaffold();
+    void DestroyOpaquePipelineCreationScaffold();
+    bool CreateOpaqueShaderPipelineScaffold();
+    void DestroyOpaqueShaderPipelineScaffold();
+    bool CreateOpaqueGraphicsPipelineScaffold();
+    void DestroyOpaqueGraphicsPipelineScaffold();
+    bool RecordFrameCommands(const RenderFrameConfig &frame);
+
+    struct PendingOpaqueDraw
+    {
+      int indexCount = 0;
+      Mat4 modelMatrix = Mat4::Identity();
+      TranslatedMaterialState material;
+      OpaquePipelineKey pipelineKey;
+    };
+
+    std::unique_ptr<Context> m_context;
+    RenderFrameConfig m_activeFrame;
+    RenderView m_activeView;
+    std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
+    OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
+    void *m_pendingOverlayRenderUserData = nullptr;
+    std::string m_lastError;
+    RenderPassId m_activePassId = RenderPassId::OpaqueScene;
+    int m_drawCalls = 0;
+    bool m_frameActive = false;
+    bool m_passActive = false;
   };
 
-  struct OpaquePipelineKey {
-    bool usesAlbedoMap = false;
-    bool usesCustomShader = false;
-    bool writesDepth = true;
-    bool depthTestEnabled = true;
-  };
-
-  static TranslatedMaterialState TranslateMaterialState(const Material& material);
-  static int ResolveIndexCount(const Mesh& mesh);
-  static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState& materialState);
-
- private:
-  struct Context;
-
-  bool Initialize(void* nativeWindowHandle);
-  void Shutdown();
-  bool RecreateSwapchain();
-  void DestroySwapchain();
-  bool CreateOpaqueRasterScaffold();
-  void DestroyOpaqueRasterScaffold();
-  bool CreateOpaquePipelineCreationScaffold();
-  void DestroyOpaquePipelineCreationScaffold();
-  bool CreateOpaqueShaderPipelineScaffold();
-  void DestroyOpaqueShaderPipelineScaffold();
-  bool CreateOpaqueGraphicsPipelineScaffold();
-  void DestroyOpaqueGraphicsPipelineScaffold();
-  bool RecordFrameCommands(const RenderFrameConfig& frame);
-
-  struct PendingOpaqueDraw {
-    int indexCount = 0;
-    Mat4 modelMatrix = Mat4::Identity();
-    TranslatedMaterialState material;
-    OpaquePipelineKey pipelineKey;
-  };
-
-  std::unique_ptr<Context> m_context;
-  RenderFrameConfig m_activeFrame;
-  RenderView m_activeView;
-  std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
-  OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
-  void* m_pendingOverlayRenderUserData = nullptr;
-  std::string m_lastError;
-  RenderPassId m_activePassId = RenderPassId::OpaqueScene;
-  int m_drawCalls = 0;
-  bool m_frameActive = false;
-  bool m_passActive = false;
-};
-
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -10,6 +10,8 @@ namespace Monolith {
 
 class VulkanRenderBackend : public IRenderBackend {
  public:
+  using OverlayRenderCallback = void (*)(void* userData, void* commandBufferHandle);
+
   explicit VulkanRenderBackend(void* nativeWindowHandle);
   ~VulkanRenderBackend() override;
 
@@ -44,6 +46,7 @@ class VulkanRenderBackend : public IRenderBackend {
                                  void** outRenderPass,
                                  uint32_t* outImageCount) const;
   void* GetActiveCommandBufferHandle() const;
+  void QueueOverlayRenderCallback(OverlayRenderCallback callback, void* userData);
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -94,6 +97,8 @@ class VulkanRenderBackend : public IRenderBackend {
   RenderFrameConfig m_activeFrame;
   RenderView m_activeView;
   std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
+  OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
+  void* m_pendingOverlayRenderUserData = nullptr;
   std::string m_lastError;
   RenderPassId m_activePassId = RenderPassId::OpaqueScene;
   int m_drawCalls = 0;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -43,8 +43,16 @@ class VulkanRenderBackend : public IRenderBackend {
     bool usesCustomShader = false;
   };
 
+  struct OpaquePipelineKey {
+    bool usesAlbedoMap = false;
+    bool usesCustomShader = false;
+    bool writesDepth = true;
+    bool depthTestEnabled = true;
+  };
+
   static TranslatedMaterialState TranslateMaterialState(const Material& material);
   static int ResolveIndexCount(const Mesh& mesh);
+  static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState& materialState);
 
  private:
   struct Context;
@@ -59,6 +67,7 @@ class VulkanRenderBackend : public IRenderBackend {
     int indexCount = 0;
     Mat4 modelMatrix = Mat4::Identity();
     TranslatedMaterialState material;
+    OpaquePipelineKey pipelineKey;
   };
 
   std::unique_ptr<Context> m_context;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -32,6 +32,7 @@ class VulkanRenderBackend : public IRenderBackend {
   int GetDrawCallCount() const override { return m_drawCalls; }
 
   bool IsInitialized() const;
+  bool HasOpaqueRasterScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -61,6 +62,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void Shutdown();
   bool RecreateSwapchain();
   void DestroySwapchain();
+  bool CreateOpaqueRasterScaffold();
+  void DestroyOpaqueRasterScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -36,6 +36,14 @@ class VulkanRenderBackend : public IRenderBackend {
   bool HasOpaquePipelineCreationScaffold() const;
   bool HasOpaqueShaderPipelineScaffold() const;
   bool HasOpaqueGraphicsPipelineScaffold() const;
+  bool TryGetImGuiVulkanInitData(void** outInstance,
+                                 void** outPhysicalDevice,
+                                 void** outDevice,
+                                 uint32_t* outQueueFamily,
+                                 void** outQueue,
+                                 void** outRenderPass,
+                                 uint32_t* outImageCount) const;
+  void* GetActiveCommandBufferHandle() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -35,6 +35,7 @@ class VulkanRenderBackend : public IRenderBackend {
   bool HasOpaqueRasterScaffold() const;
   bool HasOpaquePipelineCreationScaffold() const;
   bool HasOpaqueShaderPipelineScaffold() const;
+  bool HasOpaqueGraphicsPipelineScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -70,6 +71,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroyOpaquePipelineCreationScaffold();
   bool CreateOpaqueShaderPipelineScaffold();
   void DestroyOpaqueShaderPipelineScaffold();
+  bool CreateOpaqueGraphicsPipelineScaffold();
+  void DestroyOpaqueGraphicsPipelineScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -34,6 +34,7 @@ class VulkanRenderBackend : public IRenderBackend {
   bool IsInitialized() const;
   bool HasOpaqueRasterScaffold() const;
   bool HasOpaquePipelineCreationScaffold() const;
+  bool HasOpaqueShaderPipelineScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -67,6 +68,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroyOpaqueRasterScaffold();
   bool CreateOpaquePipelineCreationScaffold();
   void DestroyOpaquePipelineCreationScaffold();
+  bool CreateOpaqueShaderPipelineScaffold();
+  void DestroyOpaqueShaderPipelineScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -77,6 +77,10 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
                       "capability-driven parity");
   RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
                       "editor viewport");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "Current Implemented Foundation State");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "backend-parity-validation-matrix.md");
   RequireFileContains(devDocsRoot / "backend-parity-validation-matrix.md", "Vulkan-enabled build");
 }
 

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -220,11 +220,16 @@ TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]"
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorImGuiBackend: only OpenGL is supported in the current integration slice",
+TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
           "[editor][imgui][backend]") {
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::OpenGL));
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Auto));
+
+#if defined(MONOLITH_HAS_VULKAN)
+    REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
+#else
     REQUIRE_FALSE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
+#endif
 }
 
 TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -36,21 +36,24 @@
 using namespace Monolith;
 using namespace Monolith::Editor;
 
-namespace {
-Monolith::Editor::SceneObject MakeObjectFromAssetForTest(const Monolith::Editor::SceneDocument&, const std::string& assetId) {
-    Monolith::Editor::SceneObject obj;
-    obj.id = "generated";
-    obj.type = Monolith::Editor::SceneObjectType::Prop;
-    obj.assetId = assetId;
-    return obj;
-}
+namespace
+{
+    Monolith::Editor::SceneObject MakeObjectFromAssetForTest(const Monolith::Editor::SceneDocument &, const std::string &assetId)
+    {
+        Monolith::Editor::SceneObject obj;
+        obj.id = "generated";
+        obj.type = Monolith::Editor::SceneObjectType::Prop;
+        obj.assetId = assetId;
+        return obj;
+    }
 
-Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::SceneDocument& doc, const Monolith::Editor::SceneObject& src) {
-    Monolith::Editor::SceneObject clone = src;
-    clone.id = "copy_" + std::to_string(doc.objects.size());
-    clone.props.erase("_eid");
-    return clone;
-}
+    Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::SceneDocument &doc, const Monolith::Editor::SceneObject &src)
+    {
+        Monolith::Editor::SceneObject clone = src;
+        clone.id = "copy_" + std::to_string(doc.objects.size());
+        clone.props.erase("_eid");
+        return clone;
+    }
 
 }
 using Catch::Approx;
@@ -59,20 +62,24 @@ using Catch::Approx;
 // Helpers
 // ---------------------------------------------------------------------------
 
-static std::string TmpPath(const std::string& name) {
+static std::string TmpPath(const std::string &name)
+{
     return (std::filesystem::temp_directory_path() / name).string();
 }
 
-static std::filesystem::path RepoRootFromTestSource() {
+static std::filesystem::path RepoRootFromTestSource()
+{
     return std::filesystem::path(__FILE__).parent_path().parent_path().lexically_normal();
 }
 
-static void WriteFile(const std::string& path, const std::string& content) {
+static void WriteFile(const std::string &path, const std::string &content)
+{
     std::ofstream f(path);
     f << content;
 }
 
-static std::filesystem::path NormalizePathForComparison(const std::filesystem::path& path) {
+static std::filesystem::path NormalizePathForComparison(const std::filesystem::path &path)
+{
     if (path.empty())
         return path;
     std::error_code ec;
@@ -81,7 +88,8 @@ static std::filesystem::path NormalizePathForComparison(const std::filesystem::p
         return normalized;
     ec.clear();
     const std::filesystem::path parent = path.parent_path();
-    if (!parent.empty()) {
+    if (!parent.empty())
+    {
         const std::filesystem::path normalizedParent = std::filesystem::weakly_canonical(parent, ec);
         if (!ec)
             return (normalizedParent / path.filename()).lexically_normal();
@@ -89,30 +97,35 @@ static std::filesystem::path NormalizePathForComparison(const std::filesystem::p
     return path.lexically_normal();
 }
 
-struct ProjectPathGuard {
+struct ProjectPathGuard
+{
     std::filesystem::path previousRoot;
 
-    explicit ProjectPathGuard(const std::filesystem::path& nextRoot)
-        : previousRoot(Monolith::ProjectPath::Root()) {
+    explicit ProjectPathGuard(const std::filesystem::path &nextRoot)
+        : previousRoot(Monolith::ProjectPath::Root())
+    {
         Monolith::ProjectPath::Init(nextRoot);
     }
 
-    ~ProjectPathGuard() {
+    ~ProjectPathGuard()
+    {
         Monolith::ProjectPath::Init(previousRoot);
     }
 };
 
-struct HomeDirGuard {
+struct HomeDirGuard
+{
     std::string previousUserProfile;
     std::string previousHomeDrive;
     std::string previousHomePath;
     std::string previousHome;
 
-    static std::string ReadEnv(const char* name) {
+    static std::string ReadEnv(const char *name)
+    {
         if (!name || !*name)
             return {};
 #ifdef _WIN32
-        char* value = nullptr;
+        char *value = nullptr;
         size_t len = 0;
         if (_dupenv_s(&value, &len, name) != 0 || !value)
             return {};
@@ -120,16 +133,17 @@ struct HomeDirGuard {
         free(value);
         return out;
 #else
-        const char* value = std::getenv(name);
+        const char *value = std::getenv(name);
         return value ? std::string(value) : std::string();
 #endif
     }
 
-    explicit HomeDirGuard(const std::filesystem::path& nextHome)
+    explicit HomeDirGuard(const std::filesystem::path &nextHome)
         : previousUserProfile(ReadEnv("USERPROFILE")),
           previousHomeDrive(ReadEnv("HOMEDRIVE")),
           previousHomePath(ReadEnv("HOMEPATH")),
-          previousHome(ReadEnv("HOME")) {
+          previousHome(ReadEnv("HOME"))
+    {
 #ifdef _WIN32
         _putenv_s("USERPROFILE", nextHome.string().c_str());
         _putenv_s("HOMEDRIVE", "");
@@ -139,7 +153,8 @@ struct HomeDirGuard {
 #endif
     }
 
-    ~HomeDirGuard() {
+    ~HomeDirGuard()
+    {
 #ifdef _WIN32
         _putenv_s("USERPROFILE", previousUserProfile.c_str());
         _putenv_s("HOMEDRIVE", previousHomeDrive.c_str());
@@ -153,12 +168,14 @@ struct HomeDirGuard {
     }
 };
 
-struct ImGuiContextGuard {
-    ImGuiContextGuard() {
+struct ImGuiContextGuard
+{
+    ImGuiContextGuard()
+    {
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
-        ImGuiIO& io = ImGui::GetIO();
-        unsigned char* fontPixels = nullptr;
+        ImGuiIO &io = ImGui::GetIO();
+        unsigned char *fontPixels = nullptr;
         int fontWidth = 0;
         int fontHeight = 0;
         io.Fonts->GetTexDataAsRGBA32(&fontPixels, &fontWidth, &fontHeight);
@@ -168,18 +185,20 @@ struct ImGuiContextGuard {
         io.MouseDown[0] = false;
     }
 
-    ~ImGuiContextGuard() {
+    ~ImGuiContextGuard()
+    {
         ImGui::DestroyContext();
     }
 };
 
-static void SeedExternalAssetDragPayload(const char* assetId) {
+static void SeedExternalAssetDragPayload(const char *assetId)
+{
     REQUIRE(assetId != nullptr);
-    ImGuiContext& g = *ImGui::GetCurrentContext();
-    ImGuiPayload& payload = g.DragDropPayload;
+    ImGuiContext &g = *ImGui::GetCurrentContext();
+    ImGuiPayload &payload = g.DragDropPayload;
     payload.Clear();
     payload.SourceId = 1;
-    payload.Data = const_cast<char*>(assetId);
+    payload.Data = const_cast<char *>(assetId);
     payload.DataSize = static_cast<int>(std::strlen(assetId)) + 1;
     payload.DataFrameCount = g.FrameCount;
     payload.Delivery = false;
@@ -200,20 +219,23 @@ static void SeedExternalAssetDragPayload(const char* assetId) {
 // EditorSchema
 // ===========================================================================
 
-TEST_CASE("EditorSchema: missing file is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: missing file is silently ignored", "[editor][schema]")
+{
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile("/nonexistent/path/schema.json"));
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorSchema: empty JSON is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: empty JSON is silently ignored", "[editor][schema]")
+{
     WriteFile(TmpPath("schema_empty.json"), "{}");
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile(TmpPath("schema_empty.json")));
     REQUIRE(schema.GetSchema(SceneObjectType::Panel) == nullptr);
 }
 
-TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]")
+{
     WriteFile(TmpPath("schema_bad.json"), "{ this is not valid json !!!}");
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile(TmpPath("schema_bad.json")));
@@ -221,7 +243,8 @@ TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]"
 }
 
 TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
-          "[editor][imgui][backend]") {
+          "[editor][imgui][backend]")
+{
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::OpenGL));
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Auto));
 
@@ -232,7 +255,8 @@ TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
 #endif
 }
 
-TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -253,7 +277,7 @@ TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
@@ -267,7 +291,8 @@ TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
     REQUIRE(ts->fields[0].options[3] == "pyramid");
 }
 
-TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[editor][schema]") {
+TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -282,7 +307,7 @@ TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[ed
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop_mesh_legacy.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
@@ -290,7 +315,8 @@ TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[ed
     REQUIRE_FALSE(ts->fields[0].options.empty());
 }
 
-TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schema]") {
+TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -306,13 +332,14 @@ TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schem
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop_islight_deprecated.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
 }
 
-TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Light": {
@@ -327,14 +354,15 @@ TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_light.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Light);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Light);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Float);
     REQUIRE(ts->fields[0].minVal == Approx(0.0f));
     REQUIRE(ts->fields[0].maxVal == Approx(10.0f));
 }
 
-TEST_CASE("EditorSchema: loads bool field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads bool field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -349,12 +377,13 @@ TEST_CASE("EditorSchema: loads bool field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_bool.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Bool);
 }
 
-TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Panel": {
@@ -375,7 +404,7 @@ TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_enum.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Panel);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Panel);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Enum);
     REQUIRE(ts->fields[0].options.size() == 3);
@@ -384,7 +413,8 @@ TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
     REQUIRE(ts->fields[0].options[2] == "stone");
 }
 
-TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Light": {
@@ -399,12 +429,13 @@ TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_color.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Light);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Light);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Color3);
 }
 
-TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[editor][schema]") {
+TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -422,7 +453,8 @@ TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[edi
     REQUIRE(schema.GetSchema(SceneObjectType::Panel) == nullptr);
 }
 
-TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -454,7 +486,8 @@ TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]") {
     REQUIRE(schema.GetSchema(SceneObjectType::Panel)->fields.size() == 1);
 }
 
-TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]") {
+TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {}
@@ -468,7 +501,8 @@ TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]") {
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -509,14 +543,14 @@ TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor]
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_components.json"));
 
-    const TypeSchema* propSchema = schema.GetSchemaByName("Prop");
+    const TypeSchema *propSchema = schema.GetSchemaByName("Prop");
     REQUIRE(propSchema != nullptr);
     REQUIRE(propSchema->name == "Prop");
     REQUIRE(propSchema->label == "Prop");
     REQUIRE(propSchema->appliesTo.size() == 1);
     REQUIRE(propSchema->appliesTo[0] == "Prop");
 
-    const ComponentSchema* lightSchema = schema.GetComponentSchema("light");
+    const ComponentSchema *lightSchema = schema.GetComponentSchema("light");
     REQUIRE(lightSchema != nullptr);
     REQUIRE(lightSchema->name == "light");
     REQUIRE(lightSchema->label == "Light");
@@ -532,14 +566,15 @@ TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor]
     REQUIRE(lightSchema->fields[1].options.size() == 2);
 }
 
-TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]") {
+TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]")
+{
     const std::filesystem::path schemaPath = RepoRootFromTestSource() / "assets" / "editor_schema.json";
     REQUIRE(std::filesystem::exists(schemaPath));
 
     EditorSchema schema;
     schema.LoadFromFile(schemaPath.string());
 
-    const ComponentSchema* rigidbody = schema.GetComponentSchema("rigidbody");
+    const ComponentSchema *rigidbody = schema.GetComponentSchema("rigidbody");
     REQUIRE(rigidbody != nullptr);
     REQUIRE(rigidbody->label == "RigidBody");
     REQUIRE(rigidbody->appliesTo.size() == 1);
@@ -549,7 +584,7 @@ TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "
     REQUIRE(rigidbody->fields[0].hasMin);
     REQUIRE(rigidbody->fields[0].minVal == Approx(0.0f));
 
-    const ComponentSchema* script = schema.GetComponentSchema("script");
+    const ComponentSchema *script = schema.GetComponentSchema("script");
     REQUIRE(script != nullptr);
     REQUIRE(script->fields.size() == 1);
     REQUIRE(script->fields[0].key == "behaviorTag");
@@ -560,20 +595,23 @@ TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "
 // SceneSerializer
 // ===========================================================================
 
-TEST_CASE("SceneSerializer: LoadFromFile throws on missing file", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: LoadFromFile throws on missing file", "[editor][serializer]")
+{
     REQUIRE_THROWS_AS(
         SceneSerializer::LoadFromFile("/nonexistent/scene.json"),
         std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: LoadFromFile throws on invalid JSON", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: LoadFromFile throws on invalid JSON", "[editor][serializer]")
+{
     WriteFile(TmpPath("bad_scene.json"), "{ not json!!! }");
     REQUIRE_THROWS_AS(
         SceneSerializer::LoadFromFile(TmpPath("bad_scene.json")),
         std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]")
+{
     SceneDocument doc;
     doc.filePath = "test.json";
 
@@ -586,7 +624,8 @@ TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]") {
     REQUIRE(loaded.assets.empty());
 }
 
-TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -603,7 +642,7 @@ TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serialize
     SceneDocument loaded = SceneSerializer::LoadFromFile(path);
 
     REQUIRE(loaded.objects.size() == 1);
-    const auto& o = loaded.objects[0];
+    const auto &o = loaded.objects[0];
     REQUIRE(o.id == "panel_001");
     REQUIRE(o.type == SceneObjectType::Panel);
     REQUIRE(o.position.x == Approx(1.0f));
@@ -614,7 +653,8 @@ TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serialize
     REQUIRE(o.props.at("texture") == "wood.png");
 }
 
-TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject prop;
@@ -635,15 +675,25 @@ TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializ
 
     REQUIRE(loaded.objects.size() == 2);
     bool foundProp = false, foundLight = false;
-    for (const auto& o : loaded.objects) {
-        if (o.id == "prop_a") { foundProp = true; REQUIRE(o.type == SceneObjectType::Prop); }
-        if (o.id == "light_1") { foundLight = true; REQUIRE(o.type == SceneObjectType::Light); }
+    for (const auto &o : loaded.objects)
+    {
+        if (o.id == "prop_a")
+        {
+            foundProp = true;
+            REQUIRE(o.type == SceneObjectType::Prop);
+        }
+        if (o.id == "light_1")
+        {
+            foundLight = true;
+            REQUIRE(o.type == SceneObjectType::Light);
+        }
     }
     REQUIRE(foundProp);
     REQUIRE(foundLight);
 }
 
-TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]")
+{
     SceneDocument doc;
 
     AssetDef asset;
@@ -673,7 +723,8 @@ TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]") 
 }
 
 TEST_CASE("SceneSerializer: legacy asset entries gain guid and display name on load",
-          "[editor][serializer]") {
+          "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_asset_identity_scene.json");
     const std::string json = R"({
       "version": 1,
@@ -695,7 +746,8 @@ TEST_CASE("SceneSerializer: legacy asset entries gain guid and display name on l
 }
 
 TEST_CASE("AssetMetadata: EnsureAssetMetadataForDocument writes sidecar files",
-          "[editor][asset-metadata]") {
+          "[editor][asset-metadata]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_metadata_case";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -723,14 +775,15 @@ TEST_CASE("AssetMetadata: EnsureAssetMetadataForDocument writes sidecar files",
 }
 
 TEST_CASE("AssetImporterRegistry: built-in importers resolve by extension and id",
-          "[editor][asset-import]") {
+          "[editor][asset-import]")
+{
     AssetImporterRegistry registry;
-    const AssetImporter* objImporter = registry.FindByExtension("mesh.OBJ");
+    const AssetImporter *objImporter = registry.FindByExtension("mesh.OBJ");
     REQUIRE(objImporter != nullptr);
     REQUIRE(std::string(objImporter->ImporterId()) == "builtin.obj_mesh");
 
-    const AssetImporter* pngImporter = registry.FindByExtension("albedo.png");
-    const AssetImporter* jpgImporter = registry.FindByExtension("albedo.jpg");
+    const AssetImporter *pngImporter = registry.FindByExtension("albedo.png");
+    const AssetImporter *jpgImporter = registry.FindByExtension("albedo.jpg");
     REQUIRE(pngImporter != nullptr);
     REQUIRE(jpgImporter != nullptr);
     REQUIRE(std::string(pngImporter->ImporterId()) == "builtin.texture_copy");
@@ -741,7 +794,8 @@ TEST_CASE("AssetImporterRegistry: built-in importers resolve by extension and id
 }
 
 TEST_CASE("AssetImportService: imports OBJ and persists importer metadata",
-          "[editor][asset-import]") {
+          "[editor][asset-import]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_import_obj";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -775,7 +829,8 @@ TEST_CASE("AssetImportService: imports OBJ and persists importer metadata",
 }
 
 TEST_CASE("AssetImportService: unsupported source yields structured diagnostics",
-          "[editor][asset-import][diagnostics]") {
+          "[editor][asset-import][diagnostics]")
+{
     AssetImportService service;
     AssetImportResult result =
         service.ImportAssetFromSource("C:/tmp/unsupported.txt", "broken", "guid_broken", "Broken");
@@ -788,7 +843,8 @@ TEST_CASE("AssetImportService: unsupported source yields structured diagnostics"
 }
 
 TEST_CASE("AssetImportService: reimport propagation follows deterministic topological order",
-          "[editor][asset-import][reimport]") {
+          "[editor][asset-import][reimport]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_reimport_graph";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -796,12 +852,15 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
     WriteFile((root / "CMakePresets.json").string(), "{}");
     ProjectPathGuard guard(root);
 
-    auto writeObj = [](const std::filesystem::path& path, float xOffset) {
+    auto writeObj = [](const std::filesystem::path &path, float xOffset)
+    {
         WriteFile(path.string(),
                   "v " + std::to_string(xOffset) + " 0 0\n"
-                  "v " + std::to_string(xOffset) + " 1 0\n"
-                  "v " + std::to_string(xOffset + 1.0f) + " 0 0\n"
-                  "f 1 2 3\n");
+                                                   "v " +
+                      std::to_string(xOffset) + " 1 0\n"
+                                                "v " +
+                      std::to_string(xOffset + 1.0f) + " 0 0\n"
+                                                       "f 1 2 3\n");
     };
 
     writeObj(root / "root.obj", 0.0f);
@@ -811,19 +870,21 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
 
     AssetImportService service;
     SceneDocument doc;
-    for (const auto& spec : std::vector<std::tuple<std::string, std::string, std::string>>{
+    for (const auto &spec : std::vector<std::tuple<std::string, std::string, std::string>>{
              {"root", "guid_root", "root.obj"},
              {"alpha", "guid_alpha", "alpha.obj"},
              {"beta", "guid_beta", "beta.obj"},
              {"gamma", "guid_gamma", "gamma.obj"},
-         }) {
+         })
+    {
         AssetImportResult result = service.ImportAssetFromSource(
             (root / std::get<2>(spec)).string(), std::get<0>(spec), std::get<1>(spec), std::get<0>(spec));
         REQUIRE(result.ok);
         doc.assets[std::get<0>(spec)] = result.asset;
     }
 
-    auto addDependency = [](const std::string& guid, const std::string& dependsOnGuid) {
+    auto addDependency = [](const std::string &guid, const std::string &dependsOnGuid)
+    {
         AssetMetadata metadata;
         std::string error;
         REQUIRE(LoadAssetMetadata(guid, &metadata, &error));
@@ -848,7 +909,8 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
 }
 
 TEST_CASE("AssetImportService: cyclic dependencies fail reimport with actionable error",
-          "[editor][asset-import][reimport]") {
+          "[editor][asset-import][reimport]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_reimport_cycle";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -890,7 +952,8 @@ TEST_CASE("AssetImportService: cyclic dependencies fail reimport with actionable
     REQUIRE(aReloaded.diagnostics[0].code == "asset.reimport.dependency_cycle");
 }
 
-TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "prop.obj";
@@ -911,7 +974,8 @@ TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]")
     REQUIRE(loaded.assets.at("tex_asset").albedoMap == "assets/models/custom_Albedo.png");
 }
 
-TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][serializer]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "x.obj";
@@ -926,7 +990,8 @@ TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][seri
     REQUIRE(saved.find("albedoMap") == std::string::npos);
 }
 
-TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[editor][serializer]")
+{
     SceneDocument doc;
 
     AssetDef asset;
@@ -957,7 +1022,8 @@ TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[edi
     REQUIRE(loaded.objects[0].assetId == "crate");
 }
 
-TEST_CASE("SceneSerializer: inline props survive when object has no asset reference", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: inline props survive when object has no asset reference", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -977,7 +1043,8 @@ TEST_CASE("SceneSerializer: inline props survive when object has no asset refere
     REQUIRE(loaded.objects[0].props.at("renderScale") == "1.2500,1.2500,1.2500");
 }
 
-TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -997,7 +1064,8 @@ TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][ser
     REQUIRE(loaded.objects[0].prefabInstance->sourcePath == "assets/prefabs/crate_prefab.horo");
 }
 
-TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[editor]") {
+TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[editor]")
+{
     SceneDocument doc;
     SceneObject src;
     src.id = "prop_001";
@@ -1014,7 +1082,8 @@ TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[ed
     REQUIRE(clone.props.at("mesh") == "crate.obj");
 }
 
-TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[editor]") {
+TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[editor]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "torch.obj";
@@ -1026,7 +1095,8 @@ TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[edit
     REQUIRE(created.assetId == "torch");
 }
 
-TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]") {
+TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]")
+{
     SceneObject obj;
     obj.id = "prop_007";
     obj.type = SceneObjectType::Prop;
@@ -1038,7 +1108,8 @@ TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]") {
     REQUIRE_FALSE(ObjectMatchesQuickOpenQuery(obj, "torch"));
 }
 
-TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[editor]") {
+TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[editor]")
+{
     ShortcutRow row{"Editor", "Quick open", "Ctrl/Cmd + P"};
     REQUIRE(MatchesShortcutQuery(row, "editor"));
     REQUIRE(MatchesShortcutQuery(row, "quick"));
@@ -1046,7 +1117,8 @@ TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[
     REQUIRE_FALSE(MatchesShortcutQuery(row, "delete"));
 }
 
-TEST_CASE("Editor helpers: command palette query matches command and shortcut", "[editor]") {
+TEST_CASE("Editor helpers: command palette query matches command and shortcut", "[editor]")
+{
     CommandPaletteRow row{"save_scene", "Save Scene", "Toolbar"};
     REQUIRE(MatchesCommandPaletteQuery(row, "save"));
     REQUIRE(MatchesCommandPaletteQuery(row, "toolbar"));
@@ -1054,14 +1126,16 @@ TEST_CASE("Editor helpers: command palette query matches command and shortcut", 
     REQUIRE_FALSE(MatchesCommandPaletteQuery(row, "delete"));
 }
 
-TEST_CASE("Editor helpers: object type labels are stable", "[editor]") {
+TEST_CASE("Editor helpers: object type labels are stable", "[editor]")
+{
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Prop)) == "prop");
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Light)) == "light");
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Panel)) == "board");
     REQUIRE(std::string(ObjectTypeLabel(static_cast<SceneObjectType>(999))) == "unknown");
 }
 
-TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]") {
+TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]")
+{
     ShortcutRow row{"Editor", "Quick open", "Ctrl/Cmd + P"};
     REQUIRE(MatchesShortcutQuery(row, ""));
     REQUIRE(ContainsCaseInsensitive("Any Text", ""));
@@ -1078,7 +1152,8 @@ TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]
     REQUIRE(AssetMatchesQuickOpenQuery("crate_asset", asset, ""));
 }
 
-TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor]") {
+TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor]")
+{
     AssetDef asset;
     asset.mesh = "assets/models/torch.obj";
     REQUIRE(AssetMatchesQuickOpenQuery("torch_asset", asset, "torch"));
@@ -1086,21 +1161,23 @@ TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor
     REQUIRE_FALSE(AssetMatchesQuickOpenQuery("torch_asset", asset, "barrel"));
 }
 
-TEST_CASE("Editor helpers: filtered list state handles empty and no-match cases", "[editor]") {
+TEST_CASE("Editor helpers: filtered list state handles empty and no-match cases", "[editor]")
+{
     REQUIRE(EvaluateFilteredListState(3, 1, "") == FilteredListState::None);
     REQUIRE(EvaluateFilteredListState(0, 0, "") == FilteredListState::EmptyData);
     REQUIRE(EvaluateFilteredListState(4, 0, "torch") == FilteredListState::NoMatches);
     REQUIRE(EvaluateFilteredListState(4, 0, "") == FilteredListState::None);
 }
 
-TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]") {
+TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]")
+{
     const auto rows = GetEditorShortcuts();
     REQUIRE_FALSE(rows.empty());
 
-    auto hasCommandWithKeys = [&](const char* command, const char* keys) {
-        return std::any_of(rows.begin(), rows.end(), [&](const ShortcutRow& row) {
-            return std::string(row.command) == command && std::string(row.keys) == keys;
-        });
+    auto hasCommandWithKeys = [&](const char *command, const char *keys)
+    {
+        return std::any_of(rows.begin(), rows.end(), [&](const ShortcutRow &row)
+                           { return std::string(row.command) == command && std::string(row.keys) == keys; });
     };
 
     REQUIRE(hasCommandWithKeys("Run or stop game in viewport", "Toolbar: Play / Stop"));
@@ -1111,24 +1188,28 @@ TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]"
     REQUIRE(hasCommandWithKeys("Redo last scene change", "Ctrl/Cmd + Shift + Z / Ctrl+Y"));
 }
 
-TEST_CASE("Editor helpers: shortcut table commands are unique", "[editor]") {
+TEST_CASE("Editor helpers: shortcut table commands are unique", "[editor]")
+{
     const auto rows = GetEditorShortcuts();
     std::unordered_set<std::string> commandSet;
 
-    for (const auto& row : rows) {
+    for (const auto &row : rows)
+    {
         const auto [_, inserted] = commandSet.insert(row.command);
         REQUIRE(inserted);
     }
 }
 
-TEST_CASE("Editor asset import: validates obj extension case-insensitively", "[editor]") {
+TEST_CASE("Editor asset import: validates obj extension case-insensitively", "[editor]")
+{
     REQUIRE(IsObjFilePath("/tmp/mesh.obj"));
     REQUIRE(IsObjFilePath("/tmp/MESH.OBJ"));
     REQUIRE_FALSE(IsObjFilePath("/tmp/mesh.fbx"));
     REQUIRE_FALSE(IsObjFilePath(""));
 }
 
-TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[editor]") {
+TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[editor]")
+{
     const std::string path = "/Users/bodur/Downloads/torch_model.obj";
     REQUIRE(AssetIdFromImportedPath(path) == "torch_model");
     REQUIRE(MeshTagFromImportedPath(path) == "assets/models/torch_model.obj");
@@ -1137,7 +1218,8 @@ TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[edit
     REQUIRE(MeshTagFromImportedPath("").empty());
 }
 
-TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[editor][mcp][filesystem]") {
+TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[editor][mcp][filesystem]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_delete_asset_managed";
@@ -1171,7 +1253,8 @@ TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[ed
 }
 
 TEST_CASE("Editor MCP delete_asset keeps manual asset files and removes only registry entry",
-          "[editor][mcp][filesystem]") {
+          "[editor][mcp][filesystem]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_delete_asset_manual";
@@ -1195,7 +1278,8 @@ TEST_CASE("Editor MCP delete_asset keeps manual asset files and removes only reg
     REQUIRE(fs::exists(projectRoot / "assets" / "models" / "crate.obj"));
 }
 
-TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "[editor][mcp][assets]") {
+TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "[editor][mcp][assets]")
+{
     SceneDocument doc;
     doc.assets["crate"] = AssetDef{"assets/models/crate/crate.obj", "1.0000,2.0000,3.0000", ""};
 
@@ -1226,7 +1310,7 @@ TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "
     REQUIRE(rootResult.data["created"]["position"][1].get<float>() == Approx(5.0f));
     REQUIRE(rootResult.data["created"]["position"][2].get<float>() == Approx(6.0f));
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 3);
     REQUIRE(updated.objects[1].props.at("parentId") == "parent_panel");
     REQUIRE(updated.objects[2].position.x == Approx(4.0f));
@@ -1234,7 +1318,8 @@ TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "
     REQUIRE(updated.objects[2].position.z == Approx(6.0f));
 }
 
-TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor][mcp][selection]") {
+TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor][mcp][selection]")
+{
     SceneDocument doc;
 
     SceneObject first;
@@ -1265,18 +1350,18 @@ TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor]
     REQUIRE(result.data["duplicates"].is_array());
     REQUIRE(result.data["duplicates"].size() == 2);
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 5);
     REQUIRE(updated.dirty);
 
-    const SceneObject& panelClone = updated.objects[3];
+    const SceneObject &panelClone = updated.objects[3];
     REQUIRE(panelClone.id != "panel_a");
     REQUIRE(panelClone.type == SceneObjectType::Panel);
     REQUIRE(panelClone.position.x == Approx(2.0f));
     REQUIRE(panelClone.position.y == Approx(0.0f));
     REQUIRE(panelClone.position.z == Approx(3.0f));
 
-    const SceneObject& lightClone = updated.objects[4];
+    const SceneObject &lightClone = updated.objects[4];
     REQUIRE(lightClone.id != "light_c");
     REQUIRE(lightClone.type == SceneObjectType::Light);
     REQUIRE(lightClone.position.x == Approx(6.0f));
@@ -1289,7 +1374,8 @@ TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor]
     REQUIRE(selectedIds[1] == lightClone.id);
 }
 
-TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[editor][mcp][selection]") {
+TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[editor][mcp][selection]")
+{
     SceneDocument doc;
 
     SceneObject source;
@@ -1307,11 +1393,12 @@ TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[edito
     REQUIRE(result.ok);
     REQUIRE(result.data["duplicates"].size() == 3);
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 4);
 
-    for (size_t i = 1; i < updated.objects.size(); ++i) {
-        const SceneObject& clone = updated.objects[i];
+    for (size_t i = 1; i < updated.objects.size(); ++i)
+    {
+        const SceneObject &clone = updated.objects[i];
         const float expectedOffset = static_cast<float>(i);
         REQUIRE(clone.id != "camera_main");
         REQUIRE(clone.position.x == Approx(10.0f + expectedOffset));
@@ -1326,7 +1413,8 @@ TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[edito
     REQUIRE(selectedIds[2] == updated.objects[3].id);
 }
 
-TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor][mcp][history]")
+{
     EditorLayer editor;
     editor.LoadDocument(SceneDocument{});
 
@@ -1354,7 +1442,8 @@ TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor]
     REQUIRE(editor.GetSelectedObjectIds() == std::vector<std::string>{"panel_created"});
 }
 
-TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state", "[editor][mcp][history]")
+{
     SceneDocument doc;
 
     SceneObject first;
@@ -1392,7 +1481,8 @@ TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state"
     REQUIRE(editor.GetSelectedObjectIds() == duplicatedSelection);
 }
 
-TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][mcp][history]")
+{
     SceneDocument doc;
     doc.sceneId = "forest";
     doc.sceneName = "Forest";
@@ -1422,7 +1512,8 @@ TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][m
     REQUIRE_FALSE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][mcp][history]")
+{
     SceneDocument doc;
     doc.assets["crate"] = AssetDef{"assets/models/crate.obj", "1,1,1", ""};
 
@@ -1446,7 +1537,8 @@ TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][m
     REQUIRE_FALSE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instance", "[editor][mcp][prefab]") {
+TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instance", "[editor][mcp][prefab]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_create_prefab";
@@ -1480,14 +1572,15 @@ TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instan
     REQUIRE(prefabDoc.objects[0].id == "crate_prop");
     REQUIRE_FALSE(prefabDoc.objects[0].prefabInstance.has_value());
 
-    const SceneObject& updated = editor.GetDocument().objects[0];
+    const SceneObject &updated = editor.GetDocument().objects[0];
     REQUIRE(updated.prefabInstance.has_value());
     REQUIRE(updated.prefabInstance->sourcePath == result.data["prefabPath"].get<std::string>());
     REQUIRE(updated.prefabInstance->prefabId == prefabPath.stem().string());
     REQUIRE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "[editor][prefab][runtime]") {
+TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "[editor][prefab][runtime]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_runtime_prefab_instance";
@@ -1529,7 +1622,7 @@ TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "
     REQUIRE(runtime.definition.rooms.size() == 1);
     REQUIRE(runtime.definition.rooms[0].props.size() == 1);
 
-    const RuntimeSceneProp& prop = runtime.definition.rooms[0].props[0];
+    const RuntimeSceneProp &prop = runtime.definition.rooms[0].props[0];
     REQUIRE(prop.id == "crate_instance");
     REQUIRE(prop.meshTag == "assets/models/crate.obj");
     REQUIRE(prop.position.x == Approx(8.0f));
@@ -1539,14 +1632,16 @@ TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "
     REQUIRE(prop.scale.z == Approx(4.0f));
 }
 
-TEST_CASE("Editor UI logic: hotkey popup triggers only on valid rising edge", "[editor]") {
+TEST_CASE("Editor UI logic: hotkey popup triggers only on valid rising edge", "[editor]")
+{
     REQUIRE(ShouldToggleHelpPopup(true, false, false, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, true, false, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, true, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, false, true));
 }
 
-TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "[editor]") {
+TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "[editor]")
+{
     REQUIRE(ShouldOpenQuickOpen(true, false, false, false, false));
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, true, false, false));
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, false, true, false));
@@ -1554,14 +1649,15 @@ TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, true, false, false, false));
 }
 
-TEST_CASE("Editor helpers: command palette table includes scene actions", "[editor]") {
+TEST_CASE("Editor helpers: command palette table includes scene actions", "[editor]")
+{
     const auto rows = GetEditorCommands();
     REQUIRE_FALSE(rows.empty());
 
-    auto hasCommand = [&](const char* id, const char* command) {
-        return std::any_of(rows.begin(), rows.end(), [&](const CommandPaletteRow& row) {
-            return std::string(row.id) == id && std::string(row.command) == command;
-        });
+    auto hasCommand = [&](const char *id, const char *command)
+    {
+        return std::any_of(rows.begin(), rows.end(), [&](const CommandPaletteRow &row)
+                           { return std::string(row.id) == id && std::string(row.command) == command; });
     };
 
     REQUIRE(hasCommand("new_scene", "New Scene"));
@@ -1572,14 +1668,16 @@ TEST_CASE("Editor helpers: command palette table includes scene actions", "[edit
     REQUIRE(hasCommand("redo", "Redo"));
 }
 
-TEST_CASE("Editor UI logic: command palette shares quick-open gating", "[editor]") {
+TEST_CASE("Editor UI logic: command palette shares quick-open gating", "[editor]")
+{
     REQUIRE(ShouldOpenCommandPalette(true, false, false, false, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, false, true, false, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, false, false, true, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, true, false, false, false));
 }
 
-TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]") {
+TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]")
+{
     REQUIRE(ShouldCopySelectionRef(true, false, false, false, true));
     REQUIRE_FALSE(ShouldCopySelectionRef(true, false, false, false, false));
     REQUIRE_FALSE(ShouldCopySelectionRef(true, true, false, false, true));
@@ -1588,7 +1686,8 @@ TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]")
     REQUIRE_FALSE(ShouldRequestDeleteSelection(true, false, false));
 }
 
-TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[editor]") {
+TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[editor]")
+{
     REQUIRE(ShouldHandleEditorEscape(true, false, false, false, false));
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, true, false, false, false));
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, false, true, false, false));
@@ -1596,18 +1695,21 @@ TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[e
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, false, false, false, true));
 }
 
-TEST_CASE("Editor UI logic: exit decision reflects unsaved state", "[editor]") {
+TEST_CASE("Editor UI logic: exit decision reflects unsaved state", "[editor]")
+{
     REQUIRE(ResolveEditorExitDecision(false) == EditorExitDecision::ExitImmediately);
     REQUIRE(ResolveEditorExitDecision(true) == EditorExitDecision::PromptUnsavedConfirm);
 }
 
-TEST_CASE("Editor UI logic: close finalization waits for pending reload", "[editor]") {
+TEST_CASE("Editor UI logic: close finalization waits for pending reload", "[editor]")
+{
     REQUIRE_FALSE(ShouldFinalizeEditorClose(false, false));
     REQUIRE_FALSE(ShouldFinalizeEditorClose(true, true));
     REQUIRE(ShouldFinalizeEditorClose(true, false));
 }
 
-TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[editor]") {
+TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[editor]")
+{
     EditorStatusText status = BuildEditorStatusText(EditorStatusSnapshot{-2, true, false, true});
     REQUIRE(status.selectionCount == 0);
     REQUIRE(std::string(status.dirtyText) == "yes");
@@ -1621,7 +1723,8 @@ TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[edito
     REQUIRE(std::string(status.reloadText) == "idle");
 }
 
-TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", "[editor]") {
+TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", "[editor]")
+{
     REQUIRE(CanEditSingleSelection(1, 0, 1));
     REQUIRE(CanEditSingleSelection(1, 2, 5));
 
@@ -1631,12 +1734,13 @@ TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", 
     REQUIRE_FALSE(CanEditSingleSelection(1, 5, 5));
 }
 
-TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]")
+{
     SceneDocument doc;
     SceneObject obj;
     obj.id = "obj1";
     obj.type = SceneObjectType::Panel;
-    obj.props["_eid"] = "42";  // runtime-only, should not be persisted
+    obj.props["_eid"] = "42"; // runtime-only, should not be persisted
     obj.props["visible"] = "true";
     doc.objects.push_back(obj);
 
@@ -1649,7 +1753,8 @@ TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer
     REQUIRE(loaded.objects[0].props.count("visible") == 1);
 }
 
-TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_islight_true.json");
     const std::string json = R"({
       "version": 1,
@@ -1674,7 +1779,8 @@ TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[
     REQUIRE(loaded.objects[0].components[0].type == "light");
 }
 
-TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted", "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_islight_false.json");
     const std::string json = R"({
       "version": 1,
@@ -1704,7 +1810,8 @@ TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted"
     REQUIRE(roundTrip.objects[0].props.count("isLight") == 0);
 }
 
-TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][serializer]")
+{
     SceneDocument doc;
     // Unix: true root path — mkdir/open fail without privileges.
     // Windows: a leading "/" is *not* filesystem root; it resolves under the current drive
@@ -1718,7 +1825,8 @@ TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][se
     REQUIRE_THROWS_AS(SceneSerializer::SaveToFile(doc, badPath), std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]")
+{
     SceneDocument doc;
     const std::string path = TmpPath("filepath_test.json");
     SceneSerializer::SaveToFile(doc, path);
@@ -1727,7 +1835,8 @@ TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]")
     REQUIRE(loaded.filePath == path);
 }
 
-TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]")
+{
     SceneDocument doc;
     SceneObject obj;
     obj.id = "multi_prop";
@@ -1750,102 +1859,110 @@ TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]") 
 // Raycaster — RayVsAABB
 // ===========================================================================
 
-TEST_CASE("RayVsAABB: direct hit along +X axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: direct hit along +X axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 0.0f, 0.0f};
+    ray.origin = {-5.0f, 0.0f, 0.0f};
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
-    REQUIRE(t == Approx(4.0f).epsilon(1e-4f));  // ray travels 4 units before hitting near face
+    REQUIRE(t == Approx(4.0f).epsilon(1e-4f)); // ray travels 4 units before hitting near face
 }
 
-TEST_CASE("RayVsAABB: miss — ray passes above the box", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: miss — ray passes above the box", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 3.0f, 0.0f};  // y=3, above a box with half=1
+    ray.origin = {-5.0f, 3.0f, 0.0f}; // y=3, above a box with half=1
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: ray origin inside box returns 0", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: ray origin inside box returns 0", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, 0.0f, 0.0f};  // inside the box
+    ray.origin = {0.0f, 0.0f, 0.0f}; // inside the box
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(0.0f).margin(1e-5f));
 }
 
-TEST_CASE("RayVsAABB: parallel ray outside slab misses", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: parallel ray outside slab misses", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {5.0f, 5.0f, 0.0f};   // outside x-slab of box centered at origin
-    ray.direction = {0.0f, 0.0f, 1.0f};   // moves in Z only — parallel to Y slab
+    ray.origin = {5.0f, 5.0f, 0.0f};    // outside x-slab of box centered at origin
+    ray.direction = {0.0f, 0.0f, 1.0f}; // moves in Z only — parallel to Y slab
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: parallel ray inside slab hits", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: parallel ray inside slab hits", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 0.0f, 0.0f};
-    ray.direction = {0.0f, 0.0f, 1.0f};   // moves in Z, inside x and y slabs
+    ray.origin = {-5.0f, 0.0f, 0.0f};
+    ray.direction = {0.0f, 0.0f, 1.0f}; // moves in Z, inside x and y slabs
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     // parallel x-axis: origin.x=-5 is outside [-1,1] → should miss
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: hit along -Z axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: hit along -Z axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, 0.0f, 10.0f};
+    ray.origin = {0.0f, 0.0f, 10.0f};
     ray.direction = {0.0f, 0.0f, -1.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {0.5f, 0.5f, 0.5f};
+    Vec3 half = {0.5f, 0.5f, 0.5f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(9.5f).epsilon(1e-4f));
 }
 
-TEST_CASE("RayVsAABB: hit along +Y axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: hit along +Y axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, -5.0f, 0.0f};
+    ray.origin = {0.0f, -5.0f, 0.0f};
     ray.direction = {0.0f, 1.0f, 0.0f};
 
     Vec3 center = {0.0f, 2.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(6.0f).epsilon(1e-4f));
 }
 
-TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {10.0f, 0.0f, 0.0f};
-    ray.direction = {1.0f, 0.0f, 0.0f};  // pointing away from origin box
+    ray.origin = {10.0f, 0.0f, 0.0f};
+    ray.direction = {1.0f, 0.0f, 0.0f}; // pointing away from origin box
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
@@ -1855,52 +1972,55 @@ TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]")
 // Raycaster — ScreenToRay
 // ===========================================================================
 
-TEST_CASE("ScreenToRay: center of screen produces ray through view center", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: center of screen produces ray through view center", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {0.0f, 0.0f, 5.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 1.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 1.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     int W = 800, H = 800;
     Ray ray = ScreenToRay(W / 2.0f, H / 2.0f, W, H, cam);
 
     REQUIRE(ray.direction.x == Approx(0.0f).margin(1e-3f));
     REQUIRE(ray.direction.y == Approx(0.0f).margin(1e-3f));
-    REQUIRE(ray.direction.z < 0.0f);  // pointing toward -Z (into the scene)
+    REQUIRE(ray.direction.z < 0.0f); // pointing toward -Z (into the scene)
 }
 
-TEST_CASE("ScreenToRay: direction is normalized", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: direction is normalized", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {0.0f, 0.0f, 5.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 16.0f / 9.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 16.0f / 9.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     // Test multiple screen positions
-    for (auto [mx, my] : std::initializer_list<std::pair<float,float>>{
-        {0.0f, 0.0f}, {200.0f, 150.0f}, {400.0f, 300.0f}, {799.0f, 449.0f}
-    }) {
+    for (auto [mx, my] : std::initializer_list<std::pair<float, float>>{
+             {0.0f, 0.0f}, {200.0f, 150.0f}, {400.0f, 300.0f}, {799.0f, 449.0f}})
+    {
         Ray r = ScreenToRay(mx, my, 800, 450, cam);
         REQUIRE(r.direction.Length() == Approx(1.0f).epsilon(1e-4f));
     }
 }
 
-TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {3.0f, 2.0f, 7.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 1.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 1.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     Ray ray = ScreenToRay(400.0f, 300.0f, 800, 600, cam);
 
@@ -1914,28 +2034,35 @@ TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]
 // ===========================================================================
 
 // Mirror of the selection logic in EditorLayer::DrawObjectsTree.
-static void ApplyHierarchyClick(std::vector<int>& sel, int& lastIdx,
-                                 int clicked, bool shift, bool ctrl) {
-    if (shift && lastIdx >= 0) {
+static void ApplyHierarchyClick(std::vector<int> &sel, int &lastIdx,
+                                int clicked, bool shift, bool ctrl)
+{
+    if (shift && lastIdx >= 0)
+    {
         const int lo = std::min(lastIdx, clicked);
         const int hi = std::max(lastIdx, clicked);
         sel.clear();
         for (int i = lo; i <= hi; ++i)
             sel.push_back(i);
-    } else if (ctrl) {
+    }
+    else if (ctrl)
+    {
         auto it = std::find(sel.begin(), sel.end(), clicked);
         if (it != sel.end())
             sel.erase(it);
         else
             sel.push_back(clicked);
         lastIdx = clicked;
-    } else {
+    }
+    else
+    {
         sel = {clicked};
         lastIdx = clicked;
     }
 }
 
-TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1950,7 +2077,8 @@ TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]") {
     REQUIRE(last == 7);
 }
 
-TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1971,7 +2099,8 @@ TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]"
     REQUIRE(sel[2] == 2);
 }
 
-TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single select", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single select", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1983,16 +2112,17 @@ TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single selec
     REQUIRE(last == 4);
 }
 
-TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
     ApplyHierarchyClick(sel, last, 1, false, false);
-    ApplyHierarchyClick(sel, last, 3, false, true);  // ctrl-add 3
-    ApplyHierarchyClick(sel, last, 5, false, true);  // ctrl-add 5
+    ApplyHierarchyClick(sel, last, 3, false, true); // ctrl-add 3
+    ApplyHierarchyClick(sel, last, 5, false, true); // ctrl-add 5
     REQUIRE(sel.size() == 3);
 
-    ApplyHierarchyClick(sel, last, 3, false, true);  // ctrl-remove 3
+    ApplyHierarchyClick(sel, last, 3, false, true); // ctrl-remove 3
     REQUIRE(sel.size() == 2);
     REQUIRE(std::find(sel.begin(), sel.end(), 3) == sel.end());
 }
@@ -2001,13 +2131,14 @@ TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]"
 // Drag-drop ray-floor intersection math
 // ===========================================================================
 
-TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]") {
+TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]")
+{
     // Ray from above looking straight down
     Ray r;
-    r.origin    = {0.0f, 5.0f, 0.0f};
+    r.origin = {0.0f, 5.0f, 0.0f};
     r.direction = {0.0f, -1.0f, 0.0f};
 
-    const float t = -r.origin.y / r.direction.y;  // = 5
+    const float t = -r.origin.y / r.direction.y; // = 5
     const Vec3 hit = {r.origin.x + r.direction.x * t,
                       r.origin.y + r.direction.y * t,
                       r.origin.z + r.direction.z * t};
@@ -2023,10 +2154,11 @@ TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]") {
     REQUIRE(helperHit.z == Approx(0.0f));
 }
 
-TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]") {
+TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]")
+{
     // Ray from (3, 4, 1) pointing down-forward
     Ray r;
-    r.origin    = {3.0f, 4.0f, 1.0f};
+    r.origin = {3.0f, 4.0f, 1.0f};
     // Direction: slightly forward (+z) and mostly down
     const float len = std::sqrt(1.0f + 16.0f);
     r.direction = {0.0f, -4.0f / len, 1.0f / len};
@@ -2037,10 +2169,11 @@ TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]") {
                       r.origin.z + r.direction.z * t};
 
     REQUIRE(hit.y == Approx(0.0f).margin(1e-4f));
-    REQUIRE(hit.x == Approx(3.0f).margin(1e-4f));  // no x-component in direction
+    REQUIRE(hit.x == Approx(3.0f).margin(1e-4f)); // no x-component in direction
 }
 
-TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]") {
+TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]")
+{
     Ray r;
     r.origin = {2.0f, 3.0f, 4.0f};
     r.direction = {1.0f, 0.0f, 0.0f};
@@ -2049,7 +2182,8 @@ TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]")
     REQUIRE_FALSE(TryIntersectGroundPlane(r, &hit));
 }
 
-TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdrop]") {
+TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdrop]")
+{
     Ray ray;
     ray.origin = {0.0f, 5.0f, 0.0f};
     ray.direction = {0.0f, -1.0f, 0.0f};
@@ -2065,7 +2199,8 @@ TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdr
     REQUIRE(hit.normal.z == Approx(0.0f));
 }
 
-TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragdrop]") {
+TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragdrop]")
+{
     Ray ray;
     ray.origin = {-5.0f, 0.25f, 0.0f};
     ray.direction = {1.0f, 0.0f, 0.0f};
@@ -2081,7 +2216,8 @@ TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragd
     REQUIRE(hit.normal.z == Approx(0.0f));
 }
 
-TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]") {
+TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]")
+{
     const EditorViewportRect rect =
         BuildEditorViewportRect(1600.0f, 900.0f, 36.0f, 24.0f, 200.0f, 308.0f, 280.0f);
 
@@ -2095,7 +2231,8 @@ TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]") {
     REQUIRE_FALSE(rect.Contains(600.0f, 800.0f));
 }
 
-TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect", "[editor][ui]") {
+TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect", "[editor][ui]")
+{
     const EditorViewportRect viewport =
         BuildEditorViewportRect(1600.0f, 900.0f, 36.0f, 24.0f, 200.0f, 308.0f, 280.0f);
     const EditorViewGimbalLayout layout =
@@ -2112,7 +2249,8 @@ TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect
     REQUIRE(layout.pickRect.Contains(layout.gimbalRect.maxX - 4.0f, layout.gimbalRect.maxY - 4.0f));
 }
 
-TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[editor][ui]") {
+TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[editor][ui]")
+{
     REQUIRE(ComputeEditorLeftDockWidth(1200.0f) == Approx(220.0f));
     REQUIRE(ComputeEditorLeftDockWidth(2400.0f) == Approx(320.0f));
 
@@ -2123,11 +2261,12 @@ TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[edit
     REQUIRE(ComputeEditorBottomDockHeight(1440.0f) == Approx(259.2f));
 }
 
-TEST_CASE("Editor viewport asset drop target matches active asset payload inline", "[editor][ui][dragdrop]") {
+TEST_CASE("Editor viewport asset drop target matches active asset payload inline", "[editor][ui][dragdrop]")
+{
     ImGuiContextGuard imgui;
     bool callbackInvoked = false;
 
-    ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO &io = ImGui::GetIO();
     io.MousePos = ImVec2(48.0f, 48.0f);
 
     ImGui::NewFrame();
@@ -2135,7 +2274,7 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
     ImGui::SetNextWindowSize(ImVec2(320.0f, 240.0f), ImGuiCond_Always);
     ImGui::Begin("ViewportTest");
 
-    ImGuiContext& g = *ImGui::GetCurrentContext();
+    ImGuiContext &g = *ImGui::GetCurrentContext();
     g.HoveredWindow = ImGui::GetCurrentWindow();
     g.HoveredWindowUnderMovingWindow = ImGui::GetCurrentWindow();
     SeedExternalAssetDragPayload("crate");
@@ -2145,8 +2284,9 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
         220.0f,
         140.0f,
         &callbackInvoked,
-        [](void* userData, const char* assetId) {
-            auto* invoked = static_cast<bool*>(userData);
+        [](void *userData, const char *assetId)
+        {
+            auto *invoked = static_cast<bool *>(userData);
             *invoked = true;
             return assetId && std::string(assetId) == "crate";
         });
@@ -2161,11 +2301,12 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
     REQUIRE_FALSE(callbackInvoked);
 }
 
-TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "[editor][ui][dragdrop]") {
+TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "[editor][ui][dragdrop]")
+{
     ImGuiContextGuard imgui;
     bool callbackInvoked = false;
 
-    ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO &io = ImGui::GetIO();
     io.MousePos = ImVec2(48.0f, 48.0f);
 
     ImGui::NewFrame();
@@ -2173,7 +2314,7 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
     ImGui::SetNextWindowSize(ImVec2(320.0f, 240.0f), ImGuiCond_Always);
     ImGui::Begin("ViewportPlayModeTest");
 
-    ImGuiContext& g = *ImGui::GetCurrentContext();
+    ImGuiContext &g = *ImGui::GetCurrentContext();
     g.HoveredWindow = ImGui::GetCurrentWindow();
     g.HoveredWindowUnderMovingWindow = ImGui::GetCurrentWindow();
     SeedExternalAssetDragPayload("crate");
@@ -2183,8 +2324,9 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
         220.0f,
         140.0f,
         &callbackInvoked,
-        [](void* userData, const char*) {
-            auto* invoked = static_cast<bool*>(userData);
+        [](void *userData, const char *)
+        {
+            auto *invoked = static_cast<bool *>(userData);
             *invoked = true;
             return true;
         });
@@ -2199,7 +2341,8 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
     REQUIRE_FALSE(callbackInvoked);
 }
 
-TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_missing";
     fs::remove_all(tempHome);
@@ -2217,7 +2360,8 @@ TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[ed
     REQUIRE(ResolveEditorWorkspacePath() == tempHome / ".horo" / "editor_workspace.json");
 }
 
-TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_invalid";
     fs::remove_all(tempHome);
@@ -2232,7 +2376,8 @@ TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[ed
     REQUIRE(loaded.state.consoleShowInfo);
 }
 
-TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_roundtrip";
     fs::remove_all(tempHome);
@@ -2259,7 +2404,8 @@ TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[edi
     REQUIRE(loaded.state.projectBrowserCwd == "C:/project/assets");
 }
 
-TEST_CASE("Vec3 CSV parser accepts render scale triples", "[editor][ui]") {
+TEST_CASE("Vec3 CSV parser accepts render scale triples", "[editor][ui]")
+{
     Vec3 parsed = Vec3::Zero();
     REQUIRE(TryParseVec3Csv("1.5000, 2.0000,0.7500", &parsed));
     REQUIRE(parsed.x == Approx(1.5f));

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -230,6 +230,21 @@ TEST_CASE("Vulkan material translation snapshots backend-relevant material state
   REQUIRE_FALSE(translated.usesCustomShader);
 }
 
+TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
+          "[renderer][foundation][vulkan][pipeline]") {
+  VulkanRenderBackend::TranslatedMaterialState materialState;
+  materialState.usesAlbedoMap = true;
+  materialState.usesCustomShader = false;
+
+  const VulkanRenderBackend::OpaquePipelineKey key =
+      VulkanRenderBackend::BuildOpaquePipelineKey(materialState);
+
+  REQUIRE(key.usesAlbedoMap);
+  REQUIRE_FALSE(key.usesCustomShader);
+  REQUIRE(key.writesDepth);
+  REQUIRE(key.depthTestEnabled);
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -266,6 +266,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   VulkanRenderBackend backend(window);
   REQUIRE(backend.IsInitialized());
   REQUIRE(backend.HasOpaqueRasterScaffold());
+  REQUIRE(backend.HasOpaquePipelineCreationScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -267,6 +267,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.IsInitialized());
   REQUIRE(backend.HasOpaqueRasterScaffold());
   REQUIRE(backend.HasOpaquePipelineCreationScaffold());
+  REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -308,6 +308,27 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
   REQUIRE(backend.HasOpaqueGraphicsPipelineScaffold());
 
+  void *instanceHandle = nullptr;
+  void *physicalDeviceHandle = nullptr;
+  void *deviceHandle = nullptr;
+  void *queueHandle = nullptr;
+  void *renderPassHandle = nullptr;
+  uint32_t queueFamily = 0;
+  uint32_t imageCount = 0;
+  REQUIRE(backend.TryGetImGuiVulkanInitData(&instanceHandle,
+                                            &physicalDeviceHandle,
+                                            &deviceHandle,
+                                            &queueFamily,
+                                            &queueHandle,
+                                            &renderPassHandle,
+                                            &imageCount));
+  REQUIRE(instanceHandle != nullptr);
+  REQUIRE(physicalDeviceHandle != nullptr);
+  REQUIRE(deviceHandle != nullptr);
+  REQUIRE(queueHandle != nullptr);
+  REQUIRE(renderPassHandle != nullptr);
+  REQUIRE(imageCount >= 2);
+
   glfwDestroyWindow(window);
   glfwTerminate();
 }

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -89,6 +89,23 @@ namespace
     int drawCalls = 0;
   };
 
+#if defined(MONOLITH_HAS_VULKAN)
+  struct OverlayRenderProbe
+  {
+    bool invoked = false;
+    void *commandBufferHandle = nullptr;
+  };
+
+  void CaptureOverlayRenderProbe(void *userData, void *commandBufferHandle)
+  {
+    if (!userData)
+      return;
+    auto *probe = static_cast<OverlayRenderProbe *>(userData);
+    probe->invoked = true;
+    probe->commandBufferHandle = commandBufferHandle;
+  }
+#endif
+
 } // namespace
 
 TEST_CASE("Renderer routes explicit frame and pass commands through backend seam",
@@ -383,6 +400,48 @@ TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaqu
   REQUIRE(backend.GetDrawCallCount() == 1);
   REQUIRE(backend.GetLastError().find("draw submissions are queued") != std::string::npos);
   REQUIRE(backend.GetLastError().find("Pending draws: 1") != std::string::npos);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan backend executes queued overlay callbacks while recording frame commands",
+          "[renderer][foundation][vulkan][overlay]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-overlay-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan overlay callback test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  OverlayRenderProbe overlayProbe;
+
+  backend.BeginFrame({{}, "vulkan-overlay-baseline"});
+  backend.EndFrame();
+
+  // Editor integration may queue draw data after frame submission; backend
+  // should consume it on the next frame recording.
+  backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
+  backend.BeginFrame({{}, "vulkan-overlay-frame"});
+  backend.EndFrame();
+
+  REQUIRE(overlayProbe.invoked);
+  REQUIRE(overlayProbe.commandBufferHandle != nullptr);
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -268,6 +268,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.HasOpaqueRasterScaffold());
   REQUIRE(backend.HasOpaquePipelineCreationScaffold());
   REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
+  REQUIRE(backend.HasOpaqueGraphicsPipelineScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -24,65 +24,76 @@
 
 using namespace Monolith;
 
-namespace {
+namespace
+{
 
-class FakeRenderBackend : public IRenderBackend {
- public:
-  void BeginFrame(const RenderFrameConfig& frame) override {
-    events.push_back("begin-frame");
-    lastFrame = frame;
-  }
+  class FakeRenderBackend : public IRenderBackend
+  {
+  public:
+    void BeginFrame(const RenderFrameConfig &frame) override
+    {
+      events.push_back("begin-frame");
+      lastFrame = frame;
+    }
 
-  void EndFrame() override {
-    events.push_back("end-frame");
-  }
+    void EndFrame() override
+    {
+      events.push_back("end-frame");
+    }
 
-  void BeginPass(const RenderPassConfig& pass) override {
-    events.push_back("begin-pass");
-    lastPass = pass;
-  }
+    void BeginPass(const RenderPassConfig &pass) override
+    {
+      events.push_back("begin-pass");
+      lastPass = pass;
+    }
 
-  void EndPass() override {
-    events.push_back("end-pass");
-  }
+    void EndPass() override
+    {
+      events.push_back("end-pass");
+    }
 
-  void DrawMesh(const MeshDrawCommand& command) override {
-    events.push_back("draw-mesh");
-    lastMesh = command;
-    ++drawCalls;
-  }
+    void DrawMesh(const MeshDrawCommand &command) override
+    {
+      events.push_back("draw-mesh");
+      lastMesh = command;
+      ++drawCalls;
+    }
 
-  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override {
-    events.push_back("draw-skinned");
-    lastSkinned = command;
-    ++drawCalls;
-  }
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &command) override
+    {
+      events.push_back("draw-skinned");
+      lastSkinned = command;
+      ++drawCalls;
+    }
 
-  void DrawWireframe(const WireframeDrawCommand& command) override {
-    events.push_back("draw-wireframe");
-    lastWireframe = command;
-    ++drawCalls;
-  }
+    void DrawWireframe(const WireframeDrawCommand &command) override
+    {
+      events.push_back("draw-wireframe");
+      lastWireframe = command;
+      ++drawCalls;
+    }
 
-  RenderBackendId GetBackendId() const override { return RenderBackendId::OpenGL; }
-  RenderBackendCapabilities GetCapabilities() const override {
-    return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
-  }
-  int GetDrawCallCount() const override { return drawCalls; }
+    RenderBackendId GetBackendId() const override { return RenderBackendId::OpenGL; }
+    RenderBackendCapabilities GetCapabilities() const override
+    {
+      return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
+    }
+    int GetDrawCallCount() const override { return drawCalls; }
 
-  std::vector<std::string> events;
-  RenderFrameConfig lastFrame;
-  RenderPassConfig lastPass;
-  MeshDrawCommand lastMesh;
-  SkinnedMeshDrawCommand lastSkinned;
-  WireframeDrawCommand lastWireframe;
-  int drawCalls = 0;
-};
+    std::vector<std::string> events;
+    RenderFrameConfig lastFrame;
+    RenderPassConfig lastPass;
+    MeshDrawCommand lastMesh;
+    SkinnedMeshDrawCommand lastSkinned;
+    WireframeDrawCommand lastWireframe;
+    int drawCalls = 0;
+  };
 
-}  // namespace
+} // namespace
 
 TEST_CASE("Renderer routes explicit frame and pass commands through backend seam",
-          "[renderer][foundation]") {
+          "[renderer][foundation]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -109,7 +120,8 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
 }
 
 TEST_CASE("Renderer forwards frame output config through the backend seam",
-          "[renderer][foundation][frame-output]") {
+          "[renderer][foundation][frame-output]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -127,7 +139,8 @@ TEST_CASE("Renderer forwards frame output config through the backend seam",
 }
 
 TEST_CASE("Renderer initializes the default OpenGL backend through a typed selection",
-          "[renderer][foundation][backend]") {
+          "[renderer][foundation][backend]")
+{
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Auto});
 
   REQUIRE(init.ok);
@@ -147,7 +160,8 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
 }
 
 TEST_CASE("Renderer rejects unsupported backend requests without replacing the active backend",
-          "[renderer][foundation][backend]") {
+          "[renderer][foundation][backend]")
+{
   REQUIRE(Renderer::InitializeBackend({RenderBackendId::OpenGL}).ok);
 
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Vulkan});
@@ -178,17 +192,19 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 }
 
 TEST_CASE("RenderBackendSelection preserves native window handles for backend bootstrap",
-          "[renderer][foundation][backend][selection]") {
+          "[renderer][foundation][backend][selection]")
+{
   RenderBackendSelection selection;
   selection.requested = RenderBackendId::Vulkan;
-  selection.nativeWindowHandle = reinterpret_cast<void*>(0x1234);
+  selection.nativeWindowHandle = reinterpret_cast<void *>(0x1234);
 
   REQUIRE(selection.requested == RenderBackendId::Vulkan);
-  REQUIRE(selection.nativeWindowHandle == reinterpret_cast<void*>(0x1234));
+  REQUIRE(selection.nativeWindowHandle == reinterpret_cast<void *>(0x1234));
 }
 
 TEST_CASE("Backend capability defaults express the current parity matrix",
-          "[renderer][foundation][backend][parity]") {
+          "[renderer][foundation][backend][parity]")
+{
   const RenderBackendCapabilities glCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
   REQUIRE(glCaps.supportsDebugDraw);
   REQUIRE(glCaps.supportsWireframeOverlay);
@@ -210,7 +226,8 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
 
 #if defined(MONOLITH_HAS_VULKAN)
 TEST_CASE("Vulkan material translation snapshots backend-relevant material state",
-          "[renderer][foundation][vulkan][translation]") {
+          "[renderer][foundation][vulkan][translation]")
+{
   Material material;
   material.color = {0.2f, 0.4f, 0.6f, 1.0f};
   material.roughness = 0.25f;
@@ -231,7 +248,8 @@ TEST_CASE("Vulkan material translation snapshots backend-relevant material state
 }
 
 TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
-          "[renderer][foundation][vulkan][pipeline]") {
+          "[renderer][foundation][vulkan][pipeline]")
+{
   VulkanRenderBackend::TranslatedMaterialState materialState;
   materialState.usesAlbedoMap = true;
   materialState.usesCustomShader = false;
@@ -246,19 +264,22 @@ TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
 }
 
 TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a window",
-          "[renderer][foundation][vulkan][scaffold]") {
+          "[renderer][foundation][vulkan][scaffold]")
+{
   if (!glfwInit())
     SKIP("GLFW initialization failed on this machine");
 
-  if (!glfwVulkanSupported()) {
+  if (!glfwVulkanSupported())
+  {
     glfwTerminate();
     SKIP("GLFW reports Vulkan unsupported on this machine");
   }
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
-  if (!window) {
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
+  if (!window)
+  {
     glfwTerminate();
     SKIP("Unable to create hidden GLFW window for Vulkan raster scaffold test");
   }
@@ -275,19 +296,22 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
 }
 
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
-          "[renderer][foundation][vulkan][opaque]") {
+          "[renderer][foundation][vulkan][opaque]")
+{
   if (!glfwInit())
     SKIP("GLFW initialization failed on this machine");
 
-  if (!glfwVulkanSupported()) {
+  if (!glfwVulkanSupported())
+  {
     glfwTerminate();
     SKIP("GLFW reports Vulkan unsupported on this machine");
   }
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
-  if (!window) {
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
+  if (!window)
+  {
     glfwTerminate();
     SKIP("Unable to create hidden GLFW window for Vulkan backend test");
   }
@@ -297,7 +321,8 @@ TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with
   selection.nativeWindowHandle = window;
   const RenderBackendInitResult init = Renderer::InitializeBackend(selection);
 
-  if (!init.ok) {
+  if (!init.ok)
+  {
     glfwDestroyWindow(window);
     glfwTerminate();
     FAIL(init.error);
@@ -320,10 +345,53 @@ TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with
   glfwDestroyWindow(window);
   glfwTerminate();
 }
+
+TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaque draw execution",
+          "[renderer][foundation][vulkan][opaque][diagnostics]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-diagnostics-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan diagnostics test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  Mesh mesh;
+  Material material;
+  Camera camera;
+
+  backend.BeginFrame({{}, "vulkan-opaque-diagnostics"});
+  backend.BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-opaque-pass"});
+  backend.DrawMesh({&mesh, &material, Mat4::Identity()});
+  backend.EndPass();
+  backend.EndFrame();
+
+  REQUIRE(backend.GetDrawCallCount() == 1);
+  REQUIRE(backend.GetLastError().find("draw submissions are queued") != std::string::npos);
+  REQUIRE(backend.GetLastError().find("Pending draws: 1") != std::string::npos);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
 #endif
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",
-          "[renderer][foundation]") {
+          "[renderer][foundation]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -364,7 +432,8 @@ TEST_CASE("Renderer supports multiple explicit passes within a single frame",
 }
 
 TEST_CASE("RenderSystem submits visible mesh entities into the active explicit pass",
-          "[renderer][foundation][scene]") {
+          "[renderer][foundation][scene]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -403,7 +472,8 @@ TEST_CASE("RenderSystem submits visible mesh entities into the active explicit p
 }
 
 TEST_CASE("Material copies share shader and texture resource handles",
-          "[renderer][foundation][ownership]") {
+          "[renderer][foundation][ownership]")
+{
   auto shader = std::make_shared<Shader>();
   auto texture = std::make_shared<Texture>();
 

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -245,6 +245,32 @@ TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
   REQUIRE(key.depthTestEnabled);
 }
 
+TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a window",
+          "[renderer][foundation][vulkan][scaffold]") {
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported()) {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
+  if (!window) {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan raster scaffold test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+  REQUIRE(backend.HasOpaqueRasterScaffold());
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -452,13 +452,13 @@ TEST_CASE("Vulkan backend executes queued overlay callbacks while recording fram
 
   OverlayRenderProbe overlayProbe;
 
-  backend.BeginFrame({{}, "vulkan-overlay-baseline"});
-  backend.EndFrame();
-
-  // Editor integration may queue draw data after frame submission; backend
-  // should consume it on the next frame recording.
+  // Frame-external queueing should be ignored by the backend.
   backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
+  REQUIRE_FALSE(overlayProbe.invoked);
+  REQUIRE(backend.GetLastError().find("active frame") != std::string::npos);
+
   backend.BeginFrame({{}, "vulkan-overlay-frame"});
+  backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
   backend.EndFrame();
 
   REQUIRE(overlayProbe.invoked);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -16,6 +16,7 @@
 #include "renderer/RenderBackend.h"
 #include "renderer/Renderer.h"
 #include "renderer/RenderViewUtils.h"
+#include "renderer/VulkanRenderBackend.h"
 #include "scene/Registry.h"
 #include "scene/components/MeshComponent.h"
 #include "scene/components/TransformComponent.h"
@@ -208,6 +209,27 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
 }
 
 #if defined(MONOLITH_HAS_VULKAN)
+TEST_CASE("Vulkan material translation snapshots backend-relevant material state",
+          "[renderer][foundation][vulkan][translation]") {
+  Material material;
+  material.color = {0.2f, 0.4f, 0.6f, 1.0f};
+  material.roughness = 0.25f;
+  material.metallic = 0.75f;
+  material.uvScale = 2.5f;
+  material.albedoMap = std::make_shared<Texture>();
+  material.shader = std::make_shared<Shader>();
+
+  const VulkanRenderBackend::TranslatedMaterialState translated =
+      VulkanRenderBackend::TranslateMaterialState(material);
+
+  REQUIRE(translated.baseColor == material.color);
+  REQUIRE(translated.roughness == Catch::Approx(material.roughness));
+  REQUIRE(translated.metallic == Catch::Approx(material.metallic));
+  REQUIRE(translated.uvScale == Catch::Approx(material.uvScale));
+  REQUIRE_FALSE(translated.usesAlbedoMap);
+  REQUIRE_FALSE(translated.usesCustomShader);
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT TARGET imgui_lib)
     )
     FetchContent_MakeAvailable(imgui)
 
-    add_library(imgui_lib STATIC
+    set(MONOLITH_IMGUI_SOURCES
         ${imgui_SOURCE_DIR}/imgui.cpp
         ${imgui_SOURCE_DIR}/imgui_draw.cpp
         ${imgui_SOURCE_DIR}/imgui_tables.cpp
@@ -87,11 +87,25 @@ if(NOT TARGET imgui_lib)
         ${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
         ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
     )
+
+    if(MONOLITH_ENGINE_ENABLE_VULKAN)
+        list(APPEND MONOLITH_IMGUI_SOURCES
+            ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+        )
+    endif()
+
+    add_library(imgui_lib STATIC ${MONOLITH_IMGUI_SOURCES})
     target_include_directories(imgui_lib PUBLIC
         ${imgui_SOURCE_DIR}
         ${imgui_SOURCE_DIR}/backends
     )
     target_link_libraries(imgui_lib PUBLIC glfw glad)
+
+    if(MONOLITH_ENGINE_ENABLE_VULKAN)
+        target_compile_definitions(imgui_lib PUBLIC IMGUI_IMPL_VULKAN_USE_VOLK)
+        target_link_libraries(imgui_lib PUBLIC monolith_volk monolith_vulkan_headers)
+    endif()
+
     # Suppress vendor warnings (MSVC -WX, GCC/Clang -Werror)
     target_compile_options(imgui_lib PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W0>


### PR DESCRIPTION
## Summary
- update `docs/architecture/vulkan-backend-integration-and-backend-parity.md` so it reflects the renderer/editor/debug seams that are now actually implemented across the epic stack
- add explicit sections for the current implemented foundation, remaining work after the current stack, and the validation strategy tied to the parity validation matrix
- extend architecture doc regression checks so those new sections remain part of the documented review contract

## Motivation
- issue #129 is about making the Vulkan parity architecture doc match the real state of the implementation, not just the original plan
- after the stacked renderer/editor/backend PRs, the document needed to stop being purely aspirational and start recording which seams already exist versus which parity gaps remain

## Implementation Notes
- the updated doc now calls out the implemented foundation: window/bootstrap ownership split, backend-owned frame control, resource payload hiding, Vulkan bootstrap, preview handles, ImGui routing, and debug/readback capability gating
- it also records the main gaps still open for full parity, so remaining work stays explicit rather than hidden in branch history
- the architecture doc now points readers to `docs/development/backend-parity-validation-matrix.md` for the living test/validation contract

## Validation
- [x] Default architecture docs test passed
- [x] Vulkan-enabled architecture docs test passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake --build --preset debug-msvc --target test_architecture_docs
ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_architecture_docs"

cmake --build build/debug-msvc-vulkan-tests --config Debug --target test_architecture_docs
ctest --test-dir build/debug-msvc-vulkan-tests -C Debug --output-on-failure -R "test_architecture_docs"
```

## Issue Links
- Refs #129
- Parent epic: #119

## Stack Notes
- base branch: `feat/128-backend-parity-tests`
- stacked on top of PR #142, #141, #140, #139, #138, #137, #136, #135, #134, #133, #132, and root PR #118