### PR TITLE
epic(renderer): Vulkan backend parity integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
     option(MONOLITH_ENGINE_BUILD_TESTS "Build engine unit tests" ON)
+    option(MONOLITH_ENGINE_ENABLE_VULKAN "Fetch Vulkan headers/loader and compile Vulkan backend scaffolding" OFF)
 
     if(MSVC)
         add_compile_options(/W4 /WX /Zc:preprocessor)
@@ -60,6 +61,11 @@ target_link_libraries(MonolithEngine
         nlohmann_json::nlohmann_json
         tinygltf
 )
+
+if(MONOLITH_ENGINE_ENABLE_VULKAN)
+    target_link_libraries(MonolithEngine PUBLIC monolith_volk monolith_vulkan_headers)
+    target_compile_definitions(MonolithEngine PUBLIC MONOLITH_HAS_VULKAN=1)
+endif()
 
 if(APPLE)
     target_link_libraries(MonolithEngine PUBLIC "-framework OpenGL")

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ for (Entity e : registry.GetEntities<TransformComponent>()) { ... }
 
 The engine architecture guidance lives under [docs/architecture](./docs/architecture/README.md).
 
+Renderer/backend validation notes live under [docs/development/backend-parity-validation-matrix.md](./docs/development/backend-parity-validation-matrix.md).
+
 That doc set defines:
 - module boundaries and allowed dependencies
 - ownership and shutdown rules

--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -109,7 +109,8 @@ void Application::Run() {
     OnUpdate(Time::DeltaTime());
     OnRender(alpha);
 
-    m_window->SwapBuffers();
+    if (m_window->OwnsPresentation())
+      m_window->SwapBuffers();
   }
 
   OnShutdown();

--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -1,7 +1,5 @@
 #include "core/Application.h"
 
-#include <glad/glad.h>
-
 #include <filesystem>
 #include <string_view>
 #include <system_error>
@@ -69,6 +67,7 @@ Application::Application(const AppSpec& spec) {
   ws.width = spec.width;
   ws.height = spec.height;
   ws.vsync = spec.vsync;
+  ws.graphicsApi = spec.graphicsApi;
 
   m_window = std::make_unique<Window>(ws);
   m_window->SetCloseCallback([this]() { m_running = false; });

--- a/core/Application.h
+++ b/core/Application.h
@@ -12,10 +12,12 @@ struct AppSpec {
   int width = 1280;
   int height = 720;
   bool vsync = true;
-  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
   // Repo-relative path to the main scene file (e.g. "assets/scenes/scene.json").
   // Resolved to an absolute path via ProjectPath at construction time.
   std::string defaultSceneFile;
+  // Kept after defaultSceneFile to preserve aggregate-initialization compatibility
+  // with existing starter/integration apps that pass scene path as the 5th field.
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
 };
 
 class Application {

--- a/core/Application.h
+++ b/core/Application.h
@@ -12,6 +12,7 @@ struct AppSpec {
   int width = 1280;
   int height = 720;
   bool vsync = true;
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
   // Repo-relative path to the main scene file (e.g. "assets/scenes/scene.json").
   // Resolved to an absolute path via ProjectPath at construction time.
   std::string defaultSceneFile;

--- a/core/Screenshot.cpp
+++ b/core/Screenshot.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "core/Logger.h"
+#include "renderer/Renderer.h"
 
 namespace Monolith {
 
@@ -73,6 +74,11 @@ static bool WriteBMP(const std::string& path, int w, int h, const std::vector<ui
 std::string Screenshot::Save(int w, int h, const std::string& folder) {
   if (w <= 0 || h <= 0)
     return {};
+
+  if (!Renderer::GetBackendCapabilities().supportsReadback) {
+    LOG_WARN("Screenshot: active render backend does not support readback capture.");
+    return {};
+  }
 
   // Read framebuffer — GL_BGR so bytes land in BMP order directly
   std::vector<uint8_t> pixels(static_cast<size_t>(w * h * 3));

--- a/core/Screenshot.cpp
+++ b/core/Screenshot.cpp
@@ -1,7 +1,5 @@
 #include "core/Screenshot.h"
 
-#include <glad/glad.h>
-
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -80,9 +78,12 @@ std::string Screenshot::Save(int w, int h, const std::string& folder) {
     return {};
   }
 
-  // Read framebuffer — GL_BGR so bytes land in BMP order directly
-  std::vector<uint8_t> pixels(static_cast<size_t>(w * h * 3));
-  glReadPixels(0, 0, w, h, GL_BGR, GL_UNSIGNED_BYTE, pixels.data());
+  std::vector<uint8_t> pixels;
+  std::string readbackError;
+  if (!Renderer::ReadbackColorBgr8(w, h, pixels, &readbackError)) {
+    LOG_ERROR("Screenshot: color readback failed (%s)", readbackError.c_str());
+    return {};
+  }
 
   // Build timestamped filename
   std::time_t now = std::time(nullptr);

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -11,14 +11,34 @@
 
 namespace Monolith {
 
+WindowGraphicsApiTraits GetWindowGraphicsApiTraits(WindowGraphicsApi graphicsApi) {
+  switch (graphicsApi) {
+    case WindowGraphicsApi::OpenGL:
+      return {.createsClientContext = true,
+              .windowOwnsPresentation = true,
+              .windowOwnsVSync = true,
+              .windowOwnsViewportResize = true,
+              .requestsMsaaSamples = true};
+    case WindowGraphicsApi::Vulkan:
+      return {.createsClientContext = false,
+              .windowOwnsPresentation = false,
+              .windowOwnsVSync = false,
+              .windowOwnsViewportResize = false,
+              .requestsMsaaSamples = false};
+  }
+
+  return {};
+}
+
 Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.height) {
   if (!glfwInit())
     throw std::runtime_error("glfwInit failed");
 
   m_graphicsApi = spec.graphicsApi;
   m_vsync = spec.vsync;
+  const WindowGraphicsApiTraits traits = GetGraphicsApiTraits();
 
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+  if (traits.createsClientContext) {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -31,7 +51,7 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   }
 
   glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (traits.requestsMsaaSamples)
     glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
 
   m_window = glfwCreateWindow(spec.width, spec.height, spec.title.c_str(), nullptr, nullptr);
@@ -40,7 +60,7 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
     throw std::runtime_error("glfwCreateWindow failed");
   }
 
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+  if (traits.createsClientContext) {
     glfwMakeContextCurrent(m_window);
     if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
       glfwDestroyWindow(m_window);
@@ -72,7 +92,7 @@ void Window::PollEvents() {
 }
 
 void Window::SwapBuffers() {
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (OwnsPresentation())
     glfwSwapBuffers(m_window);
 }
 
@@ -82,12 +102,28 @@ bool Window::ShouldClose() const {
 
 void Window::SetVSync(bool enabled) {
   m_vsync = enabled;
-  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (OwnsVSync())
     glfwSwapInterval(enabled ? 1 : 0);
 }
 
 float Window::GetAspect() const {
   return m_height > 0 ? static_cast<float>(m_width) / m_height : 1.0f;
+}
+
+WindowGraphicsApiTraits Window::GetGraphicsApiTraits() const {
+  return Monolith::GetWindowGraphicsApiTraits(m_graphicsApi);
+}
+
+bool Window::OwnsPresentation() const {
+  return GetGraphicsApiTraits().windowOwnsPresentation;
+}
+
+bool Window::OwnsVSync() const {
+  return GetGraphicsApiTraits().windowOwnsVSync;
+}
+
+bool Window::OwnsViewportResize() const {
+  return GetGraphicsApiTraits().windowOwnsViewportResize;
 }
 
 void Window::SetCursorMode(CursorMode mode)
@@ -106,7 +142,7 @@ void Window::FramebufferSizeCallback(GLFWwindow* win, int w, int h) {
   auto* self = static_cast<Window*>(glfwGetWindowUserPointer(win));
   self->m_width = w;
   self->m_height = h;
-  if (self->m_graphicsApi == WindowGraphicsApi::OpenGL)
+  if (self->OwnsViewportResize())
     glViewport(0, 0, w, h);
   if (self->m_resizeCb)
     self->m_resizeCb(w, h);

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -15,14 +15,24 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   if (!glfwInit())
     throw std::runtime_error("glfwInit failed");
 
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+  m_graphicsApi = spec.graphicsApi;
+  m_vsync = spec.vsync;
+
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #ifdef __APPLE__
-  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
 #endif
+  } else {
+    // Vulkan path: no client graphics context should be created by GLFW.
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  }
+
   glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-  glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwWindowHint(GLFW_SAMPLES, 4);  // 4x MSAA
 
   m_window = glfwCreateWindow(spec.width, spec.height, spec.title.c_str(), nullptr, nullptr);
   if (!m_window) {
@@ -30,13 +40,18 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
     throw std::runtime_error("glfwCreateWindow failed");
   }
 
-  glfwMakeContextCurrent(m_window);
-  glfwSwapInterval(spec.vsync ? 1 : 0);
-
-  if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
-    glfwDestroyWindow(m_window);
-    glfwTerminate();
-    throw std::runtime_error("gladLoadGLLoader failed");
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL) {
+    glfwMakeContextCurrent(m_window);
+    if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress))) {
+      glfwDestroyWindow(m_window);
+      glfwTerminate();
+      throw std::runtime_error("gladLoadGLLoader failed");
+    }
+    SetVSync(spec.vsync);
+    LOG_INFO("OpenGL %s — %s", glGetString(GL_VERSION), glGetString(GL_RENDERER));
+  } else {
+    // Vulkan presentation pacing is backend-owned; the window stores the preference.
+    LOG_INFO("Window initialized for Vulkan backend (GLFW no-client-api surface).");
   }
 
   // Store this pointer for callbacks
@@ -44,8 +59,6 @@ Window::Window(const WindowSpec& spec) : m_width(spec.width), m_height(spec.heig
   glfwSetFramebufferSizeCallback(m_window, FramebufferSizeCallback);
   glfwSetWindowCloseCallback(m_window, WindowCloseCallback);
   glfwSetDropCallback(m_window, DropPathsThunk);
-
-  LOG_INFO("OpenGL %s — %s", glGetString(GL_VERSION), glGetString(GL_RENDERER));
 }
 
 Window::~Window() {
@@ -57,12 +70,22 @@ Window::~Window() {
 void Window::PollEvents() {
   glfwPollEvents();
 }
+
 void Window::SwapBuffers() {
-  glfwSwapBuffers(m_window);
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwSwapBuffers(m_window);
 }
+
 bool Window::ShouldClose() const {
   return glfwWindowShouldClose(m_window);
 }
+
+void Window::SetVSync(bool enabled) {
+  m_vsync = enabled;
+  if (m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glfwSwapInterval(enabled ? 1 : 0);
+}
+
 float Window::GetAspect() const {
   return m_height > 0 ? static_cast<float>(m_width) / m_height : 1.0f;
 }
@@ -83,7 +106,8 @@ void Window::FramebufferSizeCallback(GLFWwindow* win, int w, int h) {
   auto* self = static_cast<Window*>(glfwGetWindowUserPointer(win));
   self->m_width = w;
   self->m_height = h;
-  glViewport(0, 0, w, h);
+  if (self->m_graphicsApi == WindowGraphicsApi::OpenGL)
+    glViewport(0, 0, w, h);
   if (self->m_resizeCb)
     self->m_resizeCb(w, h);
 }

--- a/core/Window.h
+++ b/core/Window.h
@@ -13,11 +13,19 @@ enum class CursorMode
     Disabled,
 };
 
+// Window-level graphics API preference used during platform/window bootstrap.
+// This lives in core so startup does not depend on renderer module headers.
+enum class WindowGraphicsApi {
+  OpenGL,
+  Vulkan,
+};
+
 struct WindowSpec {
   std::string title = "Monolith";
   int width = 1280;
   int height = 720;
   bool vsync = true;
+  WindowGraphicsApi graphicsApi = WindowGraphicsApi::OpenGL;
 };
 
 class Window {
@@ -35,10 +43,13 @@ class Window {
   void PollEvents();
   void SwapBuffers();
   bool ShouldClose() const;
+  void SetVSync(bool enabled);
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
   float GetAspect() const;
+  bool IsVSyncEnabled() const { return m_vsync; }
+  WindowGraphicsApi GetGraphicsApi() const { return m_graphicsApi; }
 
   GLFWwindow* GetNativeHandle() const { return m_window; }
 
@@ -52,6 +63,8 @@ class Window {
   GLFWwindow* m_window = nullptr;
   int m_width = 0;
   int m_height = 0;
+  bool m_vsync = true;
+  WindowGraphicsApi m_graphicsApi = WindowGraphicsApi::OpenGL;
   ResizeCallback m_resizeCb;
   CloseCallback m_closeCb;
   FileDropCallback m_fileDropCb;

--- a/core/Window.h
+++ b/core/Window.h
@@ -20,6 +20,16 @@ enum class WindowGraphicsApi {
   Vulkan,
 };
 
+struct WindowGraphicsApiTraits {
+  bool createsClientContext = false;
+  bool windowOwnsPresentation = false;
+  bool windowOwnsVSync = false;
+  bool windowOwnsViewportResize = false;
+  bool requestsMsaaSamples = false;
+};
+
+WindowGraphicsApiTraits GetWindowGraphicsApiTraits(WindowGraphicsApi graphicsApi);
+
 struct WindowSpec {
   std::string title = "Monolith";
   int width = 1280;
@@ -50,6 +60,10 @@ class Window {
   float GetAspect() const;
   bool IsVSyncEnabled() const { return m_vsync; }
   WindowGraphicsApi GetGraphicsApi() const { return m_graphicsApi; }
+  WindowGraphicsApiTraits GetGraphicsApiTraits() const;
+  bool OwnsPresentation() const;
+  bool OwnsVSync() const;
+  bool OwnsViewportResize() const;
 
   GLFWwindow* GetNativeHandle() const { return m_window; }
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,6 +7,7 @@ This directory documents the current engine architecture, calls out temporary ex
 - [module-boundaries.md](./module-boundaries.md)
 - [renderer-foundation.md](./renderer-foundation.md)
 - [backend-agnostic-rendering-foundation-and-runtime-selection.md](./backend-agnostic-rendering-foundation-and-runtime-selection.md)
+- [vulkan-backend-integration-and-backend-parity.md](./vulkan-backend-integration-and-backend-parity.md)
 - [ownership-lifecycle.md](./ownership-lifecycle.md)
 - [error-result-model.md](./error-result-model.md)
 - [threading-and-mutation.md](./threading-and-mutation.md)

--- a/docs/architecture/vulkan-backend-integration-and-backend-parity.md
+++ b/docs/architecture/vulkan-backend-integration-and-backend-parity.md
@@ -1,0 +1,128 @@
+# Vulkan Backend Integration And Backend Parity
+
+## Intent
+
+This document locks the Vulkan v1 parity scope before deeper backend work starts. It defines what “backend parity” means for this engine, which behaviors are required in the first Vulkan milestone, and how unsupported features should fail or degrade.
+
+This document does **not** replace the backend-agnostic rendering foundation. It builds on that foundation and narrows the execution target for the Vulkan rollout.
+
+## Why This Follows The Backend-Agnostic Foundation
+
+The renderer already has:
+
+- typed backend selection
+- backend-owned frame/pass submission seams
+- explicit renderer lifecycle boundaries
+- initial backend capability reporting
+
+That foundation is necessary, but not sufficient. Before Vulkan implementation expands, the engine needs one agreed answer for:
+
+- which workflows must work in Vulkan v1
+- which workflows may degrade through explicit fallbacks
+- which workflows are deferred and must not silently appear “supported”
+
+Without this scope lock, parity work would become an unbounded rewrite.
+
+## Vulkan v1 Goal
+
+Vulkan v1 is successful when the engine can select the Vulkan backend at startup and run the agreed first-slice runtime and editor workflows without reintroducing OpenGL-only assumptions into shared engine layers.
+
+The target is **capability-driven parity**, not identical implementation details between OpenGL and Vulkan.
+
+## Non-Goals
+
+The following are explicitly out of scope for Vulkan v1:
+
+- image-perfect parity with OpenGL across all content
+- full post-processing parity
+- complete GPU profiling/tooling parity
+- bindless resource support
+- compute-driven renderer features
+- advanced editor rendering optimizations beyond the agreed first-slice workflows
+
+## Parity Model
+
+Parity in this epic means:
+
+1. higher-level engine code uses backend-neutral renderer contracts
+2. required workflows succeed on both OpenGL and Vulkan
+3. unsupported or deferred workflows are reported through explicit capabilities or deterministic fallbacks
+4. no higher-level system silently depends on OpenGL-only objects, ids, or state transitions
+
+Parity does **not** mean that both backends must:
+
+- use the same internal resource model
+- expose the same debug/profiling depth
+- produce identical implementation-specific output when a capability is intentionally deferred
+
+## Required Vulkan v1 Workflows
+
+The following workflows are required for the first Vulkan parity milestone:
+
+- runtime startup with Vulkan selected
+- runtime frame clear / present / resize recovery
+- opaque runtime scene rendering for the agreed starter/sample content set
+- editor viewport rendering through backend-neutral target ownership
+- thumbnail generation through backend-neutral offscreen rendering
+- screenshot/readback through backend-owned interfaces
+- debug draw support for the first editor/runtime parity slice
+- debug HUD support where backed by explicit capability-aware readback behavior
+
+## Capability-Driven Fallback Policy
+
+When Vulkan v1 cannot support an existing OpenGL-era workflow at the same depth, the engine must use one of the following behaviors deliberately:
+
+- **required**: feature must work; initialization or test coverage should fail if missing
+- **fallback**: higher-level code may degrade to a documented reduced behavior
+- **deferred**: feature is unavailable in Vulkan v1 and must report that unavailability explicitly
+
+Hidden no-ops are not acceptable unless the fallback is documented and test-covered.
+
+## Vulkan v1 Parity Matrix
+
+| Workflow / capability | OpenGL status | Vulkan v1 target | Policy if unsupported | Notes |
+|---|---|---|---|---|
+| Runtime backend startup | Supported | Required | Fail initialization with actionable error | Must select Vulkan through typed backend bootstrap |
+| Frame clear / present / resize recovery | Supported | Required | Fail initialization or resize path deterministically | No silent OpenGL fallback |
+| Opaque runtime scene render | Supported | Required | Fail validation/tests | First scene slice for starter/sample content |
+| Editor viewport | Supported | Required | Fallback only if explicit placeholder path exists and is test-covered | Must not rely on raw OpenGL FBO ownership in editor code |
+| Thumbnail generation | Supported | Required | Fallback to explicit placeholder thumbnail only if documented | Final policy should be deterministic, not best-effort |
+| Screenshot / readback | Supported | Required | Fail command/request with clear diagnostic | Backend-owned readback path required |
+| Debug draw | Supported | Required | Fallback to disabled debug rendering with visible capability gate | Do not silently submit OpenGL-only debug paths |
+| Debug HUD | Supported | Fallback | Suppress unsupported HUD views with explicit capability check | Depth/readback-heavy panels may ship in reduced form first |
+| Wireframe overlay | Supported | Fallback | Disable toggle or render reduced debug alternative | Capability must be surfaced explicitly |
+| Debug labels | Limited | Fallback | Omit labels if unsupported | Backend should expose support explicitly |
+| GPU timestamps / profiling | Unsupported in practice | Deferred | Report unavailable | Not required for Vulkan v1 |
+| Compute-driven features | Unsupported | Deferred | Report unavailable | Outside first parity slice |
+| Bindless resources | Unsupported | Deferred | Report unavailable | Outside first parity slice |
+
+## Initial Capability Surface Expectations
+
+The current renderer capability model already tracks a small set of backend features. Vulkan parity work is expected to extend that model so higher-level systems can make explicit decisions about at least:
+
+- wireframe overlay support
+- debug label support
+- offscreen target support
+- readback / screenshot support
+- editor viewport support
+- debug HUD feature availability
+
+This document does not require all of those fields to be added in one PR. It requires the final parity work to move toward explicit capability checks instead of backend-specific branching in editor or scene code.
+
+## Acceptance Criteria For Closing The Scope Phase
+
+The scope-definition phase is complete when:
+
+- the Vulkan v1 required workflows are documented
+- non-goals are explicit
+- the parity model is defined as capability-driven graceful degradation
+- the parity matrix identifies required, fallback, and deferred items
+- follow-up PRs can cite this document as the review contract for Vulkan parity work
+
+## Review Checklist
+
+- Does the change move a required Vulkan v1 workflow toward backend-neutral execution?
+- Does it eliminate an OpenGL-only assumption from shared engine/editor code?
+- If a feature is not fully supported, is its fallback or deferred state explicit?
+- Are tests aligned with the policy in the parity matrix?
+- Does the PR narrow risk for the next Vulkan slice rather than widen backend coupling?

--- a/docs/architecture/vulkan-backend-integration-and-backend-parity.md
+++ b/docs/architecture/vulkan-backend-integration-and-backend-parity.md
@@ -100,14 +100,68 @@ Hidden no-ops are not acceptable unless the fallback is documented and test-cove
 
 The current renderer capability model already tracks a small set of backend features. Vulkan parity work is expected to extend that model so higher-level systems can make explicit decisions about at least:
 
+- debug draw support
 - wireframe overlay support
 - debug label support
 - offscreen target support
+- native texture handle support
 - readback / screenshot support
+- depth-readback support
 - editor viewport support
 - debug HUD feature availability
 
+The current parity stack has already established explicit capability gates for:
+
+- debug draw
+- wireframe overlay
+- offscreen target usage in editor preview flows
+- native texture handle usage in editor preview flows
+- screenshot/readback
+- depth-readback-dependent DebugHUD behavior
+- ImGui backend selection support
+
 This document does not require all of those fields to be added in one PR. It requires the final parity work to move toward explicit capability checks instead of backend-specific branching in editor or scene code.
+
+## Current Implemented Foundation State
+
+The current stacked implementation toward this epic now provides:
+
+- backend-aware window/bootstrap ownership split
+- backend-owned frame output control
+- hidden OpenGL payload storage behind resource implementations
+- opt-in Vulkan dependency scaffolding (`Vulkan-Headers` + `volk`)
+- minimal Vulkan backend bootstrap with instance/device/surface/swapchain/clear/present
+- opaque-scene submission acceptance through the Vulkan backend seam
+- backend-neutral preview handle abstraction for editor thumbnail paths
+- editor ImGui backend routing through an explicit backend shim
+- capability-gated debug draw, screenshot/readback, and DebugHUD depth-readback behavior
+
+This means the architecture discussion is no longer purely aspirational. Follow-up work should now focus on turning these seams into fuller parity rather than reintroducing OpenGL assumptions into the engine-facing layers.
+
+## Remaining Work After The Current Stack
+
+The largest remaining gaps after the current implementation stack are:
+
+- real Vulkan mesh/material/pipeline translation beyond accepted opaque-scene submissions
+- backend-neutral editor viewport rendering rather than seam-only backend routing
+- full offscreen render-target ownership beyond preview handles
+- backend-owned screenshot/readback implementations rather than capability-gated OpenGL-only behavior
+- broader parity CI once Vulkan coverage is stable enough for hosted runners
+
+These gaps should be treated as explicit backlog, not silent capability drift.
+
+## Validation Strategy
+
+The living validation contract for this epic now lives in:
+
+- `docs/development/backend-parity-validation-matrix.md`
+
+That matrix complements this architecture document by defining:
+
+- required default-build contract tests
+- Vulkan-enabled smoke coverage
+- required command lines for parity-related PRs
+- current known validation gaps
 
 ## Acceptance Criteria For Closing The Scope Phase
 

--- a/docs/development/backend-parity-validation-matrix.md
+++ b/docs/development/backend-parity-validation-matrix.md
@@ -1,0 +1,73 @@
+# Backend Parity Validation Matrix
+
+This matrix tracks the minimum validation surface for epic `#119`.
+
+## Contract Tests
+
+These tests protect backend-neutral engine contracts and should remain green regardless of backend implementation details.
+
+- `test_renderer_foundation`
+  - typed backend selection
+  - frame/pass lifecycle invariants
+  - capability reporting
+  - unsupported backend request handling
+  - Vulkan bootstrap / opaque-scene submission smoke path when enabled
+- `test_architecture_docs`
+  - architecture document discoverability
+  - backend-boundary guardrails in higher-level code
+  - editor/debug/readback seam enforcement
+- `test_editor`
+  - preview handle plumbing
+  - ImGui backend selection seam
+  - editor fallback behavior on unsupported backend capabilities
+
+## Backend-Specific Smoke Coverage
+
+### OpenGL / default build
+
+- standard CI matrix: Linux, Windows, macOS
+- starter integration workflow
+- offscreen preview handles available
+- screenshot/readback available
+- debug draw + debug HUD available
+
+### Vulkan-enabled build
+
+- `MONOLITH_ENGINE_ENABLE_VULKAN=ON`
+- configure/build succeeds without machine-global SDK import-lib assumptions
+- `test_renderer_foundation` validates:
+  - support reporting
+  - deterministic failure without native window handle
+  - real hidden-window bootstrap
+  - swapchain init + clear + present
+  - opaque-scene submission acceptance
+- `test_editor` validates seam behavior under unsupported editor/debug/readback capabilities
+
+## Required Validation Commands
+
+### Default build
+
+```bash
+cmake --build --preset debug-msvc --target test_core test_renderer_foundation test_architecture_docs test_editor
+ctest --test-dir build/debug-msvc -C Debug --output-on-failure -R "test_core|test_renderer_foundation|test_architecture_docs|test_editor"
+```
+
+### Vulkan-enabled build
+
+```bash
+cmake -S . -B build/debug-msvc-vulkan-tests -G "Visual Studio 17 2022" -A x64 -DMONOLITH_ENGINE_ENABLE_VULKAN=ON -DMONOLITH_ENGINE_BUILD_TESTS=ON
+cmake --build build/debug-msvc-vulkan-tests --config Debug --target test_renderer_foundation test_architecture_docs test_editor
+ctest --test-dir build/debug-msvc-vulkan-tests -C Debug --output-on-failure -R "test_renderer_foundation|test_architecture_docs|test_editor"
+```
+
+## CI Expectations
+
+- default OpenGL contract coverage stays mandatory in hosted CI
+- starter integration remains the downstream compatibility gate for renderer changes
+- Vulkan-enabled validation remains branch/PR-local for now, but any Vulkan/parity PR must include the command results above in its validation notes
+
+## Known Gaps
+
+- Vulkan editor rendering is still seam-level, not full visual parity
+- debug HUD/readback behavior on Vulkan is currently fallback-only through capabilities
+- parity matrix coverage will expand again once editor rendering and readback implementations land

--- a/docs/development/backend-parity-validation-matrix.md
+++ b/docs/development/backend-parity-validation-matrix.md
@@ -11,7 +11,10 @@ These tests protect backend-neutral engine contracts and should remain green reg
   - frame/pass lifecycle invariants
   - capability reporting
   - unsupported backend request handling
-  - Vulkan bootstrap / opaque-scene submission smoke path when enabled
+  - Vulkan bootstrap / opaque-scene real indexed draw execution-or-diagnostics path when enabled
+  - Vulkan offscreen target lifecycle + handle metadata + resize generation validation
+  - Vulkan editor viewport target provisioning + per-frame stability + resize generation validation
+  - Vulkan color/depth readback capability-gated success/failure diagnostics
 - `test_architecture_docs`
   - architecture document discoverability
   - backend-boundary guardrails in higher-level code
@@ -41,7 +44,9 @@ These tests protect backend-neutral engine contracts and should remain green reg
   - real hidden-window bootstrap
   - swapchain init + clear + present
   - opaque-scene submission acceptance
+  - offscreen render-target create/resize/destroy metadata stability
 - `test_editor` validates seam behavior under unsupported editor/debug/readback capabilities
+  and keeps OpenGL-oriented editor behavior stable
 
 ## Required Validation Commands
 
@@ -68,6 +73,5 @@ ctest --test-dir build/debug-msvc-vulkan-tests -C Debug --output-on-failure -R "
 
 ## Known Gaps
 
-- Vulkan editor rendering is still seam-level, not full visual parity
-- debug HUD/readback behavior on Vulkan is currently fallback-only through capabilities
-- parity matrix coverage will expand again once editor rendering and readback implementations land
+- debug HUD parity on Vulkan remains capability-gated while richer tooling panels mature
+- broader Vulkan-enabled CI coverage remains branch/PR-local until hosted-runner stability is proven

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -14,68 +14,77 @@
 #include <imgui_impl_vulkan.h>
 #endif
 
-namespace Monolith::Editor {
+namespace Monolith::Editor
+{
 
-namespace {
+  namespace
+  {
 
 #if defined(MONOLITH_HAS_VULKAN)
-struct VulkanImGuiState {
-  VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
-  bool initialized = false;
-};
+    struct VulkanImGuiState
+    {
+      VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+      bool initialized = false;
+      uint32_t minImageCount = 0;
+    };
 
-VulkanImGuiState g_vulkanImGuiState;
+    VulkanImGuiState g_vulkanImGuiState;
 
-VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device) {
-  const VkDescriptorPoolSize poolSizes[] = {
-      {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
-      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
-      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
-      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
-      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
-      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
-      {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
-  };
+    VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device)
+    {
+      const VkDescriptorPoolSize poolSizes[] = {
+          {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
+          {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
+          {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
+          {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
+          {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
+          {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
+          {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
+      };
 
-  const VkDescriptorPoolCreateInfo poolInfo{
-      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-      .maxSets = 512,
-      .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
-      .pPoolSizes = poolSizes,
-  };
+      const VkDescriptorPoolCreateInfo poolInfo{
+          .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+          .maxSets = 512,
+          .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
+          .pPoolSizes = poolSizes,
+      };
 
-  VkDescriptorPool pool = VK_NULL_HANDLE;
-  if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
-    return VK_NULL_HANDLE;
-  return pool;
-}
+      VkDescriptorPool pool = VK_NULL_HANDLE;
+      if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
+        return VK_NULL_HANDLE;
+      return pool;
+    }
 
-void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
-  if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
-    return;
-  vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
-  g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
-}
+    void DestroyVulkanImGuiDescriptorPool(VkDevice device)
+    {
+      if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+        return;
+      vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
+      g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
+    }
 
-void RenderVulkanImGuiDrawDataCallback(void* userData, void* commandBufferHandle) {
-  if (userData == nullptr || commandBufferHandle == nullptr)
-    return;
+    void RenderVulkanImGuiDrawDataCallback(void *userData, void *commandBufferHandle)
+    {
+      if (userData == nullptr || commandBufferHandle == nullptr)
+        return;
 
-  ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData*>(userData),
-                                  reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
-}
+      ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData *>(userData),
+                                      reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+    }
 #endif
 
-}  // namespace
+  } // namespace
 
-bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
-  switch (backendId) {
+  bool IsSupportedEditorImGuiBackend(RenderBackendId backendId)
+  {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       return true;
@@ -85,32 +94,35 @@ bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
 #else
       return false;
 #endif
+    }
+
+    return false;
   }
 
-  return false;
-}
+  bool InitEditorImGuiBackend(GLFWwindow *window, RenderBackendId backendId)
+  {
+    if (!window || !IsSupportedEditorImGuiBackend(backendId))
+      return false;
 
-bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
-  if (!window || !IsSupportedEditorImGuiBackend(backendId))
-    return false;
-
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplGlfw_InitForOpenGL(window, true);
       ImGui_ImplOpenGL3_Init("#version 410");
       return true;
-    case RenderBackendId::Vulkan: {
+    case RenderBackendId::Vulkan:
+    {
 #if defined(MONOLITH_HAS_VULKAN)
-      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
       if (!backend)
         return false;
 
-      void* instanceHandle = nullptr;
-      void* physicalDeviceHandle = nullptr;
-      void* deviceHandle = nullptr;
-      void* queueHandle = nullptr;
-      void* renderPassHandle = nullptr;
+      void *instanceHandle = nullptr;
+      void *physicalDeviceHandle = nullptr;
+      void *deviceHandle = nullptr;
+      void *queueHandle = nullptr;
+      void *renderPassHandle = nullptr;
       uint32_t queueFamily = 0;
       uint32_t imageCount = 0;
       if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
@@ -119,18 +131,21 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
                                               &queueFamily,
                                               &queueHandle,
                                               &renderPassHandle,
-                                              &imageCount)) {
+                                              &imageCount))
+      {
         return false;
       }
 
       const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
-      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE) {
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+      {
         g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
       }
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
         return false;
 
-      if (!ImGui_ImplGlfw_InitForVulkan(window, true)) {
+      if (!ImGui_ImplGlfw_InitForVulkan(window, true))
+      {
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
@@ -149,34 +164,39 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
       initInfo.Subpass = 0;
       initInfo.UseDynamicRendering = false;
 
-      if (!ImGui_ImplVulkan_Init(&initInfo)) {
+      if (!ImGui_ImplVulkan_Init(&initInfo))
+      {
         ImGui_ImplGlfw_Shutdown();
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
 
       g_vulkanImGuiState.initialized = true;
+      g_vulkanImGuiState.minImageCount = initInfo.MinImageCount;
       return true;
 #else
       return false;
 #endif
     }
+    }
+
+    return false;
   }
 
-  return false;
-}
+  void ShutdownEditorImGuiBackend(RenderBackendId backendId)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId))
+      return;
 
-void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
-  if (!IsSupportedEditorImGuiBackend(backendId))
-    return;
-
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_Shutdown();
       ImGui_ImplGlfw_Shutdown();
       return;
-    case RenderBackendId::Vulkan: {
+    case RenderBackendId::Vulkan:
+    {
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
@@ -184,31 +204,36 @@ void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
       ImGui_ImplVulkan_Shutdown();
       ImGui_ImplGlfw_Shutdown();
       g_vulkanImGuiState.initialized = false;
+      g_vulkanImGuiState.minImageCount = 0;
 
-      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
-      if (backend) {
-        void* deviceHandle = nullptr;
+      auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
+      if (backend)
+      {
+        void *deviceHandle = nullptr;
         if (backend->TryGetImGuiVulkanInitData(nullptr,
-                                              nullptr,
-                                              &deviceHandle,
-                                              nullptr,
-                                              nullptr,
-                                              nullptr,
-                                              nullptr)) {
+                                               nullptr,
+                                               &deviceHandle,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr))
+        {
           DestroyVulkanImGuiDescriptorPool(reinterpret_cast<VkDevice>(deviceHandle));
         }
       }
 #endif
       return;
     }
+    }
   }
-}
 
-void BeginEditorImGuiFrame(RenderBackendId backendId) {
-  if (!IsSupportedEditorImGuiBackend(backendId))
-    return;
+  void BeginEditorImGuiFrame(RenderBackendId backendId)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId))
+      return;
 
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_NewFrame();
@@ -218,18 +243,41 @@ void BeginEditorImGuiFrame(RenderBackendId backendId) {
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
+
+      if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
+      {
+        uint32_t imageCount = 0;
+        if (backend->TryGetImGuiVulkanInitData(nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               nullptr,
+                                               &imageCount))
+        {
+          const uint32_t minImageCount = std::max(2u, imageCount);
+          if (minImageCount != g_vulkanImGuiState.minImageCount)
+          {
+            ImGui_ImplVulkan_SetMinImageCount(minImageCount);
+            g_vulkanImGuiState.minImageCount = minImageCount;
+          }
+        }
+      }
+
       ImGui_ImplVulkan_NewFrame();
       ImGui_ImplGlfw_NewFrame();
 #endif
       return;
+    }
   }
-}
 
-void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) {
-  if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
-    return;
+  void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData *drawData)
+  {
+    if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
+      return;
 
-  switch (backendId) {
+    switch (backendId)
+    {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
       ImGui_ImplOpenGL3_RenderDrawData(drawData);
@@ -238,12 +286,13 @@ void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) 
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
-      if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
+      if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
+      {
         backend->QueueOverlayRenderCallback(&RenderVulkanImGuiDrawDataCallback, drawData);
       }
 #endif
       return;
+    }
   }
-}
 
-}  // namespace Monolith::Editor
+} // namespace Monolith::Editor

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -24,6 +24,7 @@ namespace Monolith::Editor
     struct VulkanImGuiState
     {
       VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+      VkRenderPass renderPass = VK_NULL_HANDLE;
       bool initialized = false;
       uint32_t minImageCount = 0;
     };
@@ -77,6 +78,52 @@ namespace Monolith::Editor
       ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData *>(userData),
                                       reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
     }
+
+    bool TryBuildVulkanImGuiInitInfo(VulkanRenderBackend *backend,
+                                     ImGui_ImplVulkan_InitInfo *outInitInfo,
+                                     uint32_t *outMinImageCount,
+                                     VkRenderPass *outRenderPass)
+    {
+      if (!backend || !outInitInfo || !outMinImageCount || !outRenderPass)
+        return false;
+
+      void *instanceHandle = nullptr;
+      void *physicalDeviceHandle = nullptr;
+      void *deviceHandle = nullptr;
+      void *queueHandle = nullptr;
+      void *renderPassHandle = nullptr;
+      uint32_t queueFamily = 0;
+      uint32_t imageCount = 0;
+      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
+                                              &physicalDeviceHandle,
+                                              &deviceHandle,
+                                              &queueFamily,
+                                              &queueHandle,
+                                              &renderPassHandle,
+                                              &imageCount))
+      {
+        return false;
+      }
+
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
+      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
+      initInfo.Device = reinterpret_cast<VkDevice>(deviceHandle);
+      initInfo.QueueFamily = queueFamily;
+      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
+      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
+      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
+      initInfo.MinImageCount = std::max(2u, imageCount);
+      initInfo.ImageCount = std::max(2u, imageCount);
+      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+      initInfo.Subpass = 0;
+      initInfo.UseDynamicRendering = false;
+
+      *outInitInfo = initInfo;
+      *outMinImageCount = initInfo.MinImageCount;
+      *outRenderPass = initInfo.RenderPass;
+      return true;
+    }
 #endif
 
   } // namespace
@@ -118,25 +165,13 @@ namespace Monolith::Editor
       if (!backend)
         return false;
 
-      void *instanceHandle = nullptr;
-      void *physicalDeviceHandle = nullptr;
-      void *deviceHandle = nullptr;
-      void *queueHandle = nullptr;
-      void *renderPassHandle = nullptr;
-      uint32_t queueFamily = 0;
-      uint32_t imageCount = 0;
-      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
-                                              &physicalDeviceHandle,
-                                              &deviceHandle,
-                                              &queueFamily,
-                                              &queueHandle,
-                                              &renderPassHandle,
-                                              &imageCount))
-      {
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      uint32_t minImageCount = 0;
+      VkRenderPass renderPass = VK_NULL_HANDLE;
+      if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
         return false;
-      }
 
-      const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
+      const VkDevice device = initInfo.Device;
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
       {
         g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
@@ -144,25 +179,14 @@ namespace Monolith::Editor
       if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
         return false;
 
+      if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
+        return false;
+
       if (!ImGui_ImplGlfw_InitForVulkan(window, true))
       {
         DestroyVulkanImGuiDescriptorPool(device);
         return false;
       }
-
-      ImGui_ImplVulkan_InitInfo initInfo{};
-      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
-      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
-      initInfo.Device = device;
-      initInfo.QueueFamily = queueFamily;
-      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
-      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
-      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
-      initInfo.MinImageCount = std::max(2u, imageCount);
-      initInfo.ImageCount = std::max(2u, imageCount);
-      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
-      initInfo.Subpass = 0;
-      initInfo.UseDynamicRendering = false;
 
       if (!ImGui_ImplVulkan_Init(&initInfo))
       {
@@ -172,7 +196,8 @@ namespace Monolith::Editor
       }
 
       g_vulkanImGuiState.initialized = true;
-      g_vulkanImGuiState.minImageCount = initInfo.MinImageCount;
+  g_vulkanImGuiState.minImageCount = minImageCount;
+  g_vulkanImGuiState.renderPass = renderPass;
       return true;
 #else
       return false;
@@ -205,6 +230,7 @@ namespace Monolith::Editor
       ImGui_ImplGlfw_Shutdown();
       g_vulkanImGuiState.initialized = false;
       g_vulkanImGuiState.minImageCount = 0;
+      g_vulkanImGuiState.renderPass = VK_NULL_HANDLE;
 
       auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
       if (backend)
@@ -246,21 +272,29 @@ namespace Monolith::Editor
 
       if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
       {
-        uint32_t imageCount = 0;
-        if (backend->TryGetImGuiVulkanInitData(nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               nullptr,
-                                               &imageCount))
+        ImGui_ImplVulkan_InitInfo initInfo{};
+        uint32_t minImageCount = 0;
+        VkRenderPass renderPass = VK_NULL_HANDLE;
+        if (!TryBuildVulkanImGuiInitInfo(backend, &initInfo, &minImageCount, &renderPass))
+          return;
+
+        if (renderPass != g_vulkanImGuiState.renderPass)
         {
-          const uint32_t minImageCount = std::max(2u, imageCount);
-          if (minImageCount != g_vulkanImGuiState.minImageCount)
+          ImGui_ImplVulkan_Shutdown();
+          if (!ImGui_ImplVulkan_Init(&initInfo))
           {
-            ImGui_ImplVulkan_SetMinImageCount(minImageCount);
-            g_vulkanImGuiState.minImageCount = minImageCount;
+            g_vulkanImGuiState.initialized = false;
+            g_vulkanImGuiState.minImageCount = 0;
+            g_vulkanImGuiState.renderPass = VK_NULL_HANDLE;
+            return;
           }
+          g_vulkanImGuiState.renderPass = renderPass;
+          g_vulkanImGuiState.minImageCount = minImageCount;
+        }
+        else if (minImageCount != g_vulkanImGuiState.minImageCount)
+        {
+          ImGui_ImplVulkan_SetMinImageCount(minImageCount);
+          g_vulkanImGuiState.minImageCount = minImageCount;
         }
       }
 
@@ -285,6 +319,8 @@ namespace Monolith::Editor
     case RenderBackendId::Vulkan:
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
+        return;
+      if (!Renderer::IsFrameActive())
         return;
       if (auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop()))
       {

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -196,8 +196,8 @@ namespace Monolith::Editor
       }
 
       g_vulkanImGuiState.initialized = true;
-  g_vulkanImGuiState.minImageCount = minImageCount;
-  g_vulkanImGuiState.renderPass = renderPass;
+      g_vulkanImGuiState.minImageCount = minImageCount;
+      g_vulkanImGuiState.renderPass = renderPass;
       return true;
 #else
       return false;

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -1,0 +1,54 @@
+#include "editor/EditorImGuiBackend.h"
+
+#include <GLFW/glfw3.h>
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+
+namespace Monolith::Editor {
+
+bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      return true;
+    case RenderBackendId::Vulkan:
+      return false;
+  }
+
+  return false;
+}
+
+bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
+  if (!window || !IsSupportedEditorImGuiBackend(backendId))
+    return false;
+
+  ImGui_ImplGlfw_InitForOpenGL(window, true);
+  ImGui_ImplOpenGL3_Init("#version 410");
+  return true;
+}
+
+void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
+  if (!IsSupportedEditorImGuiBackend(backendId))
+    return;
+
+  ImGui_ImplOpenGL3_Shutdown();
+  ImGui_ImplGlfw_Shutdown();
+}
+
+void BeginEditorImGuiFrame(RenderBackendId backendId) {
+  if (!IsSupportedEditorImGuiBackend(backendId))
+    return;
+
+  ImGui_ImplOpenGL3_NewFrame();
+  ImGui_ImplGlfw_NewFrame();
+}
+
+void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) {
+  if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
+    return;
+
+  ImGui_ImplOpenGL3_RenderDrawData(drawData);
+}
+
+}  // namespace Monolith::Editor

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -1,11 +1,70 @@
 #include "editor/EditorImGuiBackend.h"
 
+#include <algorithm>
+
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 
+#include "renderer/Renderer.h"
+#include "renderer/VulkanRenderBackend.h"
+
+#if defined(MONOLITH_HAS_VULKAN)
+#include <imgui_impl_vulkan.h>
+#endif
+
 namespace Monolith::Editor {
+
+namespace {
+
+#if defined(MONOLITH_HAS_VULKAN)
+struct VulkanImGuiState {
+  VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+  bool initialized = false;
+};
+
+VulkanImGuiState g_vulkanImGuiState;
+
+VkDescriptorPool CreateVulkanImGuiDescriptorPool(VkDevice device) {
+  const VkDescriptorPoolSize poolSizes[] = {
+      {VK_DESCRIPTOR_TYPE_SAMPLER, 64},
+      {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
+      {VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 64},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 64},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 128},
+      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 128},
+      {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 64},
+      {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 64},
+      {VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 64},
+  };
+
+  const VkDescriptorPoolCreateInfo poolInfo{
+      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+      .maxSets = 512,
+      .poolSizeCount = static_cast<uint32_t>(std::size(poolSizes)),
+      .pPoolSizes = poolSizes,
+  };
+
+  VkDescriptorPool pool = VK_NULL_HANDLE;
+  if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &pool) != VK_SUCCESS)
+    return VK_NULL_HANDLE;
+  return pool;
+}
+
+void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
+  if (device == VK_NULL_HANDLE || g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+    return;
+  vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
+  g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
+}
+#endif
+
+}  // namespace
 
 bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
   switch (backendId) {
@@ -13,7 +72,11 @@ bool IsSupportedEditorImGuiBackend(RenderBackendId backendId) {
     case RenderBackendId::OpenGL:
       return true;
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      return true;
+#else
       return false;
+#endif
   }
 
   return false;
@@ -23,32 +86,165 @@ bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId) {
   if (!window || !IsSupportedEditorImGuiBackend(backendId))
     return false;
 
-  ImGui_ImplGlfw_InitForOpenGL(window, true);
-  ImGui_ImplOpenGL3_Init("#version 410");
-  return true;
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplGlfw_InitForOpenGL(window, true);
+      ImGui_ImplOpenGL3_Init("#version 410");
+      return true;
+    case RenderBackendId::Vulkan: {
+#if defined(MONOLITH_HAS_VULKAN)
+      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      if (!backend)
+        return false;
+
+      void* instanceHandle = nullptr;
+      void* physicalDeviceHandle = nullptr;
+      void* deviceHandle = nullptr;
+      void* queueHandle = nullptr;
+      void* renderPassHandle = nullptr;
+      uint32_t queueFamily = 0;
+      uint32_t imageCount = 0;
+      if (!backend->TryGetImGuiVulkanInitData(&instanceHandle,
+                                              &physicalDeviceHandle,
+                                              &deviceHandle,
+                                              &queueFamily,
+                                              &queueHandle,
+                                              &renderPassHandle,
+                                              &imageCount)) {
+        return false;
+      }
+
+      const VkDevice device = reinterpret_cast<VkDevice>(deviceHandle);
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE) {
+        g_vulkanImGuiState.descriptorPool = CreateVulkanImGuiDescriptorPool(device);
+      }
+      if (g_vulkanImGuiState.descriptorPool == VK_NULL_HANDLE)
+        return false;
+
+      if (!ImGui_ImplGlfw_InitForVulkan(window, true)) {
+        DestroyVulkanImGuiDescriptorPool(device);
+        return false;
+      }
+
+      ImGui_ImplVulkan_InitInfo initInfo{};
+      initInfo.Instance = reinterpret_cast<VkInstance>(instanceHandle);
+      initInfo.PhysicalDevice = reinterpret_cast<VkPhysicalDevice>(physicalDeviceHandle);
+      initInfo.Device = device;
+      initInfo.QueueFamily = queueFamily;
+      initInfo.Queue = reinterpret_cast<VkQueue>(queueHandle);
+      initInfo.DescriptorPool = g_vulkanImGuiState.descriptorPool;
+      initInfo.RenderPass = reinterpret_cast<VkRenderPass>(renderPassHandle);
+      initInfo.MinImageCount = std::max(2u, imageCount);
+      initInfo.ImageCount = std::max(2u, imageCount);
+      initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+      initInfo.Subpass = 0;
+      initInfo.UseDynamicRendering = false;
+
+      if (!ImGui_ImplVulkan_Init(&initInfo)) {
+        ImGui_ImplGlfw_Shutdown();
+        DestroyVulkanImGuiDescriptorPool(device);
+        return false;
+      }
+
+      g_vulkanImGuiState.initialized = true;
+      return true;
+#else
+      return false;
+#endif
+    }
+  }
+
+  return false;
 }
 
 void ShutdownEditorImGuiBackend(RenderBackendId backendId) {
   if (!IsSupportedEditorImGuiBackend(backendId))
     return;
 
-  ImGui_ImplOpenGL3_Shutdown();
-  ImGui_ImplGlfw_Shutdown();
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_Shutdown();
+      ImGui_ImplGlfw_Shutdown();
+      return;
+    case RenderBackendId::Vulkan: {
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+
+      ImGui_ImplVulkan_Shutdown();
+      ImGui_ImplGlfw_Shutdown();
+      g_vulkanImGuiState.initialized = false;
+
+      auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop());
+      if (backend) {
+        void* deviceHandle = nullptr;
+        if (backend->TryGetImGuiVulkanInitData(nullptr,
+                                              nullptr,
+                                              &deviceHandle,
+                                              nullptr,
+                                              nullptr,
+                                              nullptr,
+                                              nullptr)) {
+          DestroyVulkanImGuiDescriptorPool(reinterpret_cast<VkDevice>(deviceHandle));
+        }
+      }
+#endif
+      return;
+    }
+  }
 }
 
 void BeginEditorImGuiFrame(RenderBackendId backendId) {
   if (!IsSupportedEditorImGuiBackend(backendId))
     return;
 
-  ImGui_ImplOpenGL3_NewFrame();
-  ImGui_ImplGlfw_NewFrame();
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_NewFrame();
+      ImGui_ImplGlfw_NewFrame();
+      return;
+    case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+      ImGui_ImplVulkan_NewFrame();
+      ImGui_ImplGlfw_NewFrame();
+#endif
+      return;
+  }
 }
 
 void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) {
   if (!IsSupportedEditorImGuiBackend(backendId) || !drawData)
     return;
 
-  ImGui_ImplOpenGL3_RenderDrawData(drawData);
+  switch (backendId) {
+    case RenderBackendId::Auto:
+    case RenderBackendId::OpenGL:
+      ImGui_ImplOpenGL3_RenderDrawData(drawData);
+      return;
+    case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      if (!g_vulkanImGuiState.initialized)
+        return;
+
+      // Vulkan draw data submission requires an active recording command buffer.
+      if (!Renderer::IsPassActive())
+        return;
+
+      if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
+        void* commandBufferHandle = backend->GetActiveCommandBufferHandle();
+        if (commandBufferHandle != nullptr) {
+          ImGui_ImplVulkan_RenderDrawData(drawData,
+                                          reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+        }
+      }
+#endif
+      return;
+  }
 }
 
 }  // namespace Monolith::Editor

--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -62,6 +62,14 @@ void DestroyVulkanImGuiDescriptorPool(VkDevice device) {
   vkDestroyDescriptorPool(device, g_vulkanImGuiState.descriptorPool, nullptr);
   g_vulkanImGuiState.descriptorPool = VK_NULL_HANDLE;
 }
+
+void RenderVulkanImGuiDrawDataCallback(void* userData, void* commandBufferHandle) {
+  if (userData == nullptr || commandBufferHandle == nullptr)
+    return;
+
+  ImGui_ImplVulkan_RenderDrawData(reinterpret_cast<ImDrawData*>(userData),
+                                  reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
+}
 #endif
 
 }  // namespace
@@ -230,17 +238,8 @@ void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData) 
 #if defined(MONOLITH_HAS_VULKAN)
       if (!g_vulkanImGuiState.initialized)
         return;
-
-      // Vulkan draw data submission requires an active recording command buffer.
-      if (!Renderer::IsPassActive())
-        return;
-
       if (auto* backend = dynamic_cast<VulkanRenderBackend*>(Renderer::GetBackendForInterop())) {
-        void* commandBufferHandle = backend->GetActiveCommandBufferHandle();
-        if (commandBufferHandle != nullptr) {
-          ImGui_ImplVulkan_RenderDrawData(drawData,
-                                          reinterpret_cast<VkCommandBuffer>(commandBufferHandle));
-        }
+        backend->QueueOverlayRenderCallback(&RenderVulkanImGuiDrawDataCallback, drawData);
       }
 #endif
       return;

--- a/editor/EditorImGuiBackend.h
+++ b/editor/EditorImGuiBackend.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "renderer/RenderBackend.h"
+
+struct GLFWwindow;
+struct ImDrawData;
+
+namespace Monolith::Editor {
+
+bool IsSupportedEditorImGuiBackend(RenderBackendId backendId);
+bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId);
+void ShutdownEditorImGuiBackend(RenderBackendId backendId);
+void BeginEditorImGuiFrame(RenderBackendId backendId);
+void RenderEditorImGuiDrawData(RenderBackendId backendId, ImDrawData* drawData);
+
+}  // namespace Monolith::Editor

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -1081,6 +1081,10 @@ static bool TryGetAssetPreviewHandle(const std::string& assetId,
     return false;
   *outHandle = {};
 
+  const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+  if (!caps.supportsNativeTextureHandles)
+    return false;
+
   static std::unordered_map<std::string, Texture> s_textureByPath;
   static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
   static std::unordered_set<std::string> s_noPreviewCache;
@@ -1090,7 +1094,7 @@ static bool TryGetAssetPreviewHandle(const std::string& assetId,
     return false;
 
   auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
-    if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
+    if (!caps.supportsNativeTextureHandles)
       return {};
     if (path.empty())
       return {};
@@ -1109,7 +1113,7 @@ static bool TryGetAssetPreviewHandle(const std::string& assetId,
   };
 
   // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
-  if (!asset.mesh.empty()) {
+  if (caps.supportsOffscreenTargets && !asset.mesh.empty()) {
     auto& thumbnailRenderer = AssetThumbnailRenderer::Instance();
     if (thumbnailRenderer.Init()) {
       if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -993,6 +993,10 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 // meshKey must be the resolved mesh path (same key used in meshCache).
 static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
                                           const std::string& meshKey) {
+  const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+  if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
+    return 0;
+
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
@@ -1090,6 +1094,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
     return false;
 
   auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+    if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
+      return 0;
     if (path.empty())
       return 0;
     std::error_code ec;
@@ -3052,6 +3058,9 @@ void EditorLayer::DrawSettingsModal() {
 void EditorLayer::DrawViewGimbal(const Camera& cam) {
   ImGuiIO& io = ImGui::GetIO();
   const EditorViewGimbalMetrics& metrics = GetEditorViewGimbalMetrics();
+  const bool supportsWireframeOverlay = Renderer::GetBackendCapabilities().supportsWireframeOverlay;
+  if (!supportsWireframeOverlay)
+    m_wireframeMode = false;
   const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
   const EditorViewGimbalLayout layout =
       BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
@@ -3075,15 +3084,23 @@ void EditorLayer::DrawViewGimbal(const Camera& cam) {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.55f, 0.15f, 0.90f));
   else
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.22f, 0.30f, 0.80f));
+  if (!supportsWireframeOverlay)
+    ImGui::BeginDisabled();
   if (ImGui::Button("##wire_btn_toggle", ImVec2(metrics.buttonSize, metrics.buttonSize)))
     m_wireframeMode = !m_wireframeMode;
+  if (!supportsWireframeOverlay)
+    ImGui::EndDisabled();
   ImGui::PopStyleColor();
   dl->AddText(ImVec2(layout.wireButtonRect.minX + metrics.titleOffsetX,
                      layout.wireButtonRect.minY + metrics.titleOffsetY),
               IM_COL32(230, 235, 245, 255),
               "[W]");
-  if (ImGui::IsItemHovered())
-    ImGui::SetTooltip("Toggle Wireframe");
+  if (ImGui::IsItemHovered()) {
+    if (supportsWireframeOverlay)
+      ImGui::SetTooltip("Toggle Wireframe");
+    else
+      ImGui::SetTooltip("Wireframe overlay is unavailable on the active render backend");
+  }
 
   m_viewGizmoPickRect.valid = true;
   m_viewGizmoPickRect.minX = layout.pickRect.minX;
@@ -6869,6 +6886,11 @@ void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
 // ---- Wireframe overlay -------------------------------------------------------
 
 void EditorLayer::DrawWireframeOverlay(const Camera& cam) {
+  if (!Renderer::GetBackendCapabilities().supportsWireframeOverlay) {
+    m_wireframeMode = false;
+    return;
+  }
+
   if (!m_wireframeMode || !m_wireframeShader.IsValid())
     return;
 

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -1171,9 +1171,19 @@ static bool TryGetAssetPreviewHandle(const std::string& assetId,
 }
 
 static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
-  if (!handle.IsValid() || handle.nativeType != RenderNativeHandleType::OpenGLTexture2D)
+  if (!handle.IsValid())
     return (ImTextureID)0;
-  return (ImTextureID)(intptr_t)handle.nativeHandle;
+
+  switch (handle.nativeType) {
+    case RenderNativeHandleType::OpenGLTexture2D:
+      return (ImTextureID)(intptr_t)handle.nativeHandle;
+    case RenderNativeHandleType::VulkanImGuiDescriptorSet:
+      return (ImTextureID)(intptr_t)handle.nativeHandle;
+    case RenderNativeHandleType::None:
+      return (ImTextureID)0;
+  }
+
+  return (ImTextureID)0;
 }
 
 std::string PickTextureFilePath() {

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -63,6 +63,9 @@
 #include "renderer/Shader.h"
 #include "renderer/SkinnedMesh.h"
 #include "renderer/Texture.h"
+#if defined(MONOLITH_HAS_VULKAN)
+#include "renderer/VulkanRenderBackend.h"
+#endif
 #include "scene/Entity.h"
 #include "scene/Registry.h"
 #include "scene/SceneRuntimeConversion.h"
@@ -70,3330 +73,2610 @@
 #include "scene/components/PlayerTagComponent.h"
 #include "scene/components/TransformComponent.h"
 
-namespace Monolith {
-namespace Editor {
+namespace Monolith
+{
+  namespace Editor
+  {
 
-namespace {
+    namespace
+    {
 
-// Must match DrawToolbar / DrawStatusBar so left-column windows do not overlap each other
-// or the status strip.
-constexpr float kEditorToolbarH = 36.0f;
-constexpr float kEditorStatusH = 24.0f;
-constexpr float kHierarchySectionRatio = 0.56f;
-constexpr char kEditorHierarchyWindow[] = "Hierarchy";
-constexpr char kEditorAssetsWindow[] = "Assets";
-constexpr char kEditorWorkspaceWindow[] = "Workspace";
-constexpr char kEditorPropertiesWindow[] = "Properties";
-constexpr char kEditorViewportWindow[] = "Viewport";
-// Avoid re-reading directories every ImGui frame (Windows "not responding" on large trees).
-constexpr uint32_t kProjectListingCacheFrames = 48;
-constexpr size_t kMaxEditorHistorySnapshots = 128;
+      // Must match DrawToolbar / DrawStatusBar so left-column windows do not overlap each other
+      // or the status strip.
+      constexpr float kEditorToolbarH = 36.0f;
+      constexpr float kEditorStatusH = 24.0f;
+      constexpr float kHierarchySectionRatio = 0.56f;
+      constexpr char kEditorHierarchyWindow[] = "Hierarchy";
+      constexpr char kEditorAssetsWindow[] = "Assets";
+      constexpr char kEditorWorkspaceWindow[] = "Workspace";
+      constexpr char kEditorPropertiesWindow[] = "Properties";
+      constexpr char kEditorViewportWindow[] = "Viewport";
+      // Avoid re-reading directories every ImGui frame (Windows "not responding" on large trees).
+      constexpr uint32_t kProjectListingCacheFrames = 48;
+      constexpr size_t kMaxEditorHistorySnapshots = 128;
 
-std::string BuildIssueKey(const std::string& severity,
-                          const std::string& path,
-                          const std::string& message) {
-  return severity + "\n" + path + "\n" + message;
-}
-
-std::string BuildIssueSeverityText(SceneProjectValidationIssue::Severity severity) {
-  return severity == SceneProjectValidationIssue::Severity::Error ? "error" : "warning";
-}
-
-std::string BuildIssueSeverityText(RuntimeSceneBuildIssue::Severity severity) {
-  return severity == RuntimeSceneBuildIssue::Severity::Error ? "error" : "warning";
-}
-
-Mcp::McpBuildSnapshot BuildMcpBuildSnapshot(const SceneDocument& document) {
-  Mcp::McpBuildSnapshot snapshot;
-  snapshot.available = true;
-
-  const SceneProjectModel model = BuildSceneProjectModel(document);
-  snapshot.assetCount = model.scene.assets.size();
-  snapshot.nodeCount = model.scene.nodes.size();
-
-  const SceneProjectValidationResult validation = ValidateSceneProjectModel(model);
-  std::unordered_set<std::string> validationIssueKeys;
-  for (const SceneProjectValidationIssue& issue : validation.issues) {
-    const std::string severity = BuildIssueSeverityText(issue.severity);
-    validationIssueKeys.insert(BuildIssueKey(severity, issue.path, issue.message));
-    if (issue.severity == SceneProjectValidationIssue::Severity::Error)
-      ++snapshot.sceneValidationErrors;
-    else
-      ++snapshot.sceneValidationWarnings;
-    snapshot.issues.push_back(Mcp::McpBuildIssueSnapshot{"validation", severity, issue.path, issue.message});
-  }
-
-  const RuntimeSceneBuildResult runtimeBuild = Monolith::BuildRuntimeSceneDefinition(model);
-  snapshot.roomCount = runtimeBuild.definition.rooms.size();
-  snapshot.lightCount = runtimeBuild.definition.lights.size();
-  snapshot.hasSceneCamera = runtimeBuild.definition.sceneCamera.has_value();
-  for (const RuntimeSceneRoom& room : runtimeBuild.definition.rooms) {
-    snapshot.panelCount += room.panels.size();
-    snapshot.propCount += room.props.size();
-  }
-
-  for (const RuntimeSceneBuildIssue& issue : runtimeBuild.issues) {
-    const std::string severity = BuildIssueSeverityText(issue.severity);
-    if (validationIssueKeys.count(BuildIssueKey(severity, issue.path, issue.message)) != 0)
-      continue;
-    if (issue.severity == RuntimeSceneBuildIssue::Severity::Error)
-      ++snapshot.runtimeBuildErrors;
-    else
-      ++snapshot.runtimeBuildWarnings;
-    snapshot.issues.push_back(Mcp::McpBuildIssueSnapshot{"runtime", severity, issue.path, issue.message});
-  }
-
-  const size_t totalErrors = snapshot.sceneValidationErrors + snapshot.runtimeBuildErrors;
-  const size_t totalWarnings = snapshot.sceneValidationWarnings + snapshot.runtimeBuildWarnings;
-  snapshot.status = totalErrors > 0 ? "error" : totalWarnings > 0 ? "warning" : "ok";
-  return snapshot;
-}
-
-const char* FieldWidgetToString(FieldDef::Widget widget) {
-  switch (widget) {
-    case FieldDef::Widget::Float:
-      return "float";
-    case FieldDef::Widget::Bool:
-      return "bool";
-    case FieldDef::Widget::Enum:
-      return "enum";
-    case FieldDef::Widget::Color3:
-      return "color3";
-    case FieldDef::Widget::String:
-    default:
-      return "string";
-  }
-}
-
-Mcp::McpSchemaFieldSnapshot BuildMcpSchemaFieldSnapshot(const FieldDef& field) {
-  Mcp::McpSchemaFieldSnapshot snapshot;
-  snapshot.key = field.key;
-  snapshot.label = field.label;
-  snapshot.description = field.description;
-  snapshot.widget = FieldWidgetToString(field.widget);
-  snapshot.hasDefault = field.hasDefault;
-  snapshot.required = field.required;
-  snapshot.allowEmpty = field.allowEmpty;
-  snapshot.allowCustomValue = field.allowCustomValue;
-  snapshot.hasMin = field.hasMin;
-  snapshot.hasMax = field.hasMax;
-  snapshot.minVal = field.minVal;
-  snapshot.maxVal = field.maxVal;
-  snapshot.options = field.options;
-  snapshot.defaultValue = field.defaultValue;
-  return snapshot;
-}
-
-Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const TypeSchema& schema) {
-  Mcp::McpSchemaEntrySnapshot snapshot;
-  snapshot.kind = "object";
-  snapshot.name = schema.name;
-  snapshot.label = schema.label;
-  snapshot.appliesTo = schema.appliesTo;
-  snapshot.fields.reserve(schema.fields.size());
-  for (const FieldDef& field : schema.fields)
-    snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
-  return snapshot;
-}
-
-Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const ComponentSchema& schema) {
-  Mcp::McpSchemaEntrySnapshot snapshot;
-  snapshot.kind = "component";
-  snapshot.name = schema.name;
-  snapshot.label = schema.label;
-  snapshot.appliesTo = schema.appliesTo;
-  snapshot.fields.reserve(schema.fields.size());
-  for (const FieldDef& field : schema.fields)
-    snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
-  return snapshot;
-}
-
-Mcp::McpSchemaCatalogSnapshot BuildMcpSchemaCatalogSnapshot(const EditorSchema& schema) {
-  Mcp::McpSchemaCatalogSnapshot snapshot;
-
-  std::vector<std::string> typeNames;
-  typeNames.reserve(schema.TypeSchemas().size());
-  for (const auto& entry : schema.TypeSchemas())
-    typeNames.push_back(entry.first);
-  std::sort(typeNames.begin(), typeNames.end());
-  for (const std::string& typeName : typeNames)
-    snapshot.objectTypes.push_back(BuildMcpSchemaEntrySnapshot(schema.TypeSchemas().at(typeName)));
-
-  std::vector<std::string> componentTypes;
-  componentTypes.reserve(schema.ComponentSchemas().size());
-  for (const auto& entry : schema.ComponentSchemas())
-    componentTypes.push_back(entry.first);
-  std::sort(componentTypes.begin(), componentTypes.end());
-  for (const std::string& componentType : componentTypes)
-    snapshot.components.push_back(BuildMcpSchemaEntrySnapshot(schema.ComponentSchemas().at(componentType)));
-
-  return snapshot;
-}
-
-bool SchemaAppliesToObjectType(const std::vector<std::string>& appliesTo, SceneObjectType objectType) {
-  if (appliesTo.empty())
-    return true;
-  std::string typeName = "panel";
-  switch (objectType) {
-    case SceneObjectType::Prop:
-      typeName = "prop";
-      break;
-    case SceneObjectType::Light:
-      typeName = "light";
-      break;
-    case SceneObjectType::Camera:
-      typeName = "camera";
-      break;
-    case SceneObjectType::Panel:
-    default:
-      typeName = "panel";
-      break;
-  }
-  auto normalize = [](std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-      return static_cast<char>(std::tolower(c));
-    });
-    return value;
-  };
-  for (const std::string& entry : appliesTo) {
-    if (normalize(entry) == typeName)
-      return true;
-  }
-  return false;
-}
-
-bool AssetDefsEqual(const AssetDef& lhs, const AssetDef& rhs) {
-  return lhs.mesh == rhs.mesh &&
-         lhs.renderScale == rhs.renderScale &&
-         lhs.albedoMap == rhs.albedoMap &&
-         lhs.guid == rhs.guid &&
-         lhs.displayName == rhs.displayName;
-}
-
-bool ComponentDescsEqual(const ComponentDesc& lhs, const ComponentDesc& rhs) {
-  return lhs.type == rhs.type && lhs.props == rhs.props;
-}
-
-bool SceneObjectsEqual(const SceneObject& lhs, const SceneObject& rhs) {
-  const bool prefabEqual =
-      (!lhs.prefabInstance.has_value() && !rhs.prefabInstance.has_value()) ||
-      (lhs.prefabInstance.has_value() && rhs.prefabInstance.has_value() &&
-       lhs.prefabInstance->prefabId == rhs.prefabInstance->prefabId &&
-       lhs.prefabInstance->sourcePath == rhs.prefabInstance->sourcePath);
-  if (lhs.id != rhs.id ||
-      lhs.type != rhs.type ||
-      lhs.position.x != rhs.position.x ||
-      lhs.position.y != rhs.position.y ||
-      lhs.position.z != rhs.position.z ||
-      lhs.scale.x != rhs.scale.x ||
-      lhs.scale.y != rhs.scale.y ||
-      lhs.scale.z != rhs.scale.z ||
-      lhs.yaw != rhs.yaw ||
-      lhs.pitch != rhs.pitch ||
-      lhs.roll != rhs.roll ||
-      lhs.assetId != rhs.assetId ||
-      !prefabEqual ||
-      lhs.props != rhs.props ||
-      lhs.components.size() != rhs.components.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < lhs.components.size(); ++i) {
-    if (!ComponentDescsEqual(lhs.components[i], rhs.components[i]))
-      return false;
-  }
-  return true;
-}
-
-bool SceneDocumentsEqual(const SceneDocument& lhs, const SceneDocument& rhs) {
-  if (lhs.version != rhs.version ||
-      lhs.sceneId != rhs.sceneId ||
-      lhs.sceneName != rhs.sceneName ||
-      lhs.filePath != rhs.filePath ||
-      lhs.settings != rhs.settings ||
-      lhs.assets.size() != rhs.assets.size() ||
-      lhs.objects.size() != rhs.objects.size()) {
-    return false;
-  }
-
-  for (const auto& [assetId, asset] : lhs.assets) {
-    const auto it = rhs.assets.find(assetId);
-    if (it == rhs.assets.end() || !AssetDefsEqual(asset, it->second))
-      return false;
-  }
-
-  for (size_t i = 0; i < lhs.objects.size(); ++i) {
-    if (!SceneObjectsEqual(lhs.objects[i], rhs.objects[i]))
-      return false;
-  }
-
-  return true;
-}
-
-constexpr ImGuiWindowFlags kMainPanelWindowFlags =
-    ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |
-    ImGuiWindowFlags_NoSavedSettings;
-
-// World-space selection / picking bounds for a prop when ECS has a valid _eid.
-bool TryPropWorldAabb(Registry& reg, const SceneObject& obj, Vec3& outCenter, Vec3& outHalf) {
-  if (obj.type != SceneObjectType::Prop)
-    return false;
-  auto it = obj.props.find("_eid");
-  if (it == obj.props.end())
-    return false;
-  Entity e = static_cast<Entity>(std::stoul(it->second));
-  if (!reg.IsAlive(e) || !reg.Has<MeshComponent>(e) || !reg.Has<TransformComponent>(e))
-    return false;
-  const auto& mc = reg.Get<MeshComponent>(e);
-  const auto& tc = reg.Get<TransformComponent>(e);
-  if (!mc.mesh)
-    return false;
-  Transform wt(tc.current.position, tc.current.rotation, tc.current.scale);
-  WorldAabbFromLocalBox(mc.mesh->GetLocalAabbCenter(), mc.mesh->GetHalfExtents(), wt, outCenter,
-                        outHalf);
-  return true;
-}
-
-Vec3 ResolveObjectPlacementHalfExtents(const SceneObject& obj) {
-  Vec3 assetRenderScale = Vec3::One();
-  const auto assetScaleIt = obj.props.find("_assetRenderScale");
-  if (assetScaleIt != obj.props.end())
-    TryParseVec3Csv(assetScaleIt->second, &assetRenderScale);
-
-  return {std::max(std::abs(obj.scale.x * assetRenderScale.x), 0.01f),
-          std::max(std::abs(obj.scale.y * assetRenderScale.y), 0.01f),
-          std::max(std::abs(obj.scale.z * assetRenderScale.z), 0.01f)};
-}
-
-float ProjectHalfExtentOntoNormal(const Vec3& halfExtents, const Vec3& normal) {
-  return std::abs(normal.x) * halfExtents.x + std::abs(normal.y) * halfExtents.y +
-         std::abs(normal.z) * halfExtents.z;
-}
-
-bool TryGetPlacementSurfaceBounds(Registry* liveRegistry,
-                                  const SceneObject& obj,
-                                  Vec3* outCenter,
-                                  Vec3* outHalf) {
-  if (!outCenter || !outHalf)
-    return false;
-  if (obj.type != SceneObjectType::Panel && obj.type != SceneObjectType::Prop)
-    return false;
-
-  Vec3 center = obj.position;
-  Vec3 half = {std::max(std::abs(obj.scale.x), 0.25f),
-               std::max(std::abs(obj.scale.y), 0.25f),
-               std::max(std::abs(obj.scale.z), 0.25f)};
-  if (liveRegistry && TryPropWorldAabb(*liveRegistry, obj, center, half)) {
-    half.x = std::max(std::abs(half.x), 0.25f);
-    half.y = std::max(std::abs(half.y), 0.25f);
-    half.z = std::max(std::abs(half.z), 0.25f);
-  }
-
-  *outCenter = center;
-  *outHalf = half;
-  return true;
-}
-
-static const std::string kEmptyParentId;
-
-static const std::string& GetParentId(const SceneObject& obj) {
-  const auto it = obj.props.find("parentId");
-  return (it != obj.props.end()) ? it->second : kEmptyParentId;
-}
-
-static int FindObjectIndexById(const SceneDocument& doc, const std::string& id) {
-  if (id.empty())
-    return -1;
-  for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i) {
-    if (doc.objects[static_cast<size_t>(i)].id == id)
-      return i;
-  }
-  return -1;
-}
-
-std::string SanitizePrefabStem(std::string value) {
-  for (char& ch : value) {
-    const bool alphaNum = (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
-                          (ch >= '0' && ch <= '9');
-    if (!alphaNum && ch != '_' && ch != '-')
-      ch = '_';
-  }
-  while (!value.empty() && value.front() == '_')
-    value.erase(value.begin());
-  while (!value.empty() && value.back() == '_')
-    value.pop_back();
-  return value.empty() ? "prefab" : value;
-}
-
-std::filesystem::path BuildUniquePrefabPath(const SceneDocument& doc, const SceneObject& object) {
-  const std::filesystem::path prefabDir = ProjectPath::Resolve("assets/prefabs");
-  const std::string stemBase = SanitizePrefabStem(object.id.empty() ? doc.sceneId + "_prefab"
-                                                                    : object.id + "_prefab");
-  std::filesystem::path candidate = prefabDir / (stemBase + ".horo");
-  int suffix = 2;
-  while (std::filesystem::exists(candidate)) {
-    candidate = prefabDir / (stemBase + "_" + std::to_string(suffix) + ".horo");
-    ++suffix;
-  }
-  return candidate;
-}
-
-static bool IsDescendantOf(const SceneDocument& doc, int nodeIdx, int ancestorIdx) {
-  if (nodeIdx < 0 || ancestorIdx < 0 || nodeIdx >= static_cast<int>(doc.objects.size()) ||
-      ancestorIdx >= static_cast<int>(doc.objects.size()))
-    return false;
-
-  int cur = nodeIdx;
-  for (int guard = 0; guard < static_cast<int>(doc.objects.size()); ++guard) {
-    const int p = FindObjectIndexById(doc, GetParentId(doc.objects[static_cast<size_t>(cur)]));
-    if (p < 0)
-      return false;
-    if (p == ancestorIdx)
-      return true;
-    cur = p;
-  }
-  return false;
-}
-
-static void PropagateHierarchyTransformDelta(SceneDocument& doc,
-                                             int parentIdx,
-                                             const Vec3& oldParentPos,
-                                             const Quaternion& oldParentRot,
-                                             const Vec3& newParentPos,
-                                             const Quaternion& newParentRot,
-                                             const std::function<void(const SceneObject&)>& transformCb,
-                                             const std::vector<int>& skipIndices = {}) {
-  if (parentIdx < 0 || parentIdx >= static_cast<int>(doc.objects.size()))
-    return;
-
-  const Quaternion deltaRot = newParentRot * oldParentRot.Inverse();
-  for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i) {
-    if (i == parentIdx || !IsDescendantOf(doc, i, parentIdx))
-      continue;
-    // Skip children that are themselves being directly manipulated (e.g. multi-select gizmo).
-    bool shouldSkip = false;
-    for (int sk : skipIndices) {
-      if (sk == i) {
-        shouldSkip = true;
-        break;
+      std::string BuildIssueKey(const std::string &severity,
+                                const std::string &path,
+                                const std::string &message)
+      {
+        return severity + "\n" + path + "\n" + message;
       }
-    }
-    if (shouldSkip)
-      continue;
 
-    SceneObject& child = doc.objects[static_cast<size_t>(i)];
-    const Vec3 oldRel = child.position - oldParentPos;
-    child.position = newParentPos + deltaRot * oldRel;
+      std::string BuildIssueSeverityText(SceneProjectValidationIssue::Severity severity)
+      {
+        return severity == SceneProjectValidationIssue::Severity::Error ? "error" : "warning";
+      }
 
-    const Quaternion childRot =
-        Quaternion::FromEuler(ToRadians(child.pitch), ToRadians(child.yaw), ToRadians(child.roll));
-    const Quaternion rotatedChild = deltaRot * childRot;
-    const Vec3 e = rotatedChild.ToEuler();
-    child.pitch = ToDegrees(e.x);
-    child.yaw = ToDegrees(e.y);
-    child.roll = ToDegrees(e.z);
+      std::string BuildIssueSeverityText(RuntimeSceneBuildIssue::Severity severity)
+      {
+        return severity == RuntimeSceneBuildIssue::Severity::Error ? "error" : "warning";
+      }
 
-    if (transformCb)
-      transformCb(child);
-  }
-}
+      Mcp::McpBuildSnapshot BuildMcpBuildSnapshot(const SceneDocument &document)
+      {
+        Mcp::McpBuildSnapshot snapshot;
+        snapshot.available = true;
 
-// Screen direction of a world-space axis for the orientation corner gizmo.
-// Uses the view matrix directly — pivot-based perspective projection would introduce
-// distortion for off-centre or off-screen pivots and is incorrect for a corner widget.
-static void WorldAxisToScreenDir(const Camera& cam,
-                                 const Vec3& worldUnit,
-                                 float* outDx,
-                                 float* outDy,
-                                 float* outViewZ = nullptr) {
-  const Mat4 view = cam.GetView();
-  const Vec3 e = view.TransformVector(worldUnit);
-  if (outViewZ)
-    *outViewZ = e.z;
-  const float dx = e.x;
-  const float dy = -e.y;  // ImGui Y is down
-  const float len = std::sqrt(dx * dx + dy * dy);
-  if (len < 1e-4f) {
-    *outDx = 1.f;
-    *outDy = 0.f;
-    return;
-  }
-  *outDx = dx / len;
-  *outDy = dy / len;
-}
+        const SceneProjectModel model = BuildSceneProjectModel(document);
+        snapshot.assetCount = model.scene.assets.size();
+        snapshot.nodeCount = model.scene.nodes.size();
 
-static float DistSqPointSegment2D(float px, float py, float ax, float ay, float bx, float by) {
-  const float abx = bx - ax, aby = by - ay;
-  const float apx = px - ax, apy = py - ay;
-  const float abLen2 = abx * abx + aby * aby;
-  if (abLen2 < 1e-8f)
-    return apx * apx + apy * apy;
-  float t = (apx * abx + apy * aby) / abLen2;
-  t = std::clamp(t, 0.f, 1.f);
-  const float cx = ax + t * abx, cy = ay + t * aby;
-  const float dx = px - cx, dy = py - cy;
-  return dx * dx + dy * dy;
-}
+        const SceneProjectValidationResult validation = ValidateSceneProjectModel(model);
+        std::unordered_set<std::string> validationIssueKeys;
+        for (const SceneProjectValidationIssue &issue : validation.issues)
+        {
+          const std::string severity = BuildIssueSeverityText(issue.severity);
+          validationIssueKeys.insert(BuildIssueKey(severity, issue.path, issue.message));
+          if (issue.severity == SceneProjectValidationIssue::Severity::Error)
+            ++snapshot.sceneValidationErrors;
+          else
+            ++snapshot.sceneValidationWarnings;
+          snapshot.issues.push_back(Mcp::McpBuildIssueSnapshot{"validation", severity, issue.path, issue.message});
+        }
+
+        const RuntimeSceneBuildResult runtimeBuild = Monolith::BuildRuntimeSceneDefinition(model);
+        snapshot.roomCount = runtimeBuild.definition.rooms.size();
+        snapshot.lightCount = runtimeBuild.definition.lights.size();
+        snapshot.hasSceneCamera = runtimeBuild.definition.sceneCamera.has_value();
+        for (const RuntimeSceneRoom &room : runtimeBuild.definition.rooms)
+        {
+          snapshot.panelCount += room.panels.size();
+          snapshot.propCount += room.props.size();
+        }
+
+        for (const RuntimeSceneBuildIssue &issue : runtimeBuild.issues)
+        {
+          const std::string severity = BuildIssueSeverityText(issue.severity);
+          if (validationIssueKeys.count(BuildIssueKey(severity, issue.path, issue.message)) != 0)
+            continue;
+          if (issue.severity == RuntimeSceneBuildIssue::Severity::Error)
+            ++snapshot.runtimeBuildErrors;
+          else
+            ++snapshot.runtimeBuildWarnings;
+          snapshot.issues.push_back(Mcp::McpBuildIssueSnapshot{"runtime", severity, issue.path, issue.message});
+        }
+
+        const size_t totalErrors = snapshot.sceneValidationErrors + snapshot.runtimeBuildErrors;
+        const size_t totalWarnings = snapshot.sceneValidationWarnings + snapshot.runtimeBuildWarnings;
+        snapshot.status = totalErrors > 0 ? "error" : totalWarnings > 0 ? "warning"
+                                                                        : "ok";
+        return snapshot;
+      }
+
+      const char *FieldWidgetToString(FieldDef::Widget widget)
+      {
+        switch (widget)
+        {
+        case FieldDef::Widget::Float:
+          return "float";
+        case FieldDef::Widget::Bool:
+          return "bool";
+        case FieldDef::Widget::Enum:
+          return "enum";
+        case FieldDef::Widget::Color3:
+          return "color3";
+        case FieldDef::Widget::String:
+        default:
+          return "string";
+        }
+      }
+
+      Mcp::McpSchemaFieldSnapshot BuildMcpSchemaFieldSnapshot(const FieldDef &field)
+      {
+        Mcp::McpSchemaFieldSnapshot snapshot;
+        snapshot.key = field.key;
+        snapshot.label = field.label;
+        snapshot.description = field.description;
+        snapshot.widget = FieldWidgetToString(field.widget);
+        snapshot.hasDefault = field.hasDefault;
+        snapshot.required = field.required;
+        snapshot.allowEmpty = field.allowEmpty;
+        snapshot.allowCustomValue = field.allowCustomValue;
+        snapshot.hasMin = field.hasMin;
+        snapshot.hasMax = field.hasMax;
+        snapshot.minVal = field.minVal;
+        snapshot.maxVal = field.maxVal;
+        snapshot.options = field.options;
+        snapshot.defaultValue = field.defaultValue;
+        return snapshot;
+      }
+
+      Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const TypeSchema &schema)
+      {
+        Mcp::McpSchemaEntrySnapshot snapshot;
+        snapshot.kind = "object";
+        snapshot.name = schema.name;
+        snapshot.label = schema.label;
+        snapshot.appliesTo = schema.appliesTo;
+        snapshot.fields.reserve(schema.fields.size());
+        for (const FieldDef &field : schema.fields)
+          snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
+        return snapshot;
+      }
+
+      Mcp::McpSchemaEntrySnapshot BuildMcpSchemaEntrySnapshot(const ComponentSchema &schema)
+      {
+        Mcp::McpSchemaEntrySnapshot snapshot;
+        snapshot.kind = "component";
+        snapshot.name = schema.name;
+        snapshot.label = schema.label;
+        snapshot.appliesTo = schema.appliesTo;
+        snapshot.fields.reserve(schema.fields.size());
+        for (const FieldDef &field : schema.fields)
+          snapshot.fields.push_back(BuildMcpSchemaFieldSnapshot(field));
+        return snapshot;
+      }
+
+      Mcp::McpSchemaCatalogSnapshot BuildMcpSchemaCatalogSnapshot(const EditorSchema &schema)
+      {
+        Mcp::McpSchemaCatalogSnapshot snapshot;
+
+        std::vector<std::string> typeNames;
+        typeNames.reserve(schema.TypeSchemas().size());
+        for (const auto &entry : schema.TypeSchemas())
+          typeNames.push_back(entry.first);
+        std::sort(typeNames.begin(), typeNames.end());
+        for (const std::string &typeName : typeNames)
+          snapshot.objectTypes.push_back(BuildMcpSchemaEntrySnapshot(schema.TypeSchemas().at(typeName)));
+
+        std::vector<std::string> componentTypes;
+        componentTypes.reserve(schema.ComponentSchemas().size());
+        for (const auto &entry : schema.ComponentSchemas())
+          componentTypes.push_back(entry.first);
+        std::sort(componentTypes.begin(), componentTypes.end());
+        for (const std::string &componentType : componentTypes)
+          snapshot.components.push_back(BuildMcpSchemaEntrySnapshot(schema.ComponentSchemas().at(componentType)));
+
+        return snapshot;
+      }
+
+      bool SchemaAppliesToObjectType(const std::vector<std::string> &appliesTo, SceneObjectType objectType)
+      {
+        if (appliesTo.empty())
+          return true;
+        std::string typeName = "panel";
+        switch (objectType)
+        {
+        case SceneObjectType::Prop:
+          typeName = "prop";
+          break;
+        case SceneObjectType::Light:
+          typeName = "light";
+          break;
+        case SceneObjectType::Camera:
+          typeName = "camera";
+          break;
+        case SceneObjectType::Panel:
+        default:
+          typeName = "panel";
+          break;
+        }
+        auto normalize = [](std::string value)
+        {
+          std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c)
+                         { return static_cast<char>(std::tolower(c)); });
+          return value;
+        };
+        for (const std::string &entry : appliesTo)
+        {
+          if (normalize(entry) == typeName)
+            return true;
+        }
+        return false;
+      }
+
+      bool AssetDefsEqual(const AssetDef &lhs, const AssetDef &rhs)
+      {
+        return lhs.mesh == rhs.mesh &&
+               lhs.renderScale == rhs.renderScale &&
+               lhs.albedoMap == rhs.albedoMap &&
+               lhs.guid == rhs.guid &&
+               lhs.displayName == rhs.displayName;
+      }
+
+      bool ComponentDescsEqual(const ComponentDesc &lhs, const ComponentDesc &rhs)
+      {
+        return lhs.type == rhs.type && lhs.props == rhs.props;
+      }
+
+      bool SceneObjectsEqual(const SceneObject &lhs, const SceneObject &rhs)
+      {
+        const bool prefabEqual =
+            (!lhs.prefabInstance.has_value() && !rhs.prefabInstance.has_value()) ||
+            (lhs.prefabInstance.has_value() && rhs.prefabInstance.has_value() &&
+             lhs.prefabInstance->prefabId == rhs.prefabInstance->prefabId &&
+             lhs.prefabInstance->sourcePath == rhs.prefabInstance->sourcePath);
+        if (lhs.id != rhs.id ||
+            lhs.type != rhs.type ||
+            lhs.position.x != rhs.position.x ||
+            lhs.position.y != rhs.position.y ||
+            lhs.position.z != rhs.position.z ||
+            lhs.scale.x != rhs.scale.x ||
+            lhs.scale.y != rhs.scale.y ||
+            lhs.scale.z != rhs.scale.z ||
+            lhs.yaw != rhs.yaw ||
+            lhs.pitch != rhs.pitch ||
+            lhs.roll != rhs.roll ||
+            lhs.assetId != rhs.assetId ||
+            !prefabEqual ||
+            lhs.props != rhs.props ||
+            lhs.components.size() != rhs.components.size())
+        {
+          return false;
+        }
+
+        for (size_t i = 0; i < lhs.components.size(); ++i)
+        {
+          if (!ComponentDescsEqual(lhs.components[i], rhs.components[i]))
+            return false;
+        }
+        return true;
+      }
+
+      bool SceneDocumentsEqual(const SceneDocument &lhs, const SceneDocument &rhs)
+      {
+        if (lhs.version != rhs.version ||
+            lhs.sceneId != rhs.sceneId ||
+            lhs.sceneName != rhs.sceneName ||
+            lhs.filePath != rhs.filePath ||
+            lhs.settings != rhs.settings ||
+            lhs.assets.size() != rhs.assets.size() ||
+            lhs.objects.size() != rhs.objects.size())
+        {
+          return false;
+        }
+
+        for (const auto &[assetId, asset] : lhs.assets)
+        {
+          const auto it = rhs.assets.find(assetId);
+          if (it == rhs.assets.end() || !AssetDefsEqual(asset, it->second))
+            return false;
+        }
+
+        for (size_t i = 0; i < lhs.objects.size(); ++i)
+        {
+          if (!SceneObjectsEqual(lhs.objects[i], rhs.objects[i]))
+            return false;
+        }
+
+        return true;
+      }
+
+      constexpr ImGuiWindowFlags kMainPanelWindowFlags =
+          ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |
+          ImGuiWindowFlags_NoSavedSettings;
+
+      // World-space selection / picking bounds for a prop when ECS has a valid _eid.
+      bool TryPropWorldAabb(Registry &reg, const SceneObject &obj, Vec3 &outCenter, Vec3 &outHalf)
+      {
+        if (obj.type != SceneObjectType::Prop)
+          return false;
+        auto it = obj.props.find("_eid");
+        if (it == obj.props.end())
+          return false;
+        Entity e = static_cast<Entity>(std::stoul(it->second));
+        if (!reg.IsAlive(e) || !reg.Has<MeshComponent>(e) || !reg.Has<TransformComponent>(e))
+          return false;
+        const auto &mc = reg.Get<MeshComponent>(e);
+        const auto &tc = reg.Get<TransformComponent>(e);
+        if (!mc.mesh)
+          return false;
+        Transform wt(tc.current.position, tc.current.rotation, tc.current.scale);
+        WorldAabbFromLocalBox(mc.mesh->GetLocalAabbCenter(), mc.mesh->GetHalfExtents(), wt, outCenter,
+                              outHalf);
+        return true;
+      }
+
+      Vec3 ResolveObjectPlacementHalfExtents(const SceneObject &obj)
+      {
+        Vec3 assetRenderScale = Vec3::One();
+        const auto assetScaleIt = obj.props.find("_assetRenderScale");
+        if (assetScaleIt != obj.props.end())
+          TryParseVec3Csv(assetScaleIt->second, &assetRenderScale);
+
+        return {std::max(std::abs(obj.scale.x * assetRenderScale.x), 0.01f),
+                std::max(std::abs(obj.scale.y * assetRenderScale.y), 0.01f),
+                std::max(std::abs(obj.scale.z * assetRenderScale.z), 0.01f)};
+      }
+
+      float ProjectHalfExtentOntoNormal(const Vec3 &halfExtents, const Vec3 &normal)
+      {
+        return std::abs(normal.x) * halfExtents.x + std::abs(normal.y) * halfExtents.y +
+               std::abs(normal.z) * halfExtents.z;
+      }
+
+      bool TryGetPlacementSurfaceBounds(Registry *liveRegistry,
+                                        const SceneObject &obj,
+                                        Vec3 *outCenter,
+                                        Vec3 *outHalf)
+      {
+        if (!outCenter || !outHalf)
+          return false;
+        if (obj.type != SceneObjectType::Panel && obj.type != SceneObjectType::Prop)
+          return false;
+
+        Vec3 center = obj.position;
+        Vec3 half = {std::max(std::abs(obj.scale.x), 0.25f),
+                     std::max(std::abs(obj.scale.y), 0.25f),
+                     std::max(std::abs(obj.scale.z), 0.25f)};
+        if (liveRegistry && TryPropWorldAabb(*liveRegistry, obj, center, half))
+        {
+          half.x = std::max(std::abs(half.x), 0.25f);
+          half.y = std::max(std::abs(half.y), 0.25f);
+          half.z = std::max(std::abs(half.z), 0.25f);
+        }
+
+        *outCenter = center;
+        *outHalf = half;
+        return true;
+      }
+
+      static const std::string kEmptyParentId;
+
+      static const std::string &GetParentId(const SceneObject &obj)
+      {
+        const auto it = obj.props.find("parentId");
+        return (it != obj.props.end()) ? it->second : kEmptyParentId;
+      }
+
+      static int FindObjectIndexById(const SceneDocument &doc, const std::string &id)
+      {
+        if (id.empty())
+          return -1;
+        for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
+        {
+          if (doc.objects[static_cast<size_t>(i)].id == id)
+            return i;
+        }
+        return -1;
+      }
+
+      std::string SanitizePrefabStem(std::string value)
+      {
+        for (char &ch : value)
+        {
+          const bool alphaNum = (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+                                (ch >= '0' && ch <= '9');
+          if (!alphaNum && ch != '_' && ch != '-')
+            ch = '_';
+        }
+        while (!value.empty() && value.front() == '_')
+          value.erase(value.begin());
+        while (!value.empty() && value.back() == '_')
+          value.pop_back();
+        return value.empty() ? "prefab" : value;
+      }
+
+      std::filesystem::path BuildUniquePrefabPath(const SceneDocument &doc, const SceneObject &object)
+      {
+        const std::filesystem::path prefabDir = ProjectPath::Resolve("assets/prefabs");
+        const std::string stemBase = SanitizePrefabStem(object.id.empty() ? doc.sceneId + "_prefab"
+                                                                          : object.id + "_prefab");
+        std::filesystem::path candidate = prefabDir / (stemBase + ".horo");
+        int suffix = 2;
+        while (std::filesystem::exists(candidate))
+        {
+          candidate = prefabDir / (stemBase + "_" + std::to_string(suffix) + ".horo");
+          ++suffix;
+        }
+        return candidate;
+      }
+
+      static bool IsDescendantOf(const SceneDocument &doc, int nodeIdx, int ancestorIdx)
+      {
+        if (nodeIdx < 0 || ancestorIdx < 0 || nodeIdx >= static_cast<int>(doc.objects.size()) ||
+            ancestorIdx >= static_cast<int>(doc.objects.size()))
+          return false;
+
+        int cur = nodeIdx;
+        for (int guard = 0; guard < static_cast<int>(doc.objects.size()); ++guard)
+        {
+          const int p = FindObjectIndexById(doc, GetParentId(doc.objects[static_cast<size_t>(cur)]));
+          if (p < 0)
+            return false;
+          if (p == ancestorIdx)
+            return true;
+          cur = p;
+        }
+        return false;
+      }
+
+      static void PropagateHierarchyTransformDelta(SceneDocument &doc,
+                                                   int parentIdx,
+                                                   const Vec3 &oldParentPos,
+                                                   const Quaternion &oldParentRot,
+                                                   const Vec3 &newParentPos,
+                                                   const Quaternion &newParentRot,
+                                                   const std::function<void(const SceneObject &)> &transformCb,
+                                                   const std::vector<int> &skipIndices = {})
+      {
+        if (parentIdx < 0 || parentIdx >= static_cast<int>(doc.objects.size()))
+          return;
+
+        const Quaternion deltaRot = newParentRot * oldParentRot.Inverse();
+        for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
+        {
+          if (i == parentIdx || !IsDescendantOf(doc, i, parentIdx))
+            continue;
+          // Skip children that are themselves being directly manipulated (e.g. multi-select gizmo).
+          bool shouldSkip = false;
+          for (int sk : skipIndices)
+          {
+            if (sk == i)
+            {
+              shouldSkip = true;
+              break;
+            }
+          }
+          if (shouldSkip)
+            continue;
+
+          SceneObject &child = doc.objects[static_cast<size_t>(i)];
+          const Vec3 oldRel = child.position - oldParentPos;
+          child.position = newParentPos + deltaRot * oldRel;
+
+          const Quaternion childRot =
+              Quaternion::FromEuler(ToRadians(child.pitch), ToRadians(child.yaw), ToRadians(child.roll));
+          const Quaternion rotatedChild = deltaRot * childRot;
+          const Vec3 e = rotatedChild.ToEuler();
+          child.pitch = ToDegrees(e.x);
+          child.yaw = ToDegrees(e.y);
+          child.roll = ToDegrees(e.z);
+
+          if (transformCb)
+            transformCb(child);
+        }
+      }
+
+      // Screen direction of a world-space axis for the orientation corner gizmo.
+      // Uses the view matrix directly — pivot-based perspective projection would introduce
+      // distortion for off-centre or off-screen pivots and is incorrect for a corner widget.
+      static void WorldAxisToScreenDir(const Camera &cam,
+                                       const Vec3 &worldUnit,
+                                       float *outDx,
+                                       float *outDy,
+                                       float *outViewZ = nullptr)
+      {
+        const Mat4 view = cam.GetView();
+        const Vec3 e = view.TransformVector(worldUnit);
+        if (outViewZ)
+          *outViewZ = e.z;
+        const float dx = e.x;
+        const float dy = -e.y; // ImGui Y is down
+        const float len = std::sqrt(dx * dx + dy * dy);
+        if (len < 1e-4f)
+        {
+          *outDx = 1.f;
+          *outDy = 0.f;
+          return;
+        }
+        *outDx = dx / len;
+        *outDy = dy / len;
+      }
+
+      static float DistSqPointSegment2D(float px, float py, float ax, float ay, float bx, float by)
+      {
+        const float abx = bx - ax, aby = by - ay;
+        const float apx = px - ax, apy = py - ay;
+        const float abLen2 = abx * abx + aby * aby;
+        if (abLen2 < 1e-8f)
+          return apx * apx + apy * apy;
+        float t = (apx * abx + apy * aby) / abLen2;
+        t = std::clamp(t, 0.f, 1.f);
+        const float cx = ax + t * abx, cy = ay + t * aby;
+        const float dx = px - cx, dy = py - cy;
+        return dx * dx + dy * dy;
+      }
 
 #if defined(__APPLE__)
-static std::string ReadPathFromOsascript(const char* cmd) {
-  FILE* pipe = popen(cmd, "r");
-  if (!pipe)
-    return {};
-  char buf[1024] = {};
-  std::string out;
-  while (std::fgets(buf, sizeof(buf), pipe) != nullptr)
-    out += buf;
-  pclose(pipe);
-  out.erase(std::remove_if(out.begin(), out.end(), [](char c) {
-              return c == '\n' || c == '\r';
-            }),
-            out.end());
-  return out;
-}
-#endif
-
-std::string PickObjFilePath() {
-#ifdef _WIN32
-  char filePath[MAX_PATH] = {};
-  OPENFILENAMEA ofn = {};
-  ofn.lStructSize = sizeof(ofn);
-  ofn.lpstrFilter = "OBJ Files\0*.obj\0All Files\0*.*\0";
-  ofn.lpstrFile = filePath;
-  ofn.nMaxFile = sizeof(filePath);
-  ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
-  if (GetOpenFileNameA(&ofn))
-    return filePath;
-  return {};
-#elif defined(__APPLE__)
-  // Avoid `of type {"obj"}` — it often fails on modern macOS; we validate extension in code.
-  return ReadPathFromOsascript(
-      "/usr/bin/osascript -e 'try' "
-      "-e 'POSIX path of (choose file with prompt \"Select OBJ file\")' "
-      "-e 'on error' -e 'return \"\"' -e 'end try' 2>/dev/null");
-#else
-  return {};
-#endif
-}
-
-static bool IsTextureFilePath(const std::string& path) {
-  if (path.empty())
-    return false;
-  namespace fs = std::filesystem;
-  std::string ext = fs::path(path).extension().string();
-  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  return ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".bmp" || ext == ".tga" ||
-         ext == ".webp" || ext == ".hdr";
-}
-
-static std::string ToLowerAscii(std::string s) {
-  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  return s;
-}
-
-static std::filesystem::path ResolveProjectRelativeOrAbsolutePath(const std::string& rawPath) {
-  if (rawPath.empty())
-    return {};
-  namespace fs = std::filesystem;
-  fs::path p(rawPath);
-  if (p.is_absolute())
-    return p;
-  return ProjectPath::Root() / p;
-}
-
-static std::filesystem::path ResolvePreviewShaderPath(const char* fileName) {
-  namespace fs = std::filesystem;
-  const fs::path root = ProjectPath::Root();
-  const std::array<fs::path, 4> candidates = {
-      root / "engine" / "renderer" / "shaders" / fileName,
-      root.parent_path() / "horo-engine" / "renderer" / "shaders" / fileName,
-      root / "horo-engine" / "renderer" / "shaders" / fileName,
-      root / "renderer" / "shaders" / fileName,
-  };
-
-  for (const auto& candidate : candidates) {
-    std::error_code ec;
-    if (fs::is_regular_file(candidate, ec) && !ec)
-      return candidate;
-  }
-
-  return candidates.front();
-}
-
-const char* SceneObjectTypeToString(SceneObjectType type) {
-  switch (type) {
-    case SceneObjectType::Panel:
-      return "Panel";
-    case SceneObjectType::Prop:
-      return "Prop";
-    case SceneObjectType::Light:
-      return "Light";
-    case SceneObjectType::Camera:
-      return "Camera";
-  }
-  return "Panel";
-}
-
-bool ParseSceneObjectType(const std::string& raw, SceneObjectType* outType) {
-  if (!outType)
-    return false;
-  std::string value = raw;
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  if (value == "panel") {
-    *outType = SceneObjectType::Panel;
-    return true;
-  }
-  if (value == "prop") {
-    *outType = SceneObjectType::Prop;
-    return true;
-  }
-  if (value == "light") {
-    *outType = SceneObjectType::Light;
-    return true;
-  }
-  if (value == "camera") {
-    *outType = SceneObjectType::Camera;
-    return true;
-  }
-  return false;
-}
-
-static Vec3 MultiplyComponents(const Vec3& a, const Vec3& b) {
-  return {a.x * b.x, a.y * b.y, a.z * b.z};
-}
-
-static bool TryResolveObjectMeshPath(const SceneDocument& doc,
-                                     const SceneObject& obj,
-                                     std::string* outMeshPath,
-                                     Vec3* outAssetRenderScale) {
-  if (outMeshPath)
-    outMeshPath->clear();
-  if (outAssetRenderScale)
-    *outAssetRenderScale = Vec3::One();
-
-  if (!obj.assetId.empty()) {
-    const auto assetIt = doc.assets.find(obj.assetId);
-    if (assetIt == doc.assets.end())
-      return false;
-    if (outMeshPath)
-      *outMeshPath = assetIt->second.mesh;
-    if (outAssetRenderScale) {
-      Vec3 parsedScale = Vec3::One();
-      if (TryParseVec3Csv(assetIt->second.renderScale, &parsedScale))
-        *outAssetRenderScale = parsedScale;
-    }
-    return !assetIt->second.mesh.empty();
-  }
-
-  const auto propIt = obj.props.find("mesh");
-  if (propIt == obj.props.end() || propIt->second.empty())
-    return false;
-  if (outMeshPath)
-    *outMeshPath = propIt->second;
-  return true;
-}
-
-bool IsObjectReferencePropKey(const std::string& key) {
-  return key == "parentId" || key == "followTargetId";
-}
-
-std::unordered_set<std::string> CollectReservedObjectIds(const SceneDocument& doc) {
-  std::unordered_set<std::string> reservedIds;
-  reservedIds.reserve(doc.objects.size() * 2);
-  for (const SceneObject& obj : doc.objects) {
-    if (!obj.id.empty())
-      reservedIds.insert(obj.id);
-    for (const auto& entry : obj.props) {
-      if (IsObjectReferencePropKey(entry.first) && !entry.second.empty())
-        reservedIds.insert(entry.second);
-    }
-  }
-  return reservedIds;
-}
-
-bool IsReservedObjectId(const SceneDocument& doc,
-                        const std::string& id,
-                        const std::string* ignoreConcreteObjectId = nullptr) {
-  if (id.empty())
-    return false;
-  for (const SceneObject& obj : doc.objects) {
-    if (!obj.id.empty() && (!ignoreConcreteObjectId || obj.id != *ignoreConcreteObjectId) && obj.id == id)
-      return true;
-    for (const auto& entry : obj.props) {
-      if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
-        continue;
-      if (ignoreConcreteObjectId && entry.second == *ignoreConcreteObjectId)
-        continue;
-      if (entry.second == id)
-        return true;
-    }
-  }
-  return false;
-}
-
-void RewriteObjectIdReferences(SceneDocument* doc, const std::string& oldId, const std::string& newId) {
-  if (!doc || oldId.empty() || oldId == newId)
-    return;
-  for (SceneObject& object : doc->objects) {
-    for (auto& entry : object.props) {
-      if (IsObjectReferencePropKey(entry.first) && entry.second == oldId)
-        entry.second = newId;
-    }
-  }
-}
-
-void LogDanglingObjectReferences(const SceneDocument& doc, const std::string& sourceLabel) {
-  std::unordered_set<std::string> objectIds;
-  objectIds.reserve(doc.objects.size() * 2);
-  for (const SceneObject& object : doc.objects) {
-    if (!object.id.empty())
-      objectIds.insert(object.id);
-  }
-  for (const SceneObject& object : doc.objects) {
-    for (const auto& entry : object.props) {
-      if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
-        continue;
-      if (objectIds.find(entry.second) == objectIds.end())
-        LOG_WARN("[Editor] Dangling object reference in %s: %s.%s -> %s",
-                 sourceLabel.c_str(), object.id.c_str(), entry.first.c_str(), entry.second.c_str());
-    }
-  }
-}
-
-static Mat4 BuildObjectModelMatrix(const SceneDocument& doc, const SceneObject& obj) {
-  Vec3 assetRenderScale = Vec3::One();
-  std::string ignoredMeshPath;
-  TryResolveObjectMeshPath(doc, obj, &ignoredMeshPath, &assetRenderScale);
-
-  const Quaternion rotation =
-      Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
-  const Vec3 totalScale = MultiplyComponents(obj.scale, assetRenderScale);
-  return Mat4::Translate(obj.position) * Mat4::Rotate(rotation) * Mat4::Scale(totalScale);
-}
-
-static void SyncAssetScaleMetadata(SceneDocument* doc) {
-  if (!doc)
-    return;
-
-  for (SceneObject& obj : doc->objects) {
-    if (obj.assetId.empty()) {
-      obj.props.erase("_assetRenderScale");
-      continue;
-    }
-
-    const auto assetIt = doc->assets.find(obj.assetId);
-    if (assetIt == doc->assets.end()) {
-      obj.props.erase("_assetRenderScale");
-      continue;
-    }
-
-    obj.props["_assetRenderScale"] = assetIt->second.renderScale.empty()
-                                         ? "1.0000,1.0000,1.0000"
-                                         : assetIt->second.renderScale;
-  }
-}
-
-// ===== 3D Asset Thumbnail Rendering Infrastructure =====
-// Framebuffer object for offscreen mesh rendering (shared across all asset previews).
-struct AssetThumbnailRenderer {
-  unsigned int fbo = 0;
-  unsigned int colorTexture = 0;
-  unsigned int depthRenderBuffer = 0;
-  int width = 512;
-  int height = 512;
-  Shader shader;  // Basic lighting shader for thumbnail
-
-  // Cache: assetKey -> currently rendered mesh/texture ID
-  struct CachedMesh {
-    std::shared_ptr<Mesh> mesh;
-    std::shared_ptr<SkinnedMesh> skinnedMesh;
-    std::shared_ptr<Skeleton> skeleton;
-    bool isSkinned = false;
-  };
-  std::unordered_map<std::string, CachedMesh> meshCache;
-  std::unordered_set<std::string> noPreviewKeys;
-  // Per-mesh rendered texture cache: each mesh gets its own texture so all
-  // thumbnails don't overwrite each other by sharing a single FBO attachment.
-  std::unordered_map<std::string, unsigned int> renderedTextureCache;
-
-  static AssetThumbnailRenderer& Instance() {
-    static AssetThumbnailRenderer instance;
-    return instance;
-  }
-
-  bool Init() {
-    if (fbo != 0)
-      return IsValid();
-
-    // Create FBO
-    glGenFramebuffers(1, &fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-
-    // Create color texture
-    glGenTextures(1, &colorTexture);
-    glBindTexture(GL_TEXTURE_2D, colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0);
-
-    // Create depth renderbuffer
-    glGenRenderbuffers(1, &depthRenderBuffer);
-    glBindRenderbuffer(GL_RENDERBUFFER, depthRenderBuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthRenderBuffer);
-
-    const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-      LOG_ERROR("AssetThumbnailRenderer: FBO incomplete, status=%d", (int)status);
-      Cleanup();
-      return false;
-    }
-
-    // Load simple lighting shader
-    try {
-      const std::filesystem::path vertPath = ResolvePreviewShaderPath("basic.vert");
-      const std::filesystem::path fragPath = ResolvePreviewShaderPath("basic.frag");
-      shader = Shader::FromFiles(vertPath.generic_string(), fragPath.generic_string());
-    } catch (const std::exception& e) {
-      LOG_ERROR("Failed to load preview shader: %s", e.what());
-      Cleanup();
-      return false;
-    }
-
-    return IsValid();
-  }
-
-  bool IsValid() const {
-    return fbo != 0 && colorTexture != 0 && depthRenderBuffer != 0 && shader.IsValid();
-  }
-
-  void Cleanup() {
-    meshCache.clear();
-    noPreviewKeys.clear();
-    for (auto& [key, texId] : renderedTextureCache) {
-      if (texId != 0)
-        glDeleteTextures(1, &texId);
-    }
-    renderedTextureCache.clear();
-    if (colorTexture != 0) {
-      glDeleteTextures(1, &colorTexture);
-      colorTexture = 0;
-    }
-    if (depthRenderBuffer != 0) {
-      glDeleteRenderbuffers(1, &depthRenderBuffer);
-      depthRenderBuffer = 0;
-    }
-    if (fbo != 0) {
-      glDeleteFramebuffers(1, &fbo);
-      fbo = 0;
-    }
-  }
-
-  ~AssetThumbnailRenderer() { Cleanup(); }
-};
-
-// Try to load a static mesh (OBJ) or skinned mesh (GLTF/GLB) from the given path.
-// Returns cache entry or nullptr on failure.
-static AssetThumbnailRenderer::CachedMesh* TryLoadAssetMesh(const std::string& meshPath) {
-  if (meshPath.empty())
-    return nullptr;
-
-  const std::filesystem::path path = ResolveProjectRelativeOrAbsolutePath(meshPath);
-  const std::string ext = ToLowerAscii(path.extension().string());
-
-  auto& renderer = AssetThumbnailRenderer::Instance();
-  const std::string cacheKey = path.generic_string();
-
-  // Check no-preview cache
-  if (renderer.noPreviewKeys.find(cacheKey) != renderer.noPreviewKeys.end()) {
-    return nullptr;
-  }
-
-  // Check mesh cache
-  auto it = renderer.meshCache.find(cacheKey);
-  if (it != renderer.meshCache.end()) {
-    return &it->second;
-  }
-
-  AssetThumbnailRenderer::CachedMesh entry;
-
-  try {
-    if (ext == ".obj") {
-      entry.mesh = std::make_shared<Mesh>(ObjLoader::Load(path.generic_string()));
-      entry.isSkinned = false;
-    } else if (ext == ".gltf" || ext == ".glb") {
-      GltfLoadResult result = GltfLoader::Load(path.generic_string());
-      if (result.mesh) {
-        entry.skinnedMesh = result.mesh;
-        entry.skeleton = result.skeleton;
-        entry.isSkinned = true;
-      } else {
-        LOG_WARN("[Thumbnail] GLTF load failed (no mesh): %s", cacheKey.c_str());
-        renderer.noPreviewKeys.insert(cacheKey);
-        return nullptr;
+      static std::string ReadPathFromOsascript(const char *cmd)
+      {
+        FILE *pipe = popen(cmd, "r");
+        if (!pipe)
+          return {};
+        char buf[1024] = {};
+        std::string out;
+        while (std::fgets(buf, sizeof(buf), pipe) != nullptr)
+          out += buf;
+        pclose(pipe);
+        out.erase(std::remove_if(out.begin(), out.end(), [](char c)
+                                 { return c == '\n' || c == '\r'; }),
+                  out.end());
+        return out;
       }
-    } else {
-      LOG_WARN("[Thumbnail] Unsupported mesh format: %s", ext.c_str());
-      renderer.noPreviewKeys.insert(cacheKey);
-      return nullptr;
-    }
-  } catch (const std::exception& e) {
-    LOG_WARN("[Thumbnail] Failed to load mesh for preview: %s (error: %s)", cacheKey.c_str(), e.what());
-    renderer.noPreviewKeys.insert(cacheKey);
-    return nullptr;
-  }
+#endif
 
-  it = renderer.meshCache.emplace(cacheKey, std::move(entry)).first;
-  return &it->second;
-}
+      std::string PickObjFilePath()
+      {
+#ifdef _WIN32
+        char filePath[MAX_PATH] = {};
+        OPENFILENAMEA ofn = {};
+        ofn.lStructSize = sizeof(ofn);
+        ofn.lpstrFilter = "OBJ Files\0*.obj\0All Files\0*.*\0";
+        ofn.lpstrFile = filePath;
+        ofn.nMaxFile = sizeof(filePath);
+        ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+        if (GetOpenFileNameA(&ofn))
+          return filePath;
+        return {};
+#elif defined(__APPLE__)
+        // Avoid `of type {"obj"}` — it often fails on modern macOS; we validate extension in code.
+        return ReadPathFromOsascript(
+            "/usr/bin/osascript -e 'try' "
+            "-e 'POSIX path of (choose file with prompt \"Select OBJ file\")' "
+            "-e 'on error' -e 'return \"\"' -e 'end try' 2>/dev/null");
+#else
+        return {};
+#endif
+      }
 
-// Fit camera to mesh AABB with a comfortable margin. Returns view and projection matrices.
-static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
-                            Mat4& outView, Mat4& outProj) {
-  Vec3 aabbCenter;
-  Vec3 aabbHalf;
+      static bool IsTextureFilePath(const std::string &path)
+      {
+        if (path.empty())
+          return false;
+        namespace fs = std::filesystem;
+        std::string ext = fs::path(path).extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c)
+                       { return static_cast<char>(std::tolower(c)); });
+        return ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".bmp" || ext == ".tga" ||
+               ext == ".webp" || ext == ".hdr";
+      }
 
-  if (mesh.isSkinned && mesh.skinnedMesh) {
-    aabbCenter = mesh.skinnedMesh->GetLocalAabbCenter();
-    aabbHalf = mesh.skinnedMesh->GetHalfExtents();
-  } else if (!mesh.isSkinned && mesh.mesh) {
-    aabbCenter = mesh.mesh->GetLocalAabbCenter();
-    aabbHalf = mesh.mesh->GetHalfExtents();
-  } else {
-    // Fallback: identity view/proj
-    outView = Mat4::Identity();
-    outProj = Mat4::Perspective(45.0f, 1.0f, 0.01f, 100.0f);
-    return;
-  }
+      static std::string ToLowerAscii(std::string s)
+      {
+        std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c)
+                       { return static_cast<char>(std::tolower(c)); });
+        return s;
+      }
 
-  // Compute distance to fit AABB on screen (with 1.3x margin for breathing room)
-  const float maxHalf = std::max({aabbHalf.x, aabbHalf.y, aabbHalf.z});
-  const float fov = 45.0f * 3.14159f / 180.f;
-  const float distance = maxHalf * 1.3f / std::tan(fov * 0.5f);
+      static std::filesystem::path ResolveProjectRelativeOrAbsolutePath(const std::string &rawPath)
+      {
+        if (rawPath.empty())
+          return {};
+        namespace fs = std::filesystem;
+        fs::path p(rawPath);
+        if (p.is_absolute())
+          return p;
+        return ProjectPath::Root() / p;
+      }
 
-  // Position camera at ~22° elevation for a clear side-on view of the object
-  const Vec3 camPos = aabbCenter + Vec3(distance * 0.9f, distance * 0.4f, distance * 0.9f);
-  outView = Mat4::LookAt(camPos, aabbCenter, Vec3(0, 1, 0));
-  outProj = Mat4::Perspective(45.0f, 1.0f, 0.01f, 1000.0f);
-}
+      static std::filesystem::path ResolvePreviewShaderPath(const char *fileName)
+      {
+        namespace fs = std::filesystem;
+        const fs::path root = ProjectPath::Root();
+        const std::array<fs::path, 4> candidates = {
+            root / "engine" / "renderer" / "shaders" / fileName,
+            root.parent_path() / "horo-engine" / "renderer" / "shaders" / fileName,
+            root / "horo-engine" / "renderer" / "shaders" / fileName,
+            root / "renderer" / "shaders" / fileName,
+        };
 
-// Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
-// meshKey must be the resolved mesh path (same key used in meshCache).
-static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
-                                                const std::string& meshKey) {
-  const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
-  if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
-    return {};
+        for (const auto &candidate : candidates)
+        {
+          std::error_code ec;
+          if (fs::is_regular_file(candidate, ec) && !ec)
+            return candidate;
+        }
 
-  auto& renderer = AssetThumbnailRenderer::Instance();
+        return candidates.front();
+      }
 
-  // Return existing per-mesh texture if already rendered this session.
-  auto cacheIt = renderer.renderedTextureCache.find(meshKey);
-  if (cacheIt != renderer.renderedTextureCache.end())
-    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
+      const char *SceneObjectTypeToString(SceneObjectType type)
+      {
+        switch (type)
+        {
+        case SceneObjectType::Panel:
+          return "Panel";
+        case SceneObjectType::Prop:
+          return "Prop";
+        case SceneObjectType::Light:
+          return "Light";
+        case SceneObjectType::Camera:
+          return "Camera";
+        }
+        return "Panel";
+      }
 
-  if (!renderer.IsValid())
-    return {};
-
-  // Save GL state (viewport)
-  GLint prevViewport[4] = {0, 0, 1, 1};
-  glGetIntegerv(GL_VIEWPORT, prevViewport);
-
-  // Bind FBO and set viewport
-  glBindFramebuffer(GL_FRAMEBUFFER, renderer.fbo);
-  glViewport(0, 0, renderer.width, renderer.height);
-
-  // Clear and setup rendering
-  glClearColor(0.15f, 0.15f, 0.15f, 1.0f);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  glEnable(GL_DEPTH_TEST);
-  glEnable(GL_CULL_FACE);
-  glCullFace(GL_BACK);
-
-  // Setup camera matrices
-  Mat4 view, proj;
-  FitCameraToMesh(mesh, view, proj);
-
-  // Render mesh with basic shader
-  renderer.shader.Bind();
-  renderer.shader.SetMat4("u_model", Mat4::Identity());
-  renderer.shader.SetMat4("u_view", view);
-  renderer.shader.SetMat4("u_projection", proj);
-  renderer.shader.SetVec3("u_cameraPos", view.Inverse().GetTranslation());
-  renderer.shader.SetVec4("u_color", Vec4(0.8f, 0.8f, 0.8f, 1.0f));
-  renderer.shader.SetInt("u_hasTexture", 0);
-  renderer.shader.SetInt("u_lightCount", 2);
-
-  // Key light: upper-left, warm white
-  renderer.shader.SetInt("u_lights[0].type", 0);
-  renderer.shader.SetVec3("u_lights[0].direction", Vec3(-1.0f, -1.5f, -0.5f).Normalized());
-  renderer.shader.SetVec3("u_lights[0].color", Vec3(1.2f, 1.2f, 1.1f));
-
-  // Fill light: lower-right, cool blue at lower intensity for depth contrast
-  renderer.shader.SetInt("u_lights[1].type", 0);
-  renderer.shader.SetVec3("u_lights[1].direction", Vec3(1.0f, 0.5f, 1.0f).Normalized());
-  renderer.shader.SetVec3("u_lights[1].color", Vec3(0.3f, 0.35f, 0.5f));
-
-  // Draw mesh
-  if (mesh.isSkinned && mesh.skinnedMesh) {
-    mesh.skinnedMesh->Draw();
-  } else if (!mesh.isSkinned && mesh.mesh) {
-    mesh.mesh->Draw();
-  }
-
-  // Copy FBO contents into a new per-mesh texture so each asset keeps its own image.
-  unsigned int destTex = 0;
-  glGenTextures(1, &destTex);
-  glBindTexture(GL_TEXTURE_2D, destTex);
-  // glReadPixels only runs once per mesh (then cached); CPU cost is acceptable.
-  std::vector<unsigned char> pixels(static_cast<size_t>(renderer.width * renderer.height * 3));
-  glReadPixels(0, 0, renderer.width, renderer.height, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, renderer.width, renderer.height, 0, GL_RGB, GL_UNSIGNED_BYTE,
-               pixels.data());
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  renderer.renderedTextureCache[meshKey] = destTex;
-
-  // Restore GL state
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-  glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
-
-  return RenderTargetHandle::OpenGLTexture(destTex, true);
-}
-
-static bool TryGetAssetPreviewHandle(const std::string& assetId,
-                                     const AssetDef& asset,
-                                     RenderTargetHandle* outHandle) {
-  if (!outHandle)
-    return false;
-  *outHandle = {};
-
-  const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
-  if (!caps.supportsNativeTextureHandles)
-    return false;
-
-  static std::unordered_map<std::string, Texture> s_textureByPath;
-  static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
-  static std::unordered_set<std::string> s_noPreviewCache;
-
-  const std::string key = assetId + "|" + asset.mesh + "|" + asset.albedoMap;
-  if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
-    return false;
-
-  auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
-    if (!caps.supportsNativeTextureHandles)
-      return {};
-    if (path.empty())
-      return {};
-    std::error_code ec;
-    if (!std::filesystem::is_regular_file(path, ec) || ec)
-      return {};
-    const std::string abs = path.generic_string();
-    auto it = s_textureByPath.find(abs);
-    if (it == s_textureByPath.end()) {
-      Texture tex = Texture::FromFile(abs, false);
-      it = s_textureByPath.emplace(abs, std::move(tex)).first;
-    }
-    if (!it->second.IsValid())
-      return {};
-    return it->second.GetRenderTargetHandle();
-  };
-
-  // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
-  if (caps.supportsOffscreenTargets && !asset.mesh.empty()) {
-    auto& thumbnailRenderer = AssetThumbnailRenderer::Instance();
-    if (thumbnailRenderer.Init()) {
-      if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {
-        const std::string meshKey =
-            ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
-        const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
-        if (handle.IsValid()) {
-          *outHandle = handle;
+      bool ParseSceneObjectType(const std::string &raw, SceneObjectType *outType)
+      {
+        if (!outType)
+          return false;
+        std::string value = raw;
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c)
+                       { return static_cast<char>(std::tolower(c)); });
+        if (value == "panel")
+        {
+          *outType = SceneObjectType::Panel;
           return true;
         }
+        if (value == "prop")
+        {
+          *outType = SceneObjectType::Prop;
+          return true;
+        }
+        if (value == "light")
+        {
+          *outType = SceneObjectType::Light;
+          return true;
+        }
+        if (value == "camera")
+        {
+          *outType = SceneObjectType::Camera;
+          return true;
+        }
+        return false;
       }
-    }
-  }
 
-  // Priority 2: Fallback to texture-based thumbnails
-  if (!asset.albedoMap.empty()) {
-    const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
-    const RenderTargetHandle handle = loadTextureByPath(albedo);
-    if (handle.IsValid()) {
-      *outHandle = handle;
-      return true;
-    }
-  }
+      static Vec3 MultiplyComponents(const Vec3 &a, const Vec3 &b)
+      {
+        return {a.x * b.x, a.y * b.y, a.z * b.z};
+      }
 
-  const std::filesystem::path meshPath = ResolveProjectRelativeOrAbsolutePath(asset.mesh);
-  if (!meshPath.empty()) {
-    const std::string ext = ToLowerAscii(meshPath.extension().string());
+      static bool TryResolveObjectMeshPath(const SceneDocument &doc,
+                                           const SceneObject &obj,
+                                           std::string *outMeshPath,
+                                           Vec3 *outAssetRenderScale)
+      {
+        if (outMeshPath)
+          outMeshPath->clear();
+        if (outAssetRenderScale)
+          *outAssetRenderScale = Vec3::One();
 
-    if (ext == ".obj") {
-      const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
-      const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
-      if (handle.IsValid()) {
-        *outHandle = handle;
+        if (!obj.assetId.empty())
+        {
+          const auto assetIt = doc.assets.find(obj.assetId);
+          if (assetIt == doc.assets.end())
+            return false;
+          if (outMeshPath)
+            *outMeshPath = assetIt->second.mesh;
+          if (outAssetRenderScale)
+          {
+            Vec3 parsedScale = Vec3::One();
+            if (TryParseVec3Csv(assetIt->second.renderScale, &parsedScale))
+              *outAssetRenderScale = parsedScale;
+          }
+          return !assetIt->second.mesh.empty();
+        }
+
+        const auto propIt = obj.props.find("mesh");
+        if (propIt == obj.props.end() || propIt->second.empty())
+          return false;
+        if (outMeshPath)
+          *outMeshPath = propIt->second;
         return true;
       }
-    }
 
-    if (ext == ".gltf" || ext == ".glb") {
-      const std::string absMesh = meshPath.generic_string();
-      auto it = s_gltfTextureByMesh.find(absMesh);
-      if (it == s_gltfTextureByMesh.end()) {
-        GltfLoadResult result = GltfLoader::Load(absMesh);
-        if (result.albedoTexture && result.albedoTexture->IsValid())
-          it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
+      bool IsObjectReferencePropKey(const std::string &key)
+      {
+        return key == "parentId" || key == "followTargetId";
       }
-      if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid()) {
-        *outHandle = it->second->GetRenderTargetHandle();
-        return true;
+
+      std::unordered_set<std::string> CollectReservedObjectIds(const SceneDocument &doc)
+      {
+        std::unordered_set<std::string> reservedIds;
+        reservedIds.reserve(doc.objects.size() * 2);
+        for (const SceneObject &obj : doc.objects)
+        {
+          if (!obj.id.empty())
+            reservedIds.insert(obj.id);
+          for (const auto &entry : obj.props)
+          {
+            if (IsObjectReferencePropKey(entry.first) && !entry.second.empty())
+              reservedIds.insert(entry.second);
+          }
+        }
+        return reservedIds;
       }
-    }
-  }
 
-  s_noPreviewCache.insert(key);
-  return false;
-}
+      bool IsReservedObjectId(const SceneDocument &doc,
+                              const std::string &id,
+                              const std::string *ignoreConcreteObjectId = nullptr)
+      {
+        if (id.empty())
+          return false;
+        for (const SceneObject &obj : doc.objects)
+        {
+          if (!obj.id.empty() && (!ignoreConcreteObjectId || obj.id != *ignoreConcreteObjectId) && obj.id == id)
+            return true;
+          for (const auto &entry : obj.props)
+          {
+            if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
+              continue;
+            if (ignoreConcreteObjectId && entry.second == *ignoreConcreteObjectId)
+              continue;
+            if (entry.second == id)
+              return true;
+          }
+        }
+        return false;
+      }
 
-static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
-  if (!handle.IsValid())
-    return (ImTextureID)0;
+      void RewriteObjectIdReferences(SceneDocument *doc, const std::string &oldId, const std::string &newId)
+      {
+        if (!doc || oldId.empty() || oldId == newId)
+          return;
+        for (SceneObject &object : doc->objects)
+        {
+          for (auto &entry : object.props)
+          {
+            if (IsObjectReferencePropKey(entry.first) && entry.second == oldId)
+              entry.second = newId;
+          }
+        }
+      }
 
-  switch (handle.nativeType) {
-    case RenderNativeHandleType::OpenGLTexture2D:
-      return (ImTextureID)(intptr_t)handle.nativeHandle;
-    case RenderNativeHandleType::VulkanImGuiDescriptorSet:
-      return (ImTextureID)(intptr_t)handle.nativeHandle;
-    case RenderNativeHandleType::None:
-      return (ImTextureID)0;
-  }
+      void LogDanglingObjectReferences(const SceneDocument &doc, const std::string &sourceLabel)
+      {
+        std::unordered_set<std::string> objectIds;
+        objectIds.reserve(doc.objects.size() * 2);
+        for (const SceneObject &object : doc.objects)
+        {
+          if (!object.id.empty())
+            objectIds.insert(object.id);
+        }
+        for (const SceneObject &object : doc.objects)
+        {
+          for (const auto &entry : object.props)
+          {
+            if (!IsObjectReferencePropKey(entry.first) || entry.second.empty())
+              continue;
+            if (objectIds.find(entry.second) == objectIds.end())
+              LOG_WARN("[Editor] Dangling object reference in %s: %s.%s -> %s",
+                       sourceLabel.c_str(), object.id.c_str(), entry.first.c_str(), entry.second.c_str());
+          }
+        }
+      }
 
-  return (ImTextureID)0;
-}
+      static Mat4 BuildObjectModelMatrix(const SceneDocument &doc, const SceneObject &obj)
+      {
+        Vec3 assetRenderScale = Vec3::One();
+        std::string ignoredMeshPath;
+        TryResolveObjectMeshPath(doc, obj, &ignoredMeshPath, &assetRenderScale);
 
-std::string PickTextureFilePath() {
-#ifdef _WIN32
-  char filePath[MAX_PATH] = {};
-  OPENFILENAMEA ofn = {};
-  ofn.lStructSize = sizeof(ofn);
-  ofn.lpstrFilter = "Images\0*.png;*.jpg;*.jpeg;*.bmp;*.tga;*.webp\0"
-                    "PNG\0*.png\0"
-                    "JPEG\0*.jpg;*.jpeg\0"
-                    "All Files\0*.*\0";
-  ofn.lpstrFile = filePath;
-  ofn.nMaxFile = sizeof(filePath);
-  ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
-  if (GetOpenFileNameA(&ofn))
-    return filePath;
-  return {};
-#elif defined(__APPLE__)
-  return ReadPathFromOsascript(
-      "/usr/bin/osascript -e 'try' "
-      "-e 'POSIX path of (choose file with prompt \"Select texture image\")' "
-      "-e 'on error' -e 'return \"\"' -e 'end try' 2>/dev/null");
-#else
-  return {};
+        const Quaternion rotation =
+            Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
+        const Vec3 totalScale = MultiplyComponents(obj.scale, assetRenderScale);
+        return Mat4::Translate(obj.position) * Mat4::Rotate(rotation) * Mat4::Scale(totalScale);
+      }
+
+      static void SyncAssetScaleMetadata(SceneDocument *doc)
+      {
+        if (!doc)
+          return;
+
+        for (SceneObject &obj : doc->objects)
+        {
+          if (obj.assetId.empty())
+          {
+            obj.props.erase("_assetRenderScale");
+            continue;
+          }
+
+          const auto assetIt = doc->assets.find(obj.assetId);
+          if (assetIt == doc->assets.end())
+          {
+            obj.props.erase("_assetRenderScale");
+            continue;
+          }
+
+          obj.props["_assetRenderScale"] = assetIt->second.renderScale.empty()
+                                               ? "1.0000,1.0000,1.0000"
+                                               : assetIt->second.renderScale;
+        }
+      }
+
+      // ===== 3D Asset Thumbnail Rendering Infrastructure =====
+      // Framebuffer object for offscreen mesh rendering (shared across all asset previews).
+      struct AssetThumbnailRenderer
+      {
+        unsigned int fbo = 0;
+        unsigned int colorTexture = 0;
+        unsigned int depthRenderBuffer = 0;
+        int width = 512;
+        int height = 512;
+        Shader shader; // Basic lighting shader for thumbnail
+
+        // Cache: assetKey -> currently rendered mesh/texture ID
+        struct CachedMesh
+        {
+          std::shared_ptr<Mesh> mesh;
+          std::shared_ptr<SkinnedMesh> skinnedMesh;
+          std::shared_ptr<Skeleton> skeleton;
+          bool isSkinned = false;
+        };
+        std::unordered_map<std::string, CachedMesh> meshCache;
+        std::unordered_set<std::string> noPreviewKeys;
+        // Per-mesh rendered texture cache: each mesh gets its own texture so all
+        // thumbnails don't overwrite each other by sharing a single FBO attachment.
+        std::unordered_map<std::string, unsigned int> renderedTextureCache;
+
+        static AssetThumbnailRenderer &Instance()
+        {
+          static AssetThumbnailRenderer instance;
+          return instance;
+        }
+
+        bool Init()
+        {
+          if (fbo != 0)
+            return IsValid();
+
+          // Create FBO
+          glGenFramebuffers(1, &fbo);
+          glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+          // Create color texture
+          glGenTextures(1, &colorTexture);
+          glBindTexture(GL_TEXTURE_2D, colorTexture);
+          glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+          glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0);
+
+          // Create depth renderbuffer
+          glGenRenderbuffers(1, &depthRenderBuffer);
+          glBindRenderbuffer(GL_RENDERBUFFER, depthRenderBuffer);
+          glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+          glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthRenderBuffer);
+
+          const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+          glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+          if (status != GL_FRAMEBUFFER_COMPLETE)
+          {
+            LOG_ERROR("AssetThumbnailRenderer: FBO incomplete, status=%d", (int)status);
+            Cleanup();
+            return false;
+          }
+
+          // Load simple lighting shader
+          try
+          {
+            const std::filesystem::path vertPath = ResolvePreviewShaderPath("basic.vert");
+            const std::filesystem::path fragPath = ResolvePreviewShaderPath("basic.frag");
+            shader = Shader::FromFiles(vertPath.generic_string(), fragPath.generic_string());
+          }
+          catch (const std::exception &e)
+          {
+            LOG_ERROR("Failed to load preview shader: %s", e.what());
+            Cleanup();
+            return false;
+          }
+
+          return IsValid();
+        }
+
+        bool IsValid() const
+        {
+          return fbo != 0 && colorTexture != 0 && depthRenderBuffer != 0 && shader.IsValid();
+        }
+
+        void Cleanup()
+        {
+          meshCache.clear();
+          noPreviewKeys.clear();
+          for (auto &[key, texId] : renderedTextureCache)
+          {
+            if (texId != 0)
+              glDeleteTextures(1, &texId);
+          }
+          renderedTextureCache.clear();
+          if (colorTexture != 0)
+          {
+            glDeleteTextures(1, &colorTexture);
+            colorTexture = 0;
+          }
+          if (depthRenderBuffer != 0)
+          {
+            glDeleteRenderbuffers(1, &depthRenderBuffer);
+            depthRenderBuffer = 0;
+          }
+          if (fbo != 0)
+          {
+            glDeleteFramebuffers(1, &fbo);
+            fbo = 0;
+          }
+        }
+
+        ~AssetThumbnailRenderer() { Cleanup(); }
+      };
+
+      // Try to load a static mesh (OBJ) or skinned mesh (GLTF/GLB) from the given path.
+      // Returns cache entry or nullptr on failure.
+      static AssetThumbnailRenderer::CachedMesh *TryLoadAssetMesh(const std::string &meshPath)
+      {
+        if (meshPath.empty())
+          return nullptr;
+
+        const std::filesystem::path path = ResolveProjectRelativeOrAbsolutePath(meshPath);
+        const std::string ext = ToLowerAscii(path.extension().string());
+
+        auto &renderer = AssetThumbnailRenderer::Instance();
+        const std::string cacheKey = path.generic_string();
+
+        // Check no-preview cache
+        if (renderer.noPreviewKeys.find(cacheKey) != renderer.noPreviewKeys.end())
+        {
+          return nullptr;
+        }
+
+        // Check mesh cache
+        auto it = renderer.meshCache.find(cacheKey);
+        if (it != renderer.meshCache.end())
+        {
+          return &it->second;
+        }
+
+        AssetThumbnailRenderer::CachedMesh entry;
+
+        try
+        {
+          if (ext == ".obj")
+          {
+            entry.mesh = std::make_shared<Mesh>(ObjLoader::Load(path.generic_string()));
+            entry.isSkinned = false;
+          }
+          else if (ext == ".gltf" || ext == ".glb")
+          {
+            GltfLoadResult result = GltfLoader::Load(path.generic_string());
+            if (result.mesh)
+            {
+              entry.skinnedMesh = result.mesh;
+              entry.skeleton = result.skeleton;
+              entry.isSkinned = true;
+            }
+            else
+            {
+              LOG_WARN("[Thumbnail] GLTF load failed (no mesh): %s", cacheKey.c_str());
+              renderer.noPreviewKeys.insert(cacheKey);
+              return nullptr;
+            }
+          }
+          else
+          {
+            LOG_WARN("[Thumbnail] Unsupported mesh format: %s", ext.c_str());
+            renderer.noPreviewKeys.insert(cacheKey);
+            return nullptr;
+          }
+        }
+        catch (const std::exception &e)
+        {
+          LOG_WARN("[Thumbnail] Failed to load mesh for preview: %s (error: %s)", cacheKey.c_str(), e.what());
+          renderer.noPreviewKeys.insert(cacheKey);
+          return nullptr;
+        }
+
+        it = renderer.meshCache.emplace(cacheKey, std::move(entry)).first;
+        return &it->second;
+      }
+
+      // Fit camera to mesh AABB with a comfortable margin. Returns view and projection matrices.
+      static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh &mesh,
+                                  Mat4 &outView, Mat4 &outProj)
+      {
+        Vec3 aabbCenter;
+        Vec3 aabbHalf;
+
+        if (mesh.isSkinned && mesh.skinnedMesh)
+        {
+          aabbCenter = mesh.skinnedMesh->GetLocalAabbCenter();
+          aabbHalf = mesh.skinnedMesh->GetHalfExtents();
+        }
+        else if (!mesh.isSkinned && mesh.mesh)
+        {
+          aabbCenter = mesh.mesh->GetLocalAabbCenter();
+          aabbHalf = mesh.mesh->GetHalfExtents();
+        }
+        else
+        {
+          // Fallback: identity view/proj
+          outView = Mat4::Identity();
+          outProj = Mat4::Perspective(45.0f, 1.0f, 0.01f, 100.0f);
+          return;
+        }
+
+        // Compute distance to fit AABB on screen (with 1.3x margin for breathing room)
+        const float maxHalf = std::max({aabbHalf.x, aabbHalf.y, aabbHalf.z});
+        const float fov = 45.0f * 3.14159f / 180.f;
+        const float distance = maxHalf * 1.3f / std::tan(fov * 0.5f);
+
+        // Position camera at ~22° elevation for a clear side-on view of the object
+        const Vec3 camPos = aabbCenter + Vec3(distance * 0.9f, distance * 0.4f, distance * 0.9f);
+        outView = Mat4::LookAt(camPos, aabbCenter, Vec3(0, 1, 0));
+        outProj = Mat4::Perspective(45.0f, 1.0f, 0.01f, 1000.0f);
+      }
+
+      // Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
+      // meshKey must be the resolved mesh path (same key used in meshCache).
+      static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh &mesh,
+                                                      const std::string &meshKey)
+      {
+        const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+        if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
+          return {};
+
+#if defined(MONOLITH_HAS_VULKAN)
+        if (Renderer::GetBackendId() == RenderBackendId::Vulkan)
+        {
+          auto *backend = dynamic_cast<VulkanRenderBackend *>(Renderer::GetBackendForInterop());
+          if (!backend)
+            return {};
+
+          auto &renderer = AssetThumbnailRenderer::Instance();
+          if (!backend->EnsureOffscreenRenderTarget(meshKey,
+                                                    static_cast<uint32_t>(renderer.width),
+                                                    static_cast<uint32_t>(renderer.height)))
+          {
+            LOG_WARN("[Thumbnail] Vulkan offscreen target creation failed for %s: %s",
+                     meshKey.c_str(),
+                     backend->GetLastError().c_str());
+            return {};
+          }
+
+          RenderTargetHandle handle;
+          if (!backend->TryGetOffscreenRenderTargetHandle(meshKey, &handle, false))
+          {
+            LOG_WARN("[Thumbnail] Vulkan offscreen handle registration failed for %s: %s",
+                     meshKey.c_str(),
+                     backend->GetLastError().c_str());
+            return {};
+          }
+          return handle;
+        }
 #endif
-}
 
-// Copy a picked texture into assets/models (same convention as OBJ import) and return
-// a project-relative path for the scene JSON / LevelLoader.
-// subfolderHint: asset name (e.g. "enemy") → copies into assets/models/enemy/.
-// Empty hint falls back to flat assets/models/.
-static bool IsPathWithinDirectory(const std::filesystem::path& path,
-                                  const std::filesystem::path& directory) {
-  namespace fs = std::filesystem;
-  std::error_code ec;
-  const fs::path normPath = fs::weakly_canonical(path, ec);
-  if (ec)
-    return false;
-  ec.clear();
-  const fs::path normDir = fs::weakly_canonical(directory, ec);
-  if (ec)
-    return false;
+        auto &renderer = AssetThumbnailRenderer::Instance();
 
-  auto dirIt = normDir.begin();
-  auto pathIt = normPath.begin();
-  for (; dirIt != normDir.end() && pathIt != normPath.end(); ++dirIt, ++pathIt) {
-    if (*dirIt != *pathIt)
-      return false;
-  }
-  return dirIt == normDir.end();
-}
+        // Return existing per-mesh texture if already rendered this session.
+        auto cacheIt = renderer.renderedTextureCache.find(meshKey);
+        if (cacheIt != renderer.renderedTextureCache.end())
+          return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
 
-static std::filesystem::path ResolveProjectAssetPath(const std::string& rawPath) {
-  namespace fs = std::filesystem;
-  if (rawPath.empty())
-    return {};
+        if (!renderer.IsValid())
+          return {};
 
-  const fs::path path(rawPath);
-  if (path.is_absolute())
-    return {};
+        // Save GL state (viewport)
+        GLint prevViewport[4] = {0, 0, 1, 1};
+        glGetIntegerv(GL_VIEWPORT, prevViewport);
 
-  std::error_code ec;
-  const fs::path root = fs::weakly_canonical(ProjectPath::Root(), ec);
-  if (ec)
-    return {};
+        // Bind FBO and set viewport
+        glBindFramebuffer(GL_FRAMEBUFFER, renderer.fbo);
+        glViewport(0, 0, renderer.width, renderer.height);
 
-  return fs::weakly_canonical(root / path, ec);
-}
+        // Clear and setup rendering
+        glClearColor(0.15f, 0.15f, 0.15f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glEnable(GL_DEPTH_TEST);
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
 
-static std::filesystem::path GetManagedImportedAssetDirectory(const AssetDef& asset) {
-  namespace fs = std::filesystem;
-  if (!asset.guid.empty()) {
-    const fs::path guidDirectory = GetManagedAssetDirectory(asset.guid);
-    std::error_code ec;
-    if (fs::exists(guidDirectory, ec) && !ec)
-      return guidDirectory;
-  }
-  if (asset.mesh.empty())
-    return {};
+        // Setup camera matrices
+        Mat4 view, proj;
+        FitCameraToMesh(mesh, view, proj);
 
-  const fs::path meshPath = ResolveProjectAssetPath(asset.mesh);
-  if (meshPath.empty())
-    return {};
+        // Render mesh with basic shader
+        renderer.shader.Bind();
+        renderer.shader.SetMat4("u_model", Mat4::Identity());
+        renderer.shader.SetMat4("u_view", view);
+        renderer.shader.SetMat4("u_projection", proj);
+        renderer.shader.SetVec3("u_cameraPos", view.Inverse().GetTranslation());
+        renderer.shader.SetVec4("u_color", Vec4(0.8f, 0.8f, 0.8f, 1.0f));
+        renderer.shader.SetInt("u_hasTexture", 0);
+        renderer.shader.SetInt("u_lightCount", 2);
 
-  std::error_code ec;
-  const fs::path modelsRoot = fs::weakly_canonical(ProjectPath::Root() / "assets" / "models", ec);
-  if (ec || !IsPathWithinDirectory(meshPath, modelsRoot))
-    return {};
+        // Key light: upper-left, warm white
+        renderer.shader.SetInt("u_lights[0].type", 0);
+        renderer.shader.SetVec3("u_lights[0].direction", Vec3(-1.0f, -1.5f, -0.5f).Normalized());
+        renderer.shader.SetVec3("u_lights[0].color", Vec3(1.2f, 1.2f, 1.1f));
 
-  const fs::path relativeMesh = fs::relative(meshPath, modelsRoot, ec);
-  if (ec || relativeMesh.empty())
-    return {};
+        // Fill light: lower-right, cool blue at lower intensity for depth contrast
+        renderer.shader.SetInt("u_lights[1].type", 0);
+        renderer.shader.SetVec3("u_lights[1].direction", Vec3(1.0f, 0.5f, 1.0f).Normalized());
+        renderer.shader.SetVec3("u_lights[1].color", Vec3(0.3f, 0.35f, 0.5f));
 
-  auto relIt = relativeMesh.begin();
-  if (relIt == relativeMesh.end())
-    return {};
-  const fs::path folder = *relIt;
-  ++relIt;
-  if (relIt == relativeMesh.end() || folder.empty() || folder == "." || folder == "..")
-    return {};
-
-  const fs::path managedDir = modelsRoot / folder;
-  if (!asset.albedoMap.empty()) {
-    const fs::path albedoPath = ResolveProjectAssetPath(asset.albedoMap);
-    if (albedoPath.empty() || !IsPathWithinDirectory(albedoPath, managedDir))
-      return {};
-  }
-
-  return managedDir;
-}
-
-}  // namespace
-
-// ---- Lifecycle ---------------------------------------------------------------
-
-void EditorLayer::Init(GLFWwindow* window) {
-  m_window = window;
-  m_mcpController.Initialize();
-  m_mcpSettingsDraft = m_mcpController.GetSettings();
-  if (m_mcpController.SettingsDocument().parseError)
-    LOG_WARN("[MCP] Settings load fallback: %s", m_mcpController.SettingsDocument().error.c_str());
-
-  IMGUI_CHECKVERSION();
-  ImGui::CreateContext();
-  ImGui::StyleColorsDark();
-  ImGuiIO& io = ImGui::GetIO();
-  m_imguiIniPath = ResolveEditorLayoutPath().string();
-  std::error_code settingsEc;
-  std::filesystem::create_directories(ResolveEditorLayoutPath().parent_path(), settingsEc);
-  if (settingsEc) {
-    LOG_WARN("[Editor] Failed to ensure editor settings directory: %s", settingsEc.message().c_str());
-    m_imguiIniPath.clear();
-    io.IniFilename = nullptr;
-  } else {
-    m_hasPersistedDockLayout = std::filesystem::exists(ResolveEditorLayoutPath());
-    io.IniFilename = m_imguiIniPath.c_str();
-  }
-  LoadWorkspaceState();
-
-  const RenderBackendId backendId = Renderer::GetBackendId();
-  m_imguiBackendInitialized = InitEditorImGuiBackend(window, backendId);
-  if (!m_imguiBackendInitialized) {
-    LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'", ToString(backendId));
-  }
-
-  m_schema.LoadFromFile("assets/editor_schema.json");
-
-  // Load wireframe shader
-  try {
-    const std::filesystem::path wv = ResolvePreviewShaderPath("wire.vert");
-    const std::filesystem::path wf = ResolvePreviewShaderPath("wire.frag");
-    m_wireframeShader = Shader::FromFiles(wv.generic_string(), wf.generic_string());
-  } catch (const std::exception& e) {
-    LOG_WARN("[Editor] Failed to load wireframe shader: %s", e.what());
-  }
-
-  // Clear thumbnail caches to allow fresh asset preview generation
-  auto& renderer = AssetThumbnailRenderer::Instance();
-  renderer.noPreviewKeys.clear();
-  renderer.meshCache.clear();
-  LOG_INFO("[Editor] Asset thumbnail caches cleared on Init");
-}
-
-void EditorLayer::Shutdown() {
-  SaveWorkspaceStateIfNeeded(true);
-  if (!m_imguiIniPath.empty())
-    ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
-  m_mcpController.Shutdown();
-  if (m_imguiBackendInitialized)
-    ShutdownEditorImGuiBackend(Renderer::GetBackendId());
-  m_imguiBackendInitialized = false;
-  ImGui::DestroyContext();
-}
-
-void EditorLayer::Toggle() {
-  m_active = !m_active;
-  if (!m_active)
-    m_playMode = false;
-  if (m_flyMode) {
-    m_flyMode = false;
-    m_flyCamInitialized = false;
-  }
-  m_closeRequested = false;
-  m_confirmExitOpen = false;
-  m_exitConfirmError.clear();
-  glfwSetInputMode(m_window, GLFW_CURSOR, m_active ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED);
-  m_prevMouseL = false;
-  m_selectedIndices.clear();
-  m_mcpController.SetEditorActive(m_active);
-}
-
-void EditorLayer::SetProjectBrowserRoot(std::filesystem::path root) {
-  InvalidateProjectBrowserCache();
-  m_projectBrowserRoot.clear();
-  m_projectBrowserRootValid = false;
-  m_projectBrowserCwd.clear();
-  m_projectBrowserCwdValid = false;
-  if (root.empty())
-    return;
-  std::error_code ec;
-  std::filesystem::path canon = std::filesystem::weakly_canonical(root, ec);
-  if (ec)
-    canon = std::move(root);
-  if (!std::filesystem::is_directory(canon, ec) || ec) {
-    m_projectBrowserRoot = canon;
-    return;
-  }
-  m_projectBrowserRoot = std::move(canon);
-  m_projectBrowserRootValid = true;
-  if (!m_savedProjectBrowserCwd.empty()) {
-    std::filesystem::path preferred = m_savedProjectBrowserCwd;
-    if (preferred.is_relative())
-      preferred = m_projectBrowserRoot / preferred;
-    preferred = std::filesystem::weakly_canonical(preferred, ec);
-    if (!ec && std::filesystem::is_directory(preferred) &&
-        preferred.native().rfind(m_projectBrowserRoot.native(), 0) == 0) {
-      m_projectBrowserCwd = std::move(preferred);
-      m_projectBrowserCwdValid = true;
-      return;
-    }
-  }
-  m_projectBrowserCwd = m_projectBrowserRoot;
-  m_projectBrowserCwdValid = true;
-}
-
-void EditorLayer::SetProjectBrowserExtraBlocklist(std::unordered_set<std::string> names) {
-  m_projectExtraBlocklist = std::move(names);
-  InvalidateProjectBrowserCache();
-}
-
-void EditorLayer::InvalidateProjectBrowserCache() {
-  m_projectDirCache.clear();
-}
-
-void EditorLayer::LoadWorkspaceState() {
-  m_workspaceDocument = LoadEditorWorkspaceDocument();
-  if (m_workspaceDocument.parseError) {
-    LOG_WARN("[Editor] Workspace settings load fallback: %s", m_workspaceDocument.error.c_str());
-  }
-
-  m_consoleShowInfo = m_workspaceDocument.state.consoleShowInfo;
-  m_consoleShowWarn = m_workspaceDocument.state.consoleShowWarn;
-  m_consoleShowError = m_workspaceDocument.state.consoleShowError;
-  if (!m_workspaceDocument.state.projectBrowserCwd.empty())
-    m_savedProjectBrowserCwd = std::filesystem::path(m_workspaceDocument.state.projectBrowserCwd);
-  m_workspaceStateDirty = false;
-}
-
-void EditorLayer::SaveWorkspaceStateIfNeeded(bool force) {
-  if (!force && !m_workspaceStateDirty)
-    return;
-
-  m_workspaceDocument.state.consoleShowInfo = m_consoleShowInfo;
-  m_workspaceDocument.state.consoleShowWarn = m_consoleShowWarn;
-  m_workspaceDocument.state.consoleShowError = m_consoleShowError;
-  if (m_projectBrowserCwdValid && !m_projectBrowserCwd.empty()) {
-    m_workspaceDocument.state.projectBrowserCwd = m_projectBrowserCwd.generic_string();
-  } else if (!m_savedProjectBrowserCwd.empty()) {
-    m_workspaceDocument.state.projectBrowserCwd = m_savedProjectBrowserCwd.generic_string();
-  } else {
-    m_workspaceDocument.state.projectBrowserCwd.clear();
-  }
-
-  std::string saveError;
-  if (!SaveEditorWorkspaceDocument(&m_workspaceDocument, &saveError)) {
-    LOG_WARN("[Editor] Failed to save workspace settings: %s", saveError.c_str());
-    return;
-  }
-  m_workspaceStateDirty = false;
-}
-
-void EditorLayer::MarkWorkspaceStateDirty() {
-  m_workspaceStateDirty = true;
-}
-
-void EditorLayer::ApplyLoadedDocument(SceneDocument doc, bool resetHistory) {
-  if (doc.filePath.empty())
-    doc.filePath = "assets/scenes/scene.json";
-
-  EnsureAssetIdentity(&doc);
-
-  for (auto& obj : doc.objects) {
-    if (obj.type != SceneObjectType::Prop)
-      continue;
-    const auto behIt = obj.props.find("behavior");
-    if (behIt == obj.props.end() || behIt->second.empty() || behIt->second == "none")
-      continue;
-
-    bool hasScript = false;
-    for (const auto& comp : obj.components) {
-      if (comp.type == "script") {
-        hasScript = true;
-        break;
-      }
-    }
-    if (!hasScript) {
-      ComponentDesc script;
-      script.type = "script";
-      script.props["behaviorTag"] = behIt->second;
-      obj.components.push_back(std::move(script));
-    }
-    obj.props.erase("behavior");
-  }
-
-  SyncAssetScaleMetadata(&doc);
-  LogDanglingObjectReferences(doc, doc.filePath);
-
-  m_document = std::move(doc);
-  m_lastSavedDocument = m_document;
-  m_selectedIndices.clear();
-  m_selectedAssetId.clear();
-  if (resetHistory)
-    ClearHistory();
-}
-
-void EditorLayer::LoadDocument(SceneDocument doc) {
-  ApplyLoadedDocument(std::move(doc), true);
-}
-
-void EditorLayer::OnPathsDropped(int pathCount, const char** utf8Paths, float dropX, float dropY) {
-  if (!utf8Paths || pathCount <= 0)
-    return;
-  m_pendingPathDropPaths.clear();
-  m_pendingPathDropPaths.reserve(static_cast<size_t>(pathCount));
-  for (int i = 0; i < pathCount; ++i) {
-    if (utf8Paths[i])
-      m_pendingPathDropPaths.emplace_back(utf8Paths[i]);
-  }
-  if (m_pendingPathDropPaths.empty())
-    return;
-  m_pendingPathDropX = dropX;
-  m_pendingPathDropY = dropY;
-  m_hasPendingPathDrop = true;
-}
-
-void EditorLayer::ProcessPendingPathDrops() {
-  if (!m_hasPendingPathDrop)
-    return;
-  m_hasPendingPathDrop = false;
-
-  constexpr float kTextureDropHitSlopPx = 6.0f;
-  const float px = m_pendingPathDropX;
-  const float py = m_pendingPathDropY;
-  auto showAlbedoTextureToast = [this] {
-    m_clipboardToastLabel = "Albedo texture set";
-    m_clipboardToastTime = 2.0f;
-  };
-
-  for (const std::string& path : m_pendingPathDropPaths) {
-    if (!IsTextureFilePath(path))
-      continue;
-
-    if (m_albedoDraftDrop.Contains(px, py, kTextureDropHitSlopPx)) {
-      if (m_assetDraftGuid.empty())
-        m_assetDraftGuid = GenerateAssetGuid();
-      if (m_assetDraftId.empty())
-        m_assetDraftId = AssetIdFromImportedPath(path);
-      if (m_assetDraftDisplayName.empty())
-        m_assetDraftDisplayName = m_assetDraftId;
-      AssetDef draftAsset;
-      draftAsset.guid = m_assetDraftGuid;
-      draftAsset.displayName = m_assetDraftDisplayName;
-      draftAsset.mesh = m_assetDraftMesh;
-      draftAsset.renderScale =
-          m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
-      draftAsset.albedoMap = m_assetDraftAlbedoMap;
-      std::string err;
-      if (!m_assetImportService.ImportTextureForAsset(path, m_assetDraftId, &draftAsset, &err)) {
-        if (!err.empty())
-          LOG_WARN("Texture drop: %s", err.c_str());
-        continue;
-      }
-      m_assetDraftAlbedoMap = draftAsset.albedoMap;
-      showAlbedoTextureToast();
-      m_pendingPathDropPaths.clear();
-      return;
-    }
-    if (m_albedoSelDrop.Contains(px, py, kTextureDropHitSlopPx) && !m_selectedAssetId.empty()) {
-      auto it = m_document.assets.find(m_selectedAssetId);
-      if (it != m_document.assets.end()) {
-        std::string err;
-        if (!m_assetImportService.ImportTextureForAsset(path, m_selectedAssetId, &it->second, &err)) {
-          if (!err.empty())
-            LOG_WARN("Texture drop: %s", err.c_str());
-          continue;
+        // Draw mesh
+        if (mesh.isSkinned && mesh.skinnedMesh)
+        {
+          mesh.skinnedMesh->Draw();
         }
-        m_document.dirty = true;
-        showAlbedoTextureToast();
-      }
-      m_pendingPathDropPaths.clear();
-      return;
-    }
-  }
-
-  for (const std::string& path : m_pendingPathDropPaths) {
-    if (!IsObjFilePath(path))
-      continue;
-    if (m_assetDraftGuid.empty())
-      m_assetDraftGuid = GenerateAssetGuid();
-    if (m_assetDraftId.empty())
-      m_assetDraftId = AssetIdFromImportedPath(path);
-    if (m_assetDraftDisplayName.empty())
-      m_assetDraftDisplayName = m_assetDraftId;
-    AssetImportResult importResult =
-        m_assetImportService.ImportAssetFromSource(path, m_assetDraftId, m_assetDraftGuid, m_assetDraftDisplayName);
-    if (!importResult.ok) {
-      const std::string& err = importResult.error;
-      if (!err.empty())
-        LOG_WARN("Drop import: %s", err.c_str());
-      m_assetImportError = err.empty() ? "Drop import failed." : err;
-      m_openNewAssetHeader = true;
-      m_pendingPathDropPaths.clear();
-      return;
-    }
-    m_assetDraftMesh = importResult.asset.mesh;
-    m_assetDraftAlbedoMap = importResult.asset.albedoMap;
-    m_assetDraftRenderScale = importResult.asset.renderScale;
-    m_assetImportError.clear();
-    m_openNewAssetHeader = true;
-    m_clipboardToastLabel = "OBJ dropped — draft ready";
-    m_clipboardToastTime = 2.2f;
-    m_pendingPathDropPaths.clear();
-    return;
-  }
-
-  m_pendingPathDropPaths.clear();
-}
-
-void EditorLayer::SyncRuntimeEntityIds(Registry& registry) {
-  std::vector<int> propIndices;
-  propIndices.reserve(m_document.objects.size());
-  for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-    if (m_document.objects[static_cast<size_t>(i)].type == SceneObjectType::Prop)
-      propIndices.push_back(i);
-  }
-
-  std::vector<Entity> meshEntities;
-  for (Entity e : registry.GetEntities<MeshComponent>()) {
-    if (registry.Has<PlayerTagComponent>(e))
-      continue;
-    meshEntities.push_back(e);
-  }
-  std::sort(meshEntities.begin(), meshEntities.end());
-
-  const size_t propN = propIndices.size();
-  const size_t meshN = meshEntities.size();
-  const size_t n = std::min(propN, meshN);
-  if (propN != meshN) {
-    LOG_WARN(
-        "EditorLayer::SyncRuntimeEntityIds: %zu prop(s) vs %zu mesh entity(ies); mapping first %zu",
-        propN, meshN, n);
-  }
-
-  for (size_t j = 0; j < n; ++j) {
-    m_document.objects[static_cast<size_t>(propIndices[j])].props["_eid"] =
-        std::to_string(meshEntities[j]);
-  }
-  for (size_t j = n; j < propN; ++j)
-    m_document.objects[static_cast<size_t>(propIndices[j])].props.erase("_eid");
-}
-
-// ---- Per-frame update --------------------------------------------------------
-
-bool EditorLayer::OnUpdate(float dt, Camera& cam, int screenW, int screenH) {
-  if (m_clipboardToastTime > 0.0f)
-    m_clipboardToastTime = std::max(0.0f, m_clipboardToastTime - dt);
-
-  if (m_active) {
-    ProcessMcpCommands();
-
-    if (ShouldFinalizeEditorClose(m_closeRequested, m_wantsReload)) {
-      Toggle();
-      return false;
-    }
-
-    if (m_playMode) {
-      PublishMcpSnapshot();
-      return false;
-    }
-
-    EditorTrace("OnUpdate frame=%u fly=%d", static_cast<unsigned>(ImGui::GetFrameCount()),
-                m_flyMode ? 1 : 0);
-
-    ImGuiIO& io = ImGui::GetIO();
-
-    const bool accelHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
-                           glfwGetKey(m_window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
-                           glfwGetKey(m_window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
-                           glfwGetKey(m_window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
-    const bool shiftHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
-                           glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
-    const bool slashHeld = glfwGetKey(m_window, GLFW_KEY_SLASH) == GLFW_PRESS;
-    const bool f1Held = glfwGetKey(m_window, GLFW_KEY_F1) == GLFW_PRESS;
-    const bool currHelpToggle = f1Held || (slashHeld && shiftHeld);
-    if (ShouldToggleHelpPopup(currHelpToggle, m_prevHelpToggle, io.WantTextInput,
-                              ImGui::IsAnyItemActive())) {
-      m_helpOpen = !m_helpOpen;
-      if (!m_helpOpen)
-        m_helpSearchQuery.clear();
-    }
-    m_prevHelpToggle = currHelpToggle;
-
-    const bool currQuickOpenToggle =
-        accelHeld && !shiftHeld && glfwGetKey(m_window, GLFW_KEY_P) == GLFW_PRESS;
-    if (ShouldOpenQuickOpen(currQuickOpenToggle, m_prevQuickOpenToggle, m_flyMode,
-                            io.WantTextInput, ImGui::IsAnyItemActive())) {
-      m_quickOpenOpen = true;
-      m_quickOpenQuery.clear();
-    }
-    m_prevQuickOpenToggle = currQuickOpenToggle;
-
-    const bool currCommandPaletteToggle =
-        accelHeld && shiftHeld && glfwGetKey(m_window, GLFW_KEY_P) == GLFW_PRESS;
-    if (ShouldOpenCommandPalette(currCommandPaletteToggle,
-                                 m_prevCommandPaletteToggle,
-                                 m_flyMode,
-                                 io.WantTextInput,
-                                 ImGui::IsAnyItemActive())) {
-      m_commandPaletteOpen = true;
-      m_commandPaletteQuery.clear();
-    }
-    m_prevCommandPaletteToggle = currCommandPaletteToggle;
-
-    const bool currEsc = glfwGetKey(m_window, GLFW_KEY_ESCAPE) == GLFW_PRESS;
-    const bool hasBlockingPopup = m_helpOpen || m_quickOpenOpen || m_commandPaletteOpen ||
-                                  m_assetSearchOpen ||
-                                  m_confirmDeleteObjectsOpen || m_confirmDeleteAssetOpen ||
-                                  m_confirmExitOpen;
-    const bool currUndo = accelHeld && !shiftHeld && glfwGetKey(m_window, GLFW_KEY_Z) == GLFW_PRESS;
-    const bool currRedo =
-        accelHeld &&
-        ((shiftHeld && glfwGetKey(m_window, GLFW_KEY_Z) == GLFW_PRESS) ||
-         glfwGetKey(m_window, GLFW_KEY_Y) == GLFW_PRESS);
-    if (!m_flyMode && !io.WantTextInput && !ImGui::IsAnyItemActive() && !hasBlockingPopup) {
-      if (currUndo && !m_prevUndo)
-        UndoHistory();
-      if (currRedo && !m_prevRedo)
-        RedoHistory();
-    }
-    m_prevUndo = currUndo;
-    m_prevRedo = currRedo;
-    // Escape: dismiss gizmo only (no editor quit on Escape; use File / window close).
-    if (currEsc && !m_prevEsc && !io.WantTextInput && !ImGui::IsAnyItemActive() &&
-        !hasBlockingPopup && m_gizmo.IsActive()) {
-      m_gizmo.Deactivate();
-      if (m_gizmoHistoryPending) {
-        FinalizeHistoryTransaction();
-        m_gizmoHistoryPending = false;
-      }
-    }
-    m_prevEsc = currEsc;
-
-    // Tab toggles fly mode
-    bool currTab = glfwGetKey(m_window, GLFW_KEY_TAB) == GLFW_PRESS;
-    if (currTab && !m_prevTab)
-      ToggleFlyMode(cam);
-    m_prevTab = currTab;
-
-    if (m_flyMode) {
-      UpdateFlyCamera(dt, cam);
-      // Keep gizmo anchored to object even while flying
-      if (m_gizmo.IsActive()) {
-        const int syncIdx = PrimaryIdx();
-        if (syncIdx >= 0 && syncIdx < static_cast<int>(m_document.objects.size())) {
-          const auto& syncObj = m_document.objects[syncIdx];
-          Quaternion  syncRot = Quaternion::FromEuler(ToRadians(syncObj.pitch),
-                                                      ToRadians(syncObj.yaw),
-                                                      ToRadians(syncObj.roll));
-          m_gizmo.SyncTarget(syncObj.position, syncRot, syncObj.scale);
+        else if (!mesh.isSkinned && mesh.mesh)
+        {
+          mesh.mesh->Draw();
         }
-      }
-    } else {
-      // Ctrl/Cmd + Shift + C copies selected object reference code to clipboard.
-      bool currCopyRef = accelHeld && shiftHeld && glfwGetKey(m_window, GLFW_KEY_C) == GLFW_PRESS;
-      const int idx = PrimaryIdx();
-      const bool hasPrimarySelection = idx >= 0 && idx < static_cast<int>(m_document.objects.size());
-      if (ShouldCopySelectionRef(currCopyRef, m_prevCopyRef, io.WantTextInput,
-                                 ImGui::IsAnyItemActive(), hasPrimarySelection)) {
-        if (idx >= 0 && idx < static_cast<int>(m_document.objects.size())) {
-          const std::string code = BuildSelectionRefCode(m_document.objects[idx], idx);
-          glfwSetClipboardString(m_window, code.c_str());
-          m_clipboardToastLabel = "Reference copied";
-          m_clipboardToastTime = 1.6f;
-        }
-      }
-      m_prevCopyRef = currCopyRef;
 
-      // ---- Gizmo mode hotkeys (W/E/R) ----------------------------------------
-      const bool currW = glfwGetKey(m_window, GLFW_KEY_W) == GLFW_PRESS;
-      const bool currE = glfwGetKey(m_window, GLFW_KEY_E) == GLFW_PRESS;
-      const bool currR = glfwGetKey(m_window, GLFW_KEY_R) == GLFW_PRESS;
-      if (!io.WantTextInput && !ImGui::IsAnyItemActive()) {
-        const int gizmoIdx = PrimaryIdx();
-        if (gizmoIdx >= 0 &&
-            gizmoIdx < static_cast<int>(m_document.objects.size()) &&
-            m_gizmo.GetDragAxis() == GizmoAxis::None) {
-          const auto& gizmoObj = m_document.objects[gizmoIdx];
-          Quaternion  gizmoRot = Quaternion::FromEuler(ToRadians(gizmoObj.pitch),
-                                                       ToRadians(gizmoObj.yaw),
-                                                       ToRadians(gizmoObj.roll));
+        // Copy FBO contents into a new per-mesh texture so each asset keeps its own image.
+        unsigned int destTex = 0;
+        glGenTextures(1, &destTex);
+        glBindTexture(GL_TEXTURE_2D, destTex);
+        // glReadPixels only runs once per mesh (then cached); CPU cost is acceptable.
+        std::vector<unsigned char> pixels(static_cast<size_t>(renderer.width * renderer.height * 3));
+        glReadPixels(0, 0, renderer.width, renderer.height, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, renderer.width, renderer.height, 0, GL_RGB, GL_UNSIGNED_BYTE,
+                     pixels.data());
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        renderer.renderedTextureCache[meshKey] = destTex;
 
-          if (currW && (!m_prevGizmoW || m_gizmo.GetMode() != GizmoMode::Translate)) {
-            m_gizmo.Activate(GizmoMode::Translate, gizmoObj.position, gizmoRot, gizmoObj.scale);
-          } else if (currE && (!m_prevGizmoE || m_gizmo.GetMode() != GizmoMode::Rotate)) {
-            m_gizmo.Activate(GizmoMode::Rotate, gizmoObj.position, gizmoRot, gizmoObj.scale);
-          } else if (currR && (!m_prevGizmoR || m_gizmo.GetMode() != GizmoMode::Scale)) {
-            m_gizmo.Activate(GizmoMode::Scale, gizmoObj.position, gizmoRot, gizmoObj.scale);
+        // Restore GL state
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+
+        return RenderTargetHandle::OpenGLTexture(destTex, true);
+      }
+
+      static bool TryGetAssetPreviewHandle(const std::string &assetId,
+                                           const AssetDef &asset,
+                                           RenderTargetHandle *outHandle)
+      {
+        if (!outHandle)
+          return false;
+        *outHandle = {};
+
+        const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+        if (!caps.supportsNativeTextureHandles)
+          return false;
+
+        static std::unordered_map<std::string, Texture> s_textureByPath;
+        static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
+        static std::unordered_set<std::string> s_noPreviewCache;
+
+        const std::string key = assetId + "|" + asset.mesh + "|" + asset.albedoMap;
+        if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
+          return false;
+
+        auto loadTextureByPath = [&](const std::filesystem::path &path) -> RenderTargetHandle
+        {
+          if (!caps.supportsNativeTextureHandles)
+            return {};
+          if (path.empty())
+            return {};
+          std::error_code ec;
+          if (!std::filesystem::is_regular_file(path, ec) || ec)
+            return {};
+          const std::string abs = path.generic_string();
+          auto it = s_textureByPath.find(abs);
+          if (it == s_textureByPath.end())
+          {
+            Texture tex = Texture::FromFile(abs, false);
+            it = s_textureByPath.emplace(abs, std::move(tex)).first;
           }
-        }
-      }
-      m_prevGizmoW = currW;
-      m_prevGizmoE = currE;
-      m_prevGizmoR = currR;
+          if (!it->second.IsValid())
+            return {};
+          return it->second.GetRenderTargetHandle();
+        };
 
-      // Sync gizmo to primary selected object each frame
-      if (m_gizmo.IsActive()) {
-        const int syncIdx = PrimaryIdx();
-        if (syncIdx < 0 ||
-            syncIdx >= static_cast<int>(m_document.objects.size())) {
-          m_gizmo.Deactivate();
-          if (m_gizmoHistoryPending) {
-            FinalizeHistoryTransaction();
-            m_gizmoHistoryPending = false;
-          }
-        } else {
-          const auto& syncObj = m_document.objects[syncIdx];
-          Quaternion  syncRot = Quaternion::FromEuler(ToRadians(syncObj.pitch),
-                                                      ToRadians(syncObj.yaw),
-                                                      ToRadians(syncObj.roll));
-          m_gizmo.SyncTarget(syncObj.position, syncRot, syncObj.scale);
-        }
-      }
-
-      // ---- Gizmo update (consumes mouse before picking) ----------------------
-      Vec3       dPos   = Vec3::Zero();
-      Quaternion dRot   = Quaternion::Identity();
-      Vec3       dScale = Vec3::One();
-      bool gizmoConsumed = false;
-      if (m_gizmo.IsActive()) {
-        gizmoConsumed = m_gizmo.Update(m_window, cam, screenW, screenH,
-                                       dPos, dRot, dScale);
-
-        // --- Surface snap (Ctrl) and Grid snap (Shift) ---
-        if (m_gizmo.GetMode() == GizmoMode::Translate) {
-          const bool ctrlHeld =
-              glfwGetKey(m_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
-              glfwGetKey(m_window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
-              glfwGetKey(m_window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
-              glfwGetKey(m_window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
-          const bool shiftHeldSnap =
-              glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
-              glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
-
-          GizmoAxis dragAxis = m_gizmo.GetDragAxis();
-          const int primIdx  = PrimaryIdx();
-
-          if (ctrlHeld && dragAxis != GizmoAxis::None &&
-              primIdx >= 0 && primIdx < static_cast<int>(m_document.objects.size())) {
-
-            const auto& selfObj    = m_document.objects[primIdx];
-            Vec3        selfCenter = selfObj.position;
-            Vec3        selfHalf   = selfObj.scale;
-            if (m_liveRegistry)
-              TryPropWorldAabb(*m_liveRegistry, selfObj, selfCenter, selfHalf);
-            Vec3 rawPos = selfCenter + dPos;
-
-            int axisIdx = (dragAxis == GizmoAxis::X) ? 0 :
-                          (dragAxis == GizmoAxis::Y) ? 1 : 2;
-
-            float bestDist   = std::numeric_limits<float>::max();
-            float bestOffset = 0.0f;
-            bool  didSnap    = false;
-
-            for (int oi = 0; oi < static_cast<int>(m_document.objects.size()); ++oi) {
-              if (IsSelected(oi)) continue;
-              const auto& other       = m_document.objects[oi];
-              Vec3        otherCenter = other.position;
-              Vec3        otherHalfV  = other.scale;
-              if (m_liveRegistry)
-                TryPropWorldAabb(*m_liveRegistry, other, otherCenter, otherHalfV);
-              float otherHalf = otherHalfV[axisIdx];
-              float selfHalf1 = selfHalf[axisIdx];
-
-              const float selfFaces[2]  = { rawPos[axisIdx] - selfHalf1,
-                                            rawPos[axisIdx] + selfHalf1 };
-              const float otherFaces[2] = { otherCenter[axisIdx] - otherHalf,
-                                            otherCenter[axisIdx] + otherHalf };
-
-              for (int sf = 0; sf < 2; ++sf) {
-                for (int of = 0; of < 2; ++of) {
-                  float gap = std::abs(selfFaces[sf] - otherFaces[of]);
-                  if (gap < bestDist) {
-                    bestDist   = gap;
-                    bestOffset = otherFaces[of] - selfFaces[sf];
-                    didSnap    = true;
-                  }
-                }
+        // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
+        if (caps.supportsOffscreenTargets && !asset.mesh.empty())
+        {
+          auto &thumbnailRenderer = AssetThumbnailRenderer::Instance();
+#if defined(MONOLITH_HAS_VULKAN)
+          const bool useVulkanOffscreen = Renderer::GetBackendId() == RenderBackendId::Vulkan;
+#else
+          const bool useVulkanOffscreen = false;
+#endif
+          if (useVulkanOffscreen || thumbnailRenderer.Init())
+          {
+            if (auto *meshEntry = TryLoadAssetMesh(asset.mesh))
+            {
+              const std::string meshKey =
+                  ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
+              const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
+              if (handle.IsValid())
+              {
+                *outHandle = handle;
+                return true;
               }
             }
+          }
+        }
 
-            if (didSnap) {
-              Vec3 snappedCenter      = rawPos;
-              snappedCenter[axisIdx] += bestOffset;
-              Vec3 centerToOrigin     = selfObj.position - selfCenter;
-              dPos = snappedCenter + centerToOrigin - selfObj.position;
+        // Priority 2: Fallback to texture-based thumbnails
+        if (!asset.albedoMap.empty())
+        {
+          const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
+          const RenderTargetHandle handle = loadTextureByPath(albedo);
+          if (handle.IsValid())
+          {
+            *outHandle = handle;
+            return true;
+          }
+        }
 
-              Vec3 axisDir   = m_gizmo.AxisDir(dragAxis);
-              Vec3 facePoint = selfObj.position + dPos;
-              DebugDraw::Line(facePoint - axisDir * 0.3f,
-                              facePoint + axisDir * 0.3f,
-                              {1.0f, 1.0f, 0.0f, 1.0f});
+        const std::filesystem::path meshPath = ResolveProjectRelativeOrAbsolutePath(asset.mesh);
+        if (!meshPath.empty())
+        {
+          const std::string ext = ToLowerAscii(meshPath.extension().string());
+
+          if (ext == ".obj")
+          {
+            const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
+            const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
+            if (handle.IsValid())
+            {
+              *outHandle = handle;
+              return true;
             }
           }
 
-          if (shiftHeldSnap && dPos.LengthSq() > 1e-12f &&
-              primIdx >= 0 && primIdx < static_cast<int>(m_document.objects.size())) {
-
-            constexpr float kGridSize = 0.5f;
-            const auto& selfObj = m_document.objects[primIdx];
-            Vec3         rawPos = selfObj.position + dPos;
-
-            rawPos.x = std::round(rawPos.x / kGridSize) * kGridSize;
-            rawPos.y = std::round(rawPos.y / kGridSize) * kGridSize;
-            rawPos.z = std::round(rawPos.z / kGridSize) * kGridSize;
-            dPos = rawPos - selfObj.position;
-          }
-        }
-
-        // Detect any non-trivial delta
-        float dRotXYZSq = dRot.x * dRot.x + dRot.y * dRot.y + dRot.z * dRot.z;
-        bool anyDelta = dPos.LengthSq() > 1e-10f
-                     || dRotXYZSq > 1e-8f
-                     || std::abs(dScale.x - 1.0f) > 1e-6f
-                     || std::abs(dScale.y - 1.0f) > 1e-6f
-                     || std::abs(dScale.z - 1.0f) > 1e-6f;
-        if (anyDelta) {
-          if (!m_gizmoHistoryPending) {
-            BeginHistoryTransaction(CaptureHistorySnapshot());
-            m_gizmoHistoryPending = true;
-          }
-          for (int si : m_selectedIndices) {
-            if (si < 0 || si >= static_cast<int>(m_document.objects.size()))
-              continue;
-            auto& applyObj   = m_document.objects[si];
-
-            // Capture pre-delta state so we can propagate to children below.
-            const Vec3 oldObjPos = applyObj.position;
-            const Quaternion oldObjRot = Quaternion::FromEuler(ToRadians(applyObj.pitch),
-                                                               ToRadians(applyObj.yaw),
-                                                               ToRadians(applyObj.roll));
-
-            applyObj.position = applyObj.position + dPos;
-            applyObj.scale.x *= dScale.x;
-            applyObj.scale.y *= dScale.y;
-            applyObj.scale.z *= dScale.z;
-            Quaternion nextRot = oldObjRot;
-            if (dRotXYZSq > 1e-8f) {
-              nextRot        = (dRot * oldObjRot).Normalized();
-              Vec3 euler     = nextRot.ToEuler();
-              applyObj.pitch = ToDegrees(euler.x);
-              applyObj.yaw   = ToDegrees(euler.y);
-              applyObj.roll  = ToDegrees(euler.z);
+          if (ext == ".gltf" || ext == ".glb")
+          {
+            const std::string absMesh = meshPath.generic_string();
+            auto it = s_gltfTextureByMesh.find(absMesh);
+            if (it == s_gltfTextureByMesh.end())
+            {
+              GltfLoadResult result = GltfLoader::Load(absMesh);
+              if (result.albedoTexture && result.albedoTexture->IsValid())
+                it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
             }
-            m_document.dirty = true;
-            if (m_transformCb)
-              m_transformCb(applyObj);
-
-            // Propagate the same delta to all hierarchy children of this object,
-            // skipping any children that are themselves directly selected (they
-            // already receive the delta above and must not be moved twice).
-            PropagateHierarchyTransformDelta(
-                m_document, si, oldObjPos, oldObjRot,
-                applyObj.position, nextRot, m_transformCb, m_selectedIndices);
+            if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid())
+            {
+              *outHandle = it->second->GetRenderTargetHandle();
+              return true;
+            }
           }
         }
-        if (m_gizmoHistoryPending && m_gizmo.GetDragAxis() == GizmoAxis::None) {
-          FinalizeHistoryTransaction();
-          m_gizmoHistoryPending = false;
+
+        s_noPreviewCache.insert(key);
+        return false;
+      }
+
+      static ImTextureID ToImTextureId(const RenderTargetHandle &handle)
+      {
+        if (!handle.IsValid())
+          return (ImTextureID)0;
+
+        switch (handle.nativeType)
+        {
+        case RenderNativeHandleType::OpenGLTexture2D:
+          return (ImTextureID)(intptr_t)handle.nativeHandle;
+        case RenderNativeHandleType::VulkanImGuiDescriptorSet:
+          return (ImTextureID)(intptr_t)handle.nativeHandle;
+        case RenderNativeHandleType::None:
+          return (ImTextureID)0;
         }
+
+        return (ImTextureID)0;
       }
 
-      if (gizmoConsumed) {
-        // Update m_prevMouseL so HandlePicking doesn't see a phantom click
-        // on the frame when the gizmo releases.
-        m_prevMouseL = glfwGetMouseButton(m_window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS;
-      } else {
-        HandlePicking(cam, screenW, screenH);
+      std::string PickTextureFilePath()
+      {
+#ifdef _WIN32
+        char filePath[MAX_PATH] = {};
+        OPENFILENAMEA ofn = {};
+        ofn.lStructSize = sizeof(ofn);
+        ofn.lpstrFilter = "Images\0*.png;*.jpg;*.jpeg;*.bmp;*.tga;*.webp\0"
+                          "PNG\0*.png\0"
+                          "JPEG\0*.jpg;*.jpeg\0"
+                          "All Files\0*.*\0";
+        ofn.lpstrFile = filePath;
+        ofn.nMaxFile = sizeof(filePath);
+        ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+        if (GetOpenFileNameA(&ofn))
+          return filePath;
+        return {};
+#elif defined(__APPLE__)
+        return ReadPathFromOsascript(
+            "/usr/bin/osascript -e 'try' "
+            "-e 'POSIX path of (choose file with prompt \"Select texture image\")' "
+            "-e 'on error' -e 'return \"\"' -e 'end try' 2>/dev/null");
+#else
+        return {};
+#endif
       }
 
-      // Del key — delete all selected objects immediately
-      bool currDel = glfwGetKey(m_window, GLFW_KEY_DELETE) == GLFW_PRESS;
-      if (ShouldRequestDeleteSelection(currDel, m_prevDel, !m_selectedIndices.empty()))
-        RequestDeleteSelectedObjects();
-      m_prevDel = currDel;
+      // Copy a picked texture into assets/models (same convention as OBJ import) and return
+      // a project-relative path for the scene JSON / LevelLoader.
+      // subfolderHint: asset name (e.g. "enemy") → copies into assets/models/enemy/.
+      // Empty hint falls back to flat assets/models/.
+      static bool IsPathWithinDirectory(const std::filesystem::path &path,
+                                        const std::filesystem::path &directory)
+      {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        const fs::path normPath = fs::weakly_canonical(path, ec);
+        if (ec)
+          return false;
+        ec.clear();
+        const fs::path normDir = fs::weakly_canonical(directory, ec);
+        if (ec)
+          return false;
+
+        auto dirIt = normDir.begin();
+        auto pathIt = normPath.begin();
+        for (; dirIt != normDir.end() && pathIt != normPath.end(); ++dirIt, ++pathIt)
+        {
+          if (*dirIt != *pathIt)
+            return false;
+        }
+        return dirIt == normDir.end();
+      }
+
+      static std::filesystem::path ResolveProjectAssetPath(const std::string &rawPath)
+      {
+        namespace fs = std::filesystem;
+        if (rawPath.empty())
+          return {};
+
+        const fs::path path(rawPath);
+        if (path.is_absolute())
+          return {};
+
+        std::error_code ec;
+        const fs::path root = fs::weakly_canonical(ProjectPath::Root(), ec);
+        if (ec)
+          return {};
+
+        return fs::weakly_canonical(root / path, ec);
+      }
+
+      static std::filesystem::path GetManagedImportedAssetDirectory(const AssetDef &asset)
+      {
+        namespace fs = std::filesystem;
+        if (!asset.guid.empty())
+        {
+          const fs::path guidDirectory = GetManagedAssetDirectory(asset.guid);
+          std::error_code ec;
+          if (fs::exists(guidDirectory, ec) && !ec)
+            return guidDirectory;
+        }
+        if (asset.mesh.empty())
+          return {};
+
+        const fs::path meshPath = ResolveProjectAssetPath(asset.mesh);
+        if (meshPath.empty())
+          return {};
+
+        std::error_code ec;
+        const fs::path modelsRoot = fs::weakly_canonical(ProjectPath::Root() / "assets" / "models", ec);
+        if (ec || !IsPathWithinDirectory(meshPath, modelsRoot))
+          return {};
+
+        const fs::path relativeMesh = fs::relative(meshPath, modelsRoot, ec);
+        if (ec || relativeMesh.empty())
+          return {};
+
+        auto relIt = relativeMesh.begin();
+        if (relIt == relativeMesh.end())
+          return {};
+        const fs::path folder = *relIt;
+        ++relIt;
+        if (relIt == relativeMesh.end() || folder.empty() || folder == "." || folder == "..")
+          return {};
+
+        const fs::path managedDir = modelsRoot / folder;
+        if (!asset.albedoMap.empty())
+        {
+          const fs::path albedoPath = ResolveProjectAssetPath(asset.albedoMap);
+          if (albedoPath.empty() || !IsPathWithinDirectory(albedoPath, managedDir))
+            return {};
+        }
+
+        return managedDir;
+      }
+
+    } // namespace
+
+    // ---- Lifecycle ---------------------------------------------------------------
+
+    void EditorLayer::Init(GLFWwindow *window)
+    {
+      m_window = window;
+      m_mcpController.Initialize();
+      m_mcpSettingsDraft = m_mcpController.GetSettings();
+      if (m_mcpController.SettingsDocument().parseError)
+        LOG_WARN("[MCP] Settings load fallback: %s", m_mcpController.SettingsDocument().error.c_str());
+
+      IMGUI_CHECKVERSION();
+      ImGui::CreateContext();
+      ImGui::StyleColorsDark();
+      ImGuiIO &io = ImGui::GetIO();
+      m_imguiIniPath = ResolveEditorLayoutPath().string();
+      std::error_code settingsEc;
+      std::filesystem::create_directories(ResolveEditorLayoutPath().parent_path(), settingsEc);
+      if (settingsEc)
+      {
+        LOG_WARN("[Editor] Failed to ensure editor settings directory: %s", settingsEc.message().c_str());
+        m_imguiIniPath.clear();
+        io.IniFilename = nullptr;
+      }
+      else
+      {
+        m_hasPersistedDockLayout = std::filesystem::exists(ResolveEditorLayoutPath());
+        io.IniFilename = m_imguiIniPath.c_str();
+      }
+      LoadWorkspaceState();
+
+      const RenderBackendId backendId = Renderer::GetBackendId();
+      m_imguiBackendInitialized = InitEditorImGuiBackend(window, backendId);
+      if (!m_imguiBackendInitialized)
+      {
+        LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'", ToString(backendId));
+      }
+
+      m_schema.LoadFromFile("assets/editor_schema.json");
+
+      // Load wireframe shader
+      try
+      {
+        const std::filesystem::path wv = ResolvePreviewShaderPath("wire.vert");
+        const std::filesystem::path wf = ResolvePreviewShaderPath("wire.frag");
+        m_wireframeShader = Shader::FromFiles(wv.generic_string(), wf.generic_string());
+      }
+      catch (const std::exception &e)
+      {
+        LOG_WARN("[Editor] Failed to load wireframe shader: %s", e.what());
+      }
+
+      // Clear thumbnail caches to allow fresh asset preview generation
+      auto &renderer = AssetThumbnailRenderer::Instance();
+      renderer.noPreviewKeys.clear();
+      renderer.meshCache.clear();
+      LOG_INFO("[Editor] Asset thumbnail caches cleared on Init");
     }
 
-    ApplyPendingViewSnap(cam);
-    PublishMcpSnapshot();
-  }
+    void EditorLayer::Shutdown()
+    {
+      SaveWorkspaceStateIfNeeded(true);
+      if (!m_imguiIniPath.empty())
+        ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
+      m_mcpController.Shutdown();
+      if (m_imguiBackendInitialized)
+        ShutdownEditorImGuiBackend(Renderer::GetBackendId());
+      m_imguiBackendInitialized = false;
+      ImGui::DestroyContext();
+    }
 
-  ImGuiIO& io = ImGui::GetIO();
-  return m_active && !m_flyMode && (io.WantCaptureMouse || io.WantCaptureKeyboard);
-}
+    void EditorLayer::Toggle()
+    {
+      m_active = !m_active;
+      if (!m_active)
+        m_playMode = false;
+      if (m_flyMode)
+      {
+        m_flyMode = false;
+        m_flyCamInitialized = false;
+      }
+      m_closeRequested = false;
+      m_confirmExitOpen = false;
+      m_exitConfirmError.clear();
+      glfwSetInputMode(m_window, GLFW_CURSOR, m_active ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED);
+      m_prevMouseL = false;
+      m_selectedIndices.clear();
+      m_mcpController.SetEditorActive(m_active);
+    }
 
-void EditorLayer::SetHotReloadOverlay(
-    bool active, float progress01, float spinnerAngleRad, const std::string& label) {
-  m_hotReloadOverlayActive = active;
-  m_hotReloadOverlayProgress = std::max(0.0f, std::min(1.0f, progress01));
-  m_hotReloadOverlaySpinner = spinnerAngleRad;
-  m_hotReloadOverlayLabel = label;
-}
+    void EditorLayer::SetProjectBrowserRoot(std::filesystem::path root)
+    {
+      InvalidateProjectBrowserCache();
+      m_projectBrowserRoot.clear();
+      m_projectBrowserRootValid = false;
+      m_projectBrowserCwd.clear();
+      m_projectBrowserCwdValid = false;
+      if (root.empty())
+        return;
+      std::error_code ec;
+      std::filesystem::path canon = std::filesystem::weakly_canonical(root, ec);
+      if (ec)
+        canon = std::move(root);
+      if (!std::filesystem::is_directory(canon, ec) || ec)
+      {
+        m_projectBrowserRoot = canon;
+        return;
+      }
+      m_projectBrowserRoot = std::move(canon);
+      m_projectBrowserRootValid = true;
+      if (!m_savedProjectBrowserCwd.empty())
+      {
+        std::filesystem::path preferred = m_savedProjectBrowserCwd;
+        if (preferred.is_relative())
+          preferred = m_projectBrowserRoot / preferred;
+        preferred = std::filesystem::weakly_canonical(preferred, ec);
+        if (!ec && std::filesystem::is_directory(preferred) &&
+            preferred.native().rfind(m_projectBrowserRoot.native(), 0) == 0)
+        {
+          m_projectBrowserCwd = std::move(preferred);
+          m_projectBrowserCwdValid = true;
+          return;
+        }
+      }
+      m_projectBrowserCwd = m_projectBrowserRoot;
+      m_projectBrowserCwdValid = true;
+    }
 
-void EditorLayer::ProcessDeferredFilePicks() {
-  const DeferredFilePick pick = m_deferredFilePick;
-  if (pick == DeferredFilePick::None)
-    return;
-  m_deferredFilePick = DeferredFilePick::None;
+    void EditorLayer::SetProjectBrowserExtraBlocklist(std::unordered_set<std::string> names)
+    {
+      m_projectExtraBlocklist = std::move(names);
+      InvalidateProjectBrowserCache();
+    }
 
-#if !defined(_WIN32) && !defined(__APPLE__)
-  (void)pick;
-  return;
-#endif
+    void EditorLayer::InvalidateProjectBrowserCache()
+    {
+      m_projectDirCache.clear();
+    }
 
-  switch (pick) {
-    case DeferredFilePick::None:
-      break;
-    case DeferredFilePick::ImportObjBulk: {
-      m_assetImportError.clear();
-      const std::string chosen = PickObjFilePath();
-      if (chosen.empty())
-        break;
-      if (m_assetDraftGuid.empty())
-        m_assetDraftGuid = GenerateAssetGuid();
-      if (m_assetDraftId.empty())
-        m_assetDraftId = AssetIdFromImportedPath(chosen);
-      if (m_assetDraftDisplayName.empty())
-        m_assetDraftDisplayName = m_assetDraftId;
-      AssetImportResult importResult =
-          m_assetImportService.ImportAssetFromSource(chosen, m_assetDraftId, m_assetDraftGuid, m_assetDraftDisplayName);
-      if (importResult.ok) {
+    void EditorLayer::LoadWorkspaceState()
+    {
+      m_workspaceDocument = LoadEditorWorkspaceDocument();
+      if (m_workspaceDocument.parseError)
+      {
+        LOG_WARN("[Editor] Workspace settings load fallback: %s", m_workspaceDocument.error.c_str());
+      }
+
+      m_consoleShowInfo = m_workspaceDocument.state.consoleShowInfo;
+      m_consoleShowWarn = m_workspaceDocument.state.consoleShowWarn;
+      m_consoleShowError = m_workspaceDocument.state.consoleShowError;
+      if (!m_workspaceDocument.state.projectBrowserCwd.empty())
+        m_savedProjectBrowserCwd = std::filesystem::path(m_workspaceDocument.state.projectBrowserCwd);
+      m_workspaceStateDirty = false;
+    }
+
+    void EditorLayer::SaveWorkspaceStateIfNeeded(bool force)
+    {
+      if (!force && !m_workspaceStateDirty)
+        return;
+
+      m_workspaceDocument.state.consoleShowInfo = m_consoleShowInfo;
+      m_workspaceDocument.state.consoleShowWarn = m_consoleShowWarn;
+      m_workspaceDocument.state.consoleShowError = m_consoleShowError;
+      if (m_projectBrowserCwdValid && !m_projectBrowserCwd.empty())
+      {
+        m_workspaceDocument.state.projectBrowserCwd = m_projectBrowserCwd.generic_string();
+      }
+      else if (!m_savedProjectBrowserCwd.empty())
+      {
+        m_workspaceDocument.state.projectBrowserCwd = m_savedProjectBrowserCwd.generic_string();
+      }
+      else
+      {
+        m_workspaceDocument.state.projectBrowserCwd.clear();
+      }
+
+      std::string saveError;
+      if (!SaveEditorWorkspaceDocument(&m_workspaceDocument, &saveError))
+      {
+        LOG_WARN("[Editor] Failed to save workspace settings: %s", saveError.c_str());
+        return;
+      }
+      m_workspaceStateDirty = false;
+    }
+
+    void EditorLayer::MarkWorkspaceStateDirty()
+    {
+      m_workspaceStateDirty = true;
+    }
+
+    void EditorLayer::ApplyLoadedDocument(SceneDocument doc, bool resetHistory)
+    {
+      if (doc.filePath.empty())
+        doc.filePath = "assets/scenes/scene.json";
+
+      EnsureAssetIdentity(&doc);
+
+      for (auto &obj : doc.objects)
+      {
+        if (obj.type != SceneObjectType::Prop)
+          continue;
+        const auto behIt = obj.props.find("behavior");
+        if (behIt == obj.props.end() || behIt->second.empty() || behIt->second == "none")
+          continue;
+
+        bool hasScript = false;
+        for (const auto &comp : obj.components)
+        {
+          if (comp.type == "script")
+          {
+            hasScript = true;
+            break;
+          }
+        }
+        if (!hasScript)
+        {
+          ComponentDesc script;
+          script.type = "script";
+          script.props["behaviorTag"] = behIt->second;
+          obj.components.push_back(std::move(script));
+        }
+        obj.props.erase("behavior");
+      }
+
+      SyncAssetScaleMetadata(&doc);
+      LogDanglingObjectReferences(doc, doc.filePath);
+
+      m_document = std::move(doc);
+      m_lastSavedDocument = m_document;
+      m_selectedIndices.clear();
+      m_selectedAssetId.clear();
+      if (resetHistory)
+        ClearHistory();
+    }
+
+    void EditorLayer::LoadDocument(SceneDocument doc)
+    {
+      ApplyLoadedDocument(std::move(doc), true);
+    }
+
+    void EditorLayer::OnPathsDropped(int pathCount, const char **utf8Paths, float dropX, float dropY)
+    {
+      if (!utf8Paths || pathCount <= 0)
+        return;
+      m_pendingPathDropPaths.clear();
+      m_pendingPathDropPaths.reserve(static_cast<size_t>(pathCount));
+      for (int i = 0; i < pathCount; ++i)
+      {
+        if (utf8Paths[i])
+          m_pendingPathDropPaths.emplace_back(utf8Paths[i]);
+      }
+      if (m_pendingPathDropPaths.empty())
+        return;
+      m_pendingPathDropX = dropX;
+      m_pendingPathDropY = dropY;
+      m_hasPendingPathDrop = true;
+    }
+
+    void EditorLayer::ProcessPendingPathDrops()
+    {
+      if (!m_hasPendingPathDrop)
+        return;
+      m_hasPendingPathDrop = false;
+
+      constexpr float kTextureDropHitSlopPx = 6.0f;
+      const float px = m_pendingPathDropX;
+      const float py = m_pendingPathDropY;
+      auto showAlbedoTextureToast = [this]
+      {
+        m_clipboardToastLabel = "Albedo texture set";
+        m_clipboardToastTime = 2.0f;
+      };
+
+      for (const std::string &path : m_pendingPathDropPaths)
+      {
+        if (!IsTextureFilePath(path))
+          continue;
+
+        if (m_albedoDraftDrop.Contains(px, py, kTextureDropHitSlopPx))
+        {
+          if (m_assetDraftGuid.empty())
+            m_assetDraftGuid = GenerateAssetGuid();
+          if (m_assetDraftId.empty())
+            m_assetDraftId = AssetIdFromImportedPath(path);
+          if (m_assetDraftDisplayName.empty())
+            m_assetDraftDisplayName = m_assetDraftId;
+          AssetDef draftAsset;
+          draftAsset.guid = m_assetDraftGuid;
+          draftAsset.displayName = m_assetDraftDisplayName;
+          draftAsset.mesh = m_assetDraftMesh;
+          draftAsset.renderScale =
+              m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
+          draftAsset.albedoMap = m_assetDraftAlbedoMap;
+          std::string err;
+          if (!m_assetImportService.ImportTextureForAsset(path, m_assetDraftId, &draftAsset, &err))
+          {
+            if (!err.empty())
+              LOG_WARN("Texture drop: %s", err.c_str());
+            continue;
+          }
+          m_assetDraftAlbedoMap = draftAsset.albedoMap;
+          showAlbedoTextureToast();
+          m_pendingPathDropPaths.clear();
+          return;
+        }
+        if (m_albedoSelDrop.Contains(px, py, kTextureDropHitSlopPx) && !m_selectedAssetId.empty())
+        {
+          auto it = m_document.assets.find(m_selectedAssetId);
+          if (it != m_document.assets.end())
+          {
+            std::string err;
+            if (!m_assetImportService.ImportTextureForAsset(path, m_selectedAssetId, &it->second, &err))
+            {
+              if (!err.empty())
+                LOG_WARN("Texture drop: %s", err.c_str());
+              continue;
+            }
+            m_document.dirty = true;
+            showAlbedoTextureToast();
+          }
+          m_pendingPathDropPaths.clear();
+          return;
+        }
+      }
+
+      for (const std::string &path : m_pendingPathDropPaths)
+      {
+        if (!IsObjFilePath(path))
+          continue;
+        if (m_assetDraftGuid.empty())
+          m_assetDraftGuid = GenerateAssetGuid();
+        if (m_assetDraftId.empty())
+          m_assetDraftId = AssetIdFromImportedPath(path);
+        if (m_assetDraftDisplayName.empty())
+          m_assetDraftDisplayName = m_assetDraftId;
+        AssetImportResult importResult =
+            m_assetImportService.ImportAssetFromSource(path, m_assetDraftId, m_assetDraftGuid, m_assetDraftDisplayName);
+        if (!importResult.ok)
+        {
+          const std::string &err = importResult.error;
+          if (!err.empty())
+            LOG_WARN("Drop import: %s", err.c_str());
+          m_assetImportError = err.empty() ? "Drop import failed." : err;
+          m_openNewAssetHeader = true;
+          m_pendingPathDropPaths.clear();
+          return;
+        }
         m_assetDraftMesh = importResult.asset.mesh;
         m_assetDraftAlbedoMap = importResult.asset.albedoMap;
         m_assetDraftRenderScale = importResult.asset.renderScale;
         m_assetImportError.clear();
-      } else if (!importResult.error.empty())
-        m_assetImportError = importResult.error;
-      break;
-    }
-    case DeferredFilePick::NewAssetAlbedo: {
-      if (m_assetDraftGuid.empty())
-        m_assetDraftGuid = GenerateAssetGuid();
-      if (m_assetDraftId.empty())
-        m_assetDraftId = "draft_asset";
-      if (m_assetDraftDisplayName.empty())
-        m_assetDraftDisplayName = m_assetDraftId;
-      AssetDef draftAsset;
-      draftAsset.guid = m_assetDraftGuid;
-      draftAsset.displayName = m_assetDraftDisplayName;
-      draftAsset.mesh = m_assetDraftMesh;
-      draftAsset.renderScale =
-          m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
-      draftAsset.albedoMap = m_assetDraftAlbedoMap;
-      std::string err;
-      if (m_assetImportService.ImportTextureForAsset(PickTextureFilePath(), m_assetDraftId, &draftAsset, &err))
-        m_assetDraftAlbedoMap = draftAsset.albedoMap;
-      else if (!err.empty())
-        LOG_WARN("Texture browse: %s", err.c_str());
-      break;
-    }
-    case DeferredFilePick::SelectedAssetAlbedo: {
-      const std::string id = m_selectedAssetId;
-      if (id.empty() || m_document.assets.find(id) == m_document.assets.end())
-        break;
-      std::string err;
-      if (m_assetImportService.ImportTextureForAsset(PickTextureFilePath(), id, &m_document.assets[id], &err)) {
-        m_document.dirty = true;
-      } else if (!err.empty())
-        LOG_WARN("Texture browse: %s", err.c_str());
-      break;
-    }
-  }
-}
-
-void EditorLayer::Render(const Camera& cam, int screenW, int screenH) {
-  ProcessDeferredFilePicks();
-  if (!m_active) {
-    m_albedoDraftDrop.Clear();
-    m_albedoSelDrop.Clear();
-    m_viewGizmoPickRect.Clear();
-    m_viewportPanelRect = {};
-  }
-  m_viewGizmoPickRect.Clear();
-  ProcessPendingPathDrops();
-
-  if (m_imguiBackendInitialized)
-    BeginEditorImGuiFrame(Renderer::GetBackendId());
-  ImGui::NewFrame();
-
-  const EditorHistorySnapshot frameHistoryBefore = m_active ? CaptureHistorySnapshot()
-                                                            : EditorHistorySnapshot{};
-  const size_t undoHistorySizeBeforeRender = m_undoHistory.size();
-  const size_t redoHistorySizeBeforeRender = m_redoHistory.size();
-
-  if (m_active) {
-    DrawToolbar();
-    DrawDockspace();
-    DrawViewportPanel(cam, screenW, screenH);
-    DrawObjectList();
-    DrawAssetsPanel();
-    DrawPropertiesPanel();
-    DrawBottomDock();
-    DrawStatusBar();
-    DrawHelpPopup();
-    DrawCommandPalettePopup();
-    DrawQuickOpenPopup();
-    DrawSettingsModal();
-    DrawDeleteConfirmModals();
-    DrawExitConfirmModal();
-    if (!m_playMode) {
-      DrawSelectionHighlight();  // queues to DebugDraw
-      if (m_gizmo.IsActive())
-        m_gizmo.Draw(cam, screenW, screenH);  // queues to DebugDraw
-    }
-  }
-  DrawHotReloadOverlay();
-  DrawClipboardToast();
-  SaveWorkspaceStateIfNeeded(false);
-
-  if (m_active &&
-      !m_historyTransactionOpen &&
-      m_undoHistory.size() == undoHistorySizeBeforeRender &&
-      m_redoHistory.size() == redoHistorySizeBeforeRender) {
-    CommitHistoryChange(frameHistoryBefore);
-  }
-
-  // Wireframe pass: clears solid scene and draws edges; must happen before
-  // DebugDraw::Flush so selection highlight/gizmo render on top.
-  if (m_active && !m_playMode)
-    DrawWireframeOverlay(cam);
-
-  // Flush any queued debug primitives (selection box, gizmo, etc.) before ImGui
-  DebugDraw::Flush(cam);
-
-  ImGui::Render();
-  if (m_imguiBackendInitialized)
-    RenderEditorImGuiDrawData(Renderer::GetBackendId(), ImGui::GetDrawData());
-}
-
-void EditorLayer::DrawDockspace() {
-  if (!m_resetDockLayoutRequested)
-    return;
-
-  ImGui::LoadIniSettingsFromMemory("", 0);
-  if (!m_imguiIniPath.empty()) {
-    std::error_code ec;
-    std::filesystem::remove(ResolveEditorLayoutPath(), ec);
-    ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
-  }
-  m_hasPersistedDockLayout = false;
-  m_resetDockLayoutRequested = false;
-}
-
-void EditorLayer::RefreshViewportPanelRect() {
-  const ImVec2 winPos = ImGui::GetWindowPos();
-  const ImVec2 innerMin = ImGui::GetWindowContentRegionMin();
-  const ImVec2 innerMax = ImGui::GetWindowContentRegionMax();
-  m_viewportPanelRect.minX = winPos.x + innerMin.x;
-  m_viewportPanelRect.minY = winPos.y + innerMin.y;
-  m_viewportPanelRect.maxX = winPos.x + innerMax.x;
-  m_viewportPanelRect.maxY = winPos.y + innerMax.y;
-}
-
-void EditorLayer::DrawViewportPanel(const Camera& cam, int screenW, int screenH) {
-  struct ViewportAssetDropContext {
-    EditorLayer* editor = nullptr;
-    const Camera* camera = nullptr;
-    int screenW = 0;
-    int screenH = 0;
-  };
-
-  ImGuiIO& io = ImGui::GetIO();
-  const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
-  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
-  const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
-  const EditorViewportRect defaultRect =
-      BuildEditorViewportRect(io.DisplaySize.x,
-                              io.DisplaySize.y,
-                              kEditorToolbarH,
-                              kEditorStatusH,
-                              bottomDockH,
-                              leftDockW,
-                              rightDockW);
-  ImGui::SetNextWindowPos(ImVec2(defaultRect.minX, defaultRect.minY), ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2(defaultRect.maxX - defaultRect.minX,
-                                  defaultRect.maxY - defaultRect.minY),
-                           ImGuiCond_Always);
-  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-  ImGui::SetNextWindowBgAlpha(0.06f);
-  m_viewportPanelRect = {};
-  if (ImGui::Begin(kEditorViewportWindow,
-                   nullptr,
-                   kMainPanelWindowFlags | ImGuiWindowFlags_NoScrollbar |
-                       ImGuiWindowFlags_NoScrollWithMouse)) {
-    RefreshViewportPanelRect();
-    const ImVec2 dropTargetSize = ImGui::GetContentRegionAvail();
-    ViewportAssetDropContext dropContext{this, &cam, screenW, screenH};
-    DrawViewportAssetDropTarget(
-        m_playMode,
-        dropTargetSize.x,
-        dropTargetSize.y,
-        &dropContext,
-        [](void* userData, const char* assetIdText) -> bool {
-          auto* context = static_cast<ViewportAssetDropContext*>(userData);
-          if (!context || !context->editor || !context->camera || !assetIdText)
-            return false;
-
-          EditorLayer& editor = *context->editor;
-          const std::string assetId(assetIdText);
-          if (editor.m_document.assets.find(assetId) == editor.m_document.assets.end()) {
-            LOG_WARN("[Editor] Viewport drop rejected: missing asset '%s'", assetId.c_str());
-            return false;
-          }
-
-          Vec3 dropPos = Vec3::Zero();
-          if (!editor.TryBuildViewportDropPosition(
-                  *context->camera, context->screenW, context->screenH, assetId, &dropPos)) {
-            LOG_WARN("[Editor] Viewport drop rejected: camera ray did not hit a placement surface");
-            return false;
-          }
-
-          std::string createError;
-          if (!editor.CreateObjectFromAsset(
-                  assetId, std::string(), &dropPos, nullptr, nullptr, &createError)) {
-            LOG_WARN("[Editor] Viewport drop failed: %s", createError.c_str());
-            return false;
-          }
-          return true;
-        });
-
-    if (!m_playMode)
-      DrawViewGimbal(cam);
-  }
-  ImGui::End();
-  ImGui::PopStyleVar();
-}
-
-void EditorLayer::DrawClipboardToast() {
-  if (m_clipboardToastTime <= 0.0f)
-    return;
-
-  ImGuiIO& io = ImGui::GetIO();
-  ImDrawList* draw = ImGui::GetForegroundDrawList();
-
-  const ImVec2 size(230.0f, 32.0f);
-  const ImVec2 pos(io.DisplaySize.x - size.x - 14.0f, io.DisplaySize.y - size.y - 14.0f);
-  const ImVec2 max(pos.x + size.x, pos.y + size.y);
-
-  draw->AddRectFilled(pos, max, IM_COL32(12, 18, 28, 215), 8.0f);
-  draw->AddRect(pos, max, IM_COL32(90, 190, 255, 185), 8.0f, 0, 1.0f);
-  const char* label = m_clipboardToastLabel.empty() ? "Reference copied" : m_clipboardToastLabel.c_str();
-  draw->AddText(ImVec2(pos.x + 10.0f, pos.y + 9.0f), IM_COL32(220, 235, 255, 255), label);
-}
-
-void EditorLayer::DrawHotReloadOverlay() {
-  if (!m_hotReloadOverlayActive)
-    return;
-
-  ImGuiIO& io = ImGui::GetIO();
-  ImDrawList* draw = ImGui::GetForegroundDrawList();
-
-  const ImVec2 panelSize(280.0f, 74.0f);
-  const ImVec2 panelPos((io.DisplaySize.x - panelSize.x) * 0.5f, 18.0f);
-  const ImVec2 panelMax(panelPos.x + panelSize.x, panelPos.y + panelSize.y);
-
-  draw->AddRectFilled(panelPos, panelMax, IM_COL32(10, 14, 22, 215), 10.0f);
-  draw->AddRect(panelPos, panelMax, IM_COL32(70, 120, 190, 180), 10.0f, 0, 1.0f);
-
-  const ImVec2 spinnerCenter(panelPos.x + 24.0f, panelPos.y + panelSize.y * 0.5f);
-  const float spinnerR = 10.0f;
-  draw->AddCircle(spinnerCenter, spinnerR, IM_COL32(80, 90, 120, 200), 24, 2.0f);
-
-  const float arcStart = m_hotReloadOverlaySpinner;
-  const float arcEnd = arcStart + 2.5f;
-  draw->PathArcTo(spinnerCenter, spinnerR, arcStart, arcEnd, 24);
-  draw->PathStroke(IM_COL32(110, 210, 255, 255), false, 3.0f);
-
-  const char* label = m_hotReloadOverlayLabel.empty() ? "Hot Reload" : m_hotReloadOverlayLabel.c_str();
-  draw->AddText(ImVec2(panelPos.x + 44.0f, panelPos.y + 14.0f), IM_COL32(230, 240, 255, 255), label);
-
-  const ImVec2 barMin(panelPos.x + 44.0f, panelPos.y + 42.0f);
-  const ImVec2 barMax(panelMax.x - 16.0f, panelPos.y + 56.0f);
-  draw->AddRectFilled(barMin, barMax, IM_COL32(26, 32, 46, 255), 4.0f);
-
-  const float w = (barMax.x - barMin.x) * m_hotReloadOverlayProgress;
-  if (w > 1.0f)
-    draw->AddRectFilled(barMin, ImVec2(barMin.x + w, barMax.y), IM_COL32(90, 190, 255, 255), 4.0f);
-}
-
-// ---- Toolbar -----------------------------------------------------------------
-
-void EditorLayer::DrawToolbar() {
-  ImGuiIO& io = ImGui::GetIO();
-  ImGui::SetNextWindowPos(ImVec2(0, 0));
-  ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kEditorToolbarH));
-  ImGui::SetNextWindowBgAlpha(0.85f);
-  ImGui::Begin("##toolbar",
-               nullptr,
-               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
-                   ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
-
-  ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "EDITOR");
-  ImGui::SameLine();
-  ImGui::Separator();
-  ImGui::SameLine();
-
-  const bool hasSelectedAsset = !m_selectedAssetId.empty() &&
-                                m_document.assets.find(m_selectedAssetId) != m_document.assets.end();
-  const bool hasSelection = !m_selectedIndices.empty();
-  const int primaryIdx = PrimaryIdx();
-  const bool hasSingleSelection = CanEditSingleSelection(
-      static_cast<int>(m_selectedIndices.size()),
-      primaryIdx,
-      static_cast<int>(m_document.objects.size()));
-
-  if (ImGui::Button("File"))
-    ImGui::OpenPopup("##toolbar_file_popup");
-  if (ImGui::BeginPopup("##toolbar_file_popup")) {
-    if (ImGui::MenuItem("New Scene"))
-      RequestSceneAction(PendingSceneAction::NewScene);
-    if (ImGui::MenuItem("Open Scene..."))
-      RequestSceneAction(PendingSceneAction::OpenSceneFile);
-    if (ImGui::MenuItem("Reset Layout"))
-      m_resetDockLayoutRequested = true;
-    ImGui::Separator();
-    if (ImGui::MenuItem("Settings...")) {
-      m_settingsOpen = true;
-      m_mcpSettingsDraft = m_mcpController.GetSettings();
-      m_mcpSettingsError.clear();
-    }
-    ImGui::EndPopup();
-  }
-  ImGui::SameLine();
-
-  if (ImGui::Button("Add"))
-    ImGui::OpenPopup("##toolbar_add_popup");
-  if (ImGui::BeginPopup("##toolbar_add_popup")) {
-    if (ImGui::MenuItem("Panel"))
-      AddObject(SceneObjectType::Panel);
-    if (ImGui::MenuItem("Prop"))
-      AddObject(SceneObjectType::Prop);
-    if (ImGui::MenuItem("Light"))
-      AddObject(SceneObjectType::Light);
-    if (ImGui::MenuItem("Camera"))
-      AddObject(SceneObjectType::Camera);
-
-    ImGui::Separator();
-    if (!hasSelectedAsset)
-      ImGui::BeginDisabled();
-    if (ImGui::MenuItem("Prop from Selected Asset"))
-      AddObjectFromSelectedAsset();
-    if (!hasSelectedAsset)
-      ImGui::EndDisabled();
-    ImGui::EndPopup();
-  }
-  ImGui::SameLine();
-
-  if (ImGui::Button("Edit"))
-    ImGui::OpenPopup("##toolbar_edit_popup");
-  if (ImGui::BeginPopup("##toolbar_edit_popup")) {
-    if (!CanUndoHistory())
-      ImGui::BeginDisabled();
-    if (ImGui::MenuItem("Undo", "Ctrl/Cmd+Z"))
-      UndoHistory();
-    if (!CanUndoHistory())
-      ImGui::EndDisabled();
-    if (!CanRedoHistory())
-      ImGui::BeginDisabled();
-    if (ImGui::MenuItem("Redo", "Ctrl/Cmd+Shift+Z / Ctrl+Y"))
-      RedoHistory();
-    if (!CanRedoHistory())
-      ImGui::EndDisabled();
-    ImGui::Separator();
-    if (!hasSelection)
-      ImGui::BeginDisabled();
-    if (!hasSingleSelection)
-      ImGui::BeginDisabled();
-    if (ImGui::MenuItem("Rename..."))
-      OpenRenameObjectModal(primaryIdx);
-    if (ImGui::MenuItem("Create Prefab")) {
-      std::string prefabError;
-      if (!CreatePrefabFromSelection(&prefabError))
-        LOG_ERROR("[Editor] Create prefab failed: %s", prefabError.c_str());
-    }
-    if (!hasSingleSelection)
-      ImGui::EndDisabled();
-    if (ImGui::MenuItem("Duplicate"))
-      DuplicateSelectedObjects();
-    if (ImGui::MenuItem("Delete"))
-      RequestDeleteSelectedObjects();
-    ImGui::Separator();
-    if (!hasSingleSelection)
-      ImGui::BeginDisabled();
-    if (ImGui::MenuItem("Copy Ref", "Ctrl/Cmd+Shift+C")) {
-      const int idx = PrimaryIdx();
-      if (idx >= 0 && idx < static_cast<int>(m_document.objects.size())) {
-        const std::string ref = BuildSelectionRefCode(m_document.objects[static_cast<size_t>(idx)], idx);
-        ImGui::SetClipboardText(ref.c_str());
-        m_clipboardToastLabel = "Reference copied";
-        m_clipboardToastTime = 1.5f;
+        m_openNewAssetHeader = true;
+        m_clipboardToastLabel = "OBJ dropped — draft ready";
+        m_clipboardToastTime = 2.2f;
+        m_pendingPathDropPaths.clear();
+        return;
       }
-    }
-    if (!hasSingleSelection)
-      ImGui::EndDisabled();
-    if (!hasSelection)
-      ImGui::EndDisabled();
-    ImGui::EndPopup();
-  }
-  ImGui::SameLine();
 
-  if (ImGui::Button("View"))
-    ImGui::OpenPopup("##toolbar_view_popup");
-  if (ImGui::BeginPopup("##toolbar_view_popup")) {
-    const bool flyBefore = m_flyMode;
-    if (ImGui::MenuItem("Fly Mode", "Tab", m_flyMode)) {
-      m_flyMode = !m_flyMode;
-      m_flyCamInitialized = false;
-      m_prevCursorInit = false;
-      glfwSetInputMode(m_window, GLFW_CURSOR,
-                       m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
+      m_pendingPathDropPaths.clear();
     }
-    if (flyBefore || m_flyMode)
-      ImGui::TextDisabled("WASD + mouse");
-    if (ImGui::MenuItem("Help", "? / F1"))
-      m_helpOpen = true;
-    if (ImGui::MenuItem("Quick Open", "Ctrl/Cmd+P"))
-      m_quickOpenOpen = true;
-    if (ImGui::MenuItem("Command Palette", "Ctrl/Cmd+Shift+P")) {
-      m_commandPaletteOpen = true;
-      m_commandPaletteQuery.clear();
-    }
-    if (ImGui::MenuItem("Reset Layout"))
-      m_resetDockLayoutRequested = true;
-    ImGui::EndPopup();
-  }
-  ImGui::SameLine();
-  ImGui::TextDisabled("Copy Ref: Ctrl/Cmd+Shift+C");
-  ImGui::SameLine();
-  ImGui::Separator();
-  ImGui::SameLine();
-  if (!m_playMode) {
-    if (ImGui::Button("Play")) {
-      m_playMode = true;
-      if (m_flyMode) {
-        m_flyMode = false;
-        m_flyCamInitialized = false;
-        m_prevCursorInit = false;
+
+    void EditorLayer::SyncRuntimeEntityIds(Registry &registry)
+    {
+      std::vector<int> propIndices;
+      propIndices.reserve(m_document.objects.size());
+      for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+      {
+        if (m_document.objects[static_cast<size_t>(i)].type == SceneObjectType::Prop)
+          propIndices.push_back(i);
       }
-      glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-    }
-  } else {
-    if (ImGui::Button("Stop")) {
-      m_playMode = false;
-      glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
-    }
-  }
-  ImGui::SameLine();
 
-  // Right-aligned controls
-  const float rightW = 300.0f;
-  ImGui::SetCursorPosX(io.DisplaySize.x - rightW);
-
-  if (ImGui::Button("Load")) {
-    RequestSceneAction(PendingSceneAction::LoadSceneFromDisk);
-  }
-  ImGui::SameLine();
-
-  {
-    const bool canSave = m_document.dirty;
-    if (!canSave)
-      ImGui::BeginDisabled();
-    if (ImGui::Button("Save")) {
-      std::string saveError;
-      if (!SaveDocument(&saveError))
-        LOG_ERROR("EditorLayer: save failed: %s", saveError.c_str());
-    }
-    if (!canSave)
-      ImGui::EndDisabled();
-  }
-  ImGui::SameLine();
-
-  if (ImGui::Button("Close editor")) {
-    RequestSceneAction(PendingSceneAction::CloseEditor);
-  }
-
-  ImGui::End();
-}
-
-void EditorLayer::DrawStatusBar() {
-  ImGuiIO& io = ImGui::GetIO();
-  const EditorStatusText status = BuildEditorStatusText(
-      EditorStatusSnapshot{static_cast<int>(m_selectedIndices.size()), m_document.dirty, m_flyMode, m_wantsReload});
-
-  ImGui::SetNextWindowPos(ImVec2(0.0f, io.DisplaySize.y - kEditorStatusH));
-  ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kEditorStatusH));
-  ImGui::SetNextWindowBgAlpha(0.82f);
-  ImGui::Begin("##editor_statusbar",
-               nullptr,
-               ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
-                   ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
-
-  ImGui::TextDisabled("Sel: %d", status.selectionCount);
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::TextDisabled("Dirty: %s", status.dirtyText);
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::TextDisabled("Fly: %s", status.flyText);
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::TextDisabled("Reload: %s", status.reloadText);
-
-  ImGui::End();
-}
-
-const std::vector<std::pair<std::filesystem::path, bool>>* EditorLayer::GetProjectDirListing(
-    const std::filesystem::path& absPath) {
-  namespace fs = std::filesystem;
-  std::error_code existsEc;
-  if (!fs::is_directory(absPath, existsEc) || existsEc)
-    return nullptr;
-
-  const std::string key = absPath.generic_string();
-  const uint32_t frame = static_cast<uint32_t>(ImGui::GetFrameCount());
-  auto it = m_projectDirCache.find(key);
-  if (it != m_projectDirCache.end()) {
-    const uint32_t age = frame - it->second.cachedAtFrame;
-    if (age < kProjectListingCacheFrames)
-      return &it->second.entries;
-  }
-
-  std::vector<std::pair<fs::path, bool>> sorted;
-  std::error_code ec;
-  for (fs::directory_iterator dit(absPath, fs::directory_options::skip_permission_denied, ec), end;
-       !ec && dit != end;
-       dit.increment(ec)) {
-    const fs::directory_entry ent = *dit;
-    const std::string name = ent.path().filename().string();
-    if (Editor::IsHiddenDotEntry(name))
-      continue;
-    std::error_code typEc;
-    const bool isDir = ent.is_directory(typEc);
-    if (isDir && !typEc && Editor::IsBlockedProjectDirName(name, &m_projectExtraBlocklist))
-      continue;
-    sorted.emplace_back(ent.path(), isDir && !typEc);
-  }
-  std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
-    if (a.second != b.second)
-      return a.second > b.second;
-    return a.first.filename() < b.first.filename();
-  });
-
-  ProjectDirCache slot;
-  slot.cachedAtFrame = frame;
-  slot.entries = std::move(sorted);
-  m_projectDirCache[key] = std::move(slot);
-  return &m_projectDirCache.at(key).entries;
-}
-
-void EditorLayer::DrawProjectTreeRecursive(const std::filesystem::path& absPath,
-                                           const std::filesystem::path& /*displayRoot*/) {
-  namespace fs = std::filesystem;
-  const auto* listing = GetProjectDirListing(absPath);
-  if (!listing)
-    return;
-
-  for (const auto& ent : *listing) {
-    const fs::path& p = ent.first;
-    const bool isDir = ent.second;
-    const std::string name = p.filename().string();
-    if (isDir) {
-      if (ImGui::TreeNodeEx(name.c_str(), 0)) {
-        DrawProjectTreeRecursive(p, absPath);
-        ImGui::TreePop();
+      std::vector<Entity> meshEntities;
+      for (Entity e : registry.GetEntities<MeshComponent>())
+      {
+        if (registry.Has<PlayerTagComponent>(e))
+          continue;
+        meshEntities.push_back(e);
       }
-    } else {
-      ImGui::BulletText("%s", name.c_str());
+      std::sort(meshEntities.begin(), meshEntities.end());
+
+      const size_t propN = propIndices.size();
+      const size_t meshN = meshEntities.size();
+      const size_t n = std::min(propN, meshN);
+      if (propN != meshN)
+      {
+        LOG_WARN(
+            "EditorLayer::SyncRuntimeEntityIds: %zu prop(s) vs %zu mesh entity(ies); mapping first %zu",
+            propN, meshN, n);
+      }
+
+      for (size_t j = 0; j < n; ++j)
+      {
+        m_document.objects[static_cast<size_t>(propIndices[j])].props["_eid"] =
+            std::to_string(meshEntities[j]);
+      }
+      for (size_t j = n; j < propN; ++j)
+        m_document.objects[static_cast<size_t>(propIndices[j])].props.erase("_eid");
     }
-  }
-}
 
-static void FormatLogTime(const LogLine& entry, char* buf, size_t bufSize) {
-  using clock = std::chrono::system_clock;
-  const std::time_t t = clock::to_time_t(entry.time);
-  std::tm tmBuf{};
-#ifdef _WIN32
-  localtime_s(&tmBuf, &t);
-#else
-  localtime_r(&t, &tmBuf);
-#endif
-  std::strftime(buf, bufSize, "%H:%M:%S", &tmBuf);
-}
+    // ---- Per-frame update --------------------------------------------------------
 
-void EditorLayer::DrawBottomDock() {
-  ImGuiIO& io = ImGui::GetIO();
-  const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
-  const float dockTop = io.DisplaySize.y - kEditorStatusH - bottomDockH;
-  ImGui::SetNextWindowPos(ImVec2(0.0f, dockTop), ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, bottomDockH), ImGuiCond_Always);
-  ImGui::Begin(kEditorWorkspaceWindow, nullptr, kMainPanelWindowFlags);
+    bool EditorLayer::OnUpdate(float dt, Camera &cam, int screenW, int screenH)
+    {
+      if (m_clipboardToastTime > 0.0f)
+        m_clipboardToastTime = std::max(0.0f, m_clipboardToastTime - dt);
 
-  if (ImGui::BeginTabBar("##bottom_tabs", ImGuiTabBarFlags_None)) {
-    if (ImGui::BeginTabItem("Project")) {
-      if (m_projectBrowserRootValid &&
-          std::filesystem::is_directory(m_projectBrowserRoot)) {
-        if (!m_projectBrowserCwdValid ||
-            !std::filesystem::is_directory(m_projectBrowserCwd) ||
-            m_projectBrowserCwd.empty()) {
-          m_projectBrowserCwd = m_projectBrowserRoot;
-          m_projectBrowserCwdValid = true;
+      if (m_active)
+      {
+        ProcessMcpCommands();
+
+        if (ShouldFinalizeEditorClose(m_closeRequested, m_wantsReload))
+        {
+          Toggle();
+          return false;
         }
 
-        ImGui::BeginChild("##project_tiles", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
-
-        bool cwdChanged = false;
-        std::filesystem::path nextCwd = m_projectBrowserCwd;
-        const std::string rootLabel = m_projectBrowserRoot.filename().string().empty()
-                                          ? m_projectBrowserRoot.generic_string()
-                                          : m_projectBrowserRoot.filename().string();
-        if (ImGui::SmallButton(rootLabel.c_str())) {
-          nextCwd = m_projectBrowserRoot;
-          cwdChanged = true;
+        if (m_playMode)
+        {
+          PublishMcpSnapshot();
+          return false;
         }
 
-        std::error_code relEc;
-        const std::filesystem::path relPath =
-            std::filesystem::relative(m_projectBrowserCwd, m_projectBrowserRoot, relEc);
-        if (!relEc && !relPath.empty() && relPath != ".") {
-          std::filesystem::path crumb = m_projectBrowserRoot;
-          for (const auto& part : relPath) {
-            ImGui::SameLine();
-            ImGui::TextUnformatted(">");
-            ImGui::SameLine();
-            crumb /= part;
-            const std::string partLabel = part.string();
-            if (ImGui::SmallButton(partLabel.c_str())) {
-              nextCwd = crumb;
-              cwdChanged = true;
+        EditorTrace("OnUpdate frame=%u fly=%d", static_cast<unsigned>(ImGui::GetFrameCount()),
+                    m_flyMode ? 1 : 0);
+
+        ImGuiIO &io = ImGui::GetIO();
+
+        const bool accelHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+                               glfwGetKey(m_window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
+                               glfwGetKey(m_window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
+                               glfwGetKey(m_window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
+        const bool shiftHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+                               glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
+        const bool slashHeld = glfwGetKey(m_window, GLFW_KEY_SLASH) == GLFW_PRESS;
+        const bool f1Held = glfwGetKey(m_window, GLFW_KEY_F1) == GLFW_PRESS;
+        const bool currHelpToggle = f1Held || (slashHeld && shiftHeld);
+        if (ShouldToggleHelpPopup(currHelpToggle, m_prevHelpToggle, io.WantTextInput,
+                                  ImGui::IsAnyItemActive()))
+        {
+          m_helpOpen = !m_helpOpen;
+          if (!m_helpOpen)
+            m_helpSearchQuery.clear();
+        }
+        m_prevHelpToggle = currHelpToggle;
+
+        const bool currQuickOpenToggle =
+            accelHeld && !shiftHeld && glfwGetKey(m_window, GLFW_KEY_P) == GLFW_PRESS;
+        if (ShouldOpenQuickOpen(currQuickOpenToggle, m_prevQuickOpenToggle, m_flyMode,
+                                io.WantTextInput, ImGui::IsAnyItemActive()))
+        {
+          m_quickOpenOpen = true;
+          m_quickOpenQuery.clear();
+        }
+        m_prevQuickOpenToggle = currQuickOpenToggle;
+
+        const bool currCommandPaletteToggle =
+            accelHeld && shiftHeld && glfwGetKey(m_window, GLFW_KEY_P) == GLFW_PRESS;
+        if (ShouldOpenCommandPalette(currCommandPaletteToggle,
+                                     m_prevCommandPaletteToggle,
+                                     m_flyMode,
+                                     io.WantTextInput,
+                                     ImGui::IsAnyItemActive()))
+        {
+          m_commandPaletteOpen = true;
+          m_commandPaletteQuery.clear();
+        }
+        m_prevCommandPaletteToggle = currCommandPaletteToggle;
+
+        const bool currEsc = glfwGetKey(m_window, GLFW_KEY_ESCAPE) == GLFW_PRESS;
+        const bool hasBlockingPopup = m_helpOpen || m_quickOpenOpen || m_commandPaletteOpen ||
+                                      m_assetSearchOpen ||
+                                      m_confirmDeleteObjectsOpen || m_confirmDeleteAssetOpen ||
+                                      m_confirmExitOpen;
+        const bool currUndo = accelHeld && !shiftHeld && glfwGetKey(m_window, GLFW_KEY_Z) == GLFW_PRESS;
+        const bool currRedo =
+            accelHeld &&
+            ((shiftHeld && glfwGetKey(m_window, GLFW_KEY_Z) == GLFW_PRESS) ||
+             glfwGetKey(m_window, GLFW_KEY_Y) == GLFW_PRESS);
+        if (!m_flyMode && !io.WantTextInput && !ImGui::IsAnyItemActive() && !hasBlockingPopup)
+        {
+          if (currUndo && !m_prevUndo)
+            UndoHistory();
+          if (currRedo && !m_prevRedo)
+            RedoHistory();
+        }
+        m_prevUndo = currUndo;
+        m_prevRedo = currRedo;
+        // Escape: dismiss gizmo only (no editor quit on Escape; use File / window close).
+        if (currEsc && !m_prevEsc && !io.WantTextInput && !ImGui::IsAnyItemActive() &&
+            !hasBlockingPopup && m_gizmo.IsActive())
+        {
+          m_gizmo.Deactivate();
+          if (m_gizmoHistoryPending)
+          {
+            FinalizeHistoryTransaction();
+            m_gizmoHistoryPending = false;
+          }
+        }
+        m_prevEsc = currEsc;
+
+        // Tab toggles fly mode
+        bool currTab = glfwGetKey(m_window, GLFW_KEY_TAB) == GLFW_PRESS;
+        if (currTab && !m_prevTab)
+          ToggleFlyMode(cam);
+        m_prevTab = currTab;
+
+        if (m_flyMode)
+        {
+          UpdateFlyCamera(dt, cam);
+          // Keep gizmo anchored to object even while flying
+          if (m_gizmo.IsActive())
+          {
+            const int syncIdx = PrimaryIdx();
+            if (syncIdx >= 0 && syncIdx < static_cast<int>(m_document.objects.size()))
+            {
+              const auto &syncObj = m_document.objects[syncIdx];
+              Quaternion syncRot = Quaternion::FromEuler(ToRadians(syncObj.pitch),
+                                                         ToRadians(syncObj.yaw),
+                                                         ToRadians(syncObj.roll));
+              m_gizmo.SyncTarget(syncObj.position, syncRot, syncObj.scale);
             }
           }
         }
+        else
+        {
+          // Ctrl/Cmd + Shift + C copies selected object reference code to clipboard.
+          bool currCopyRef = accelHeld && shiftHeld && glfwGetKey(m_window, GLFW_KEY_C) == GLFW_PRESS;
+          const int idx = PrimaryIdx();
+          const bool hasPrimarySelection = idx >= 0 && idx < static_cast<int>(m_document.objects.size());
+          if (ShouldCopySelectionRef(currCopyRef, m_prevCopyRef, io.WantTextInput,
+                                     ImGui::IsAnyItemActive(), hasPrimarySelection))
+          {
+            if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+            {
+              const std::string code = BuildSelectionRefCode(m_document.objects[idx], idx);
+              glfwSetClipboardString(m_window, code.c_str());
+              m_clipboardToastLabel = "Reference copied";
+              m_clipboardToastTime = 1.6f;
+            }
+          }
+          m_prevCopyRef = currCopyRef;
 
-        ImGui::Separator();
+          // ---- Gizmo mode hotkeys (W/E/R) ----------------------------------------
+          const bool currW = glfwGetKey(m_window, GLFW_KEY_W) == GLFW_PRESS;
+          const bool currE = glfwGetKey(m_window, GLFW_KEY_E) == GLFW_PRESS;
+          const bool currR = glfwGetKey(m_window, GLFW_KEY_R) == GLFW_PRESS;
+          if (!io.WantTextInput && !ImGui::IsAnyItemActive())
+          {
+            const int gizmoIdx = PrimaryIdx();
+            if (gizmoIdx >= 0 &&
+                gizmoIdx < static_cast<int>(m_document.objects.size()) &&
+                m_gizmo.GetDragAxis() == GizmoAxis::None)
+            {
+              const auto &gizmoObj = m_document.objects[gizmoIdx];
+              Quaternion gizmoRot = Quaternion::FromEuler(ToRadians(gizmoObj.pitch),
+                                                          ToRadians(gizmoObj.yaw),
+                                                          ToRadians(gizmoObj.roll));
 
-        const auto* listing = GetProjectDirListing(m_projectBrowserCwd);
-        if (!listing) {
-          ImGui::TextDisabled("Cannot read '%s'", m_projectBrowserCwd.generic_string().c_str());
-        } else {
-          const float spacing = 10.0f;
-          const float minTileW = 120.0f;
-          const float tileH = 104.0f;
-          const float iconW = 64.0f;
-          const float iconH = 42.0f;
-          const float availW = std::max(0.0f, ImGui::GetContentRegionAvail().x);
-          const int columns = std::max(1, static_cast<int>((availW + spacing) / (minTileW + spacing)));
-          const float tileW = std::max(minTileW,
-                                       (availW - spacing * static_cast<float>(columns - 1)) /
-                                           static_cast<float>(columns));
+              if (currW && (!m_prevGizmoW || m_gizmo.GetMode() != GizmoMode::Translate))
+              {
+                m_gizmo.Activate(GizmoMode::Translate, gizmoObj.position, gizmoRot, gizmoObj.scale);
+              }
+              else if (currE && (!m_prevGizmoE || m_gizmo.GetMode() != GizmoMode::Rotate))
+              {
+                m_gizmo.Activate(GizmoMode::Rotate, gizmoObj.position, gizmoRot, gizmoObj.scale);
+              }
+              else if (currR && (!m_prevGizmoR || m_gizmo.GetMode() != GizmoMode::Scale))
+              {
+                m_gizmo.Activate(GizmoMode::Scale, gizmoObj.position, gizmoRot, gizmoObj.scale);
+              }
+            }
+          }
+          m_prevGizmoW = currW;
+          m_prevGizmoE = currE;
+          m_prevGizmoR = currR;
 
-          int itemIndex = 0;
-          for (const auto& ent : *listing) {
-            const std::filesystem::path& p = ent.first;
-            const bool isDir = ent.second;
-            const std::string name = p.filename().string();
+          // Sync gizmo to primary selected object each frame
+          if (m_gizmo.IsActive())
+          {
+            const int syncIdx = PrimaryIdx();
+            if (syncIdx < 0 ||
+                syncIdx >= static_cast<int>(m_document.objects.size()))
+            {
+              m_gizmo.Deactivate();
+              if (m_gizmoHistoryPending)
+              {
+                FinalizeHistoryTransaction();
+                m_gizmoHistoryPending = false;
+              }
+            }
+            else
+            {
+              const auto &syncObj = m_document.objects[syncIdx];
+              Quaternion syncRot = Quaternion::FromEuler(ToRadians(syncObj.pitch),
+                                                         ToRadians(syncObj.yaw),
+                                                         ToRadians(syncObj.roll));
+              m_gizmo.SyncTarget(syncObj.position, syncRot, syncObj.scale);
+            }
+          }
 
-            ImGui::PushID(p.generic_string().c_str());
-            ImGui::InvisibleButton("##project_item_btn", ImVec2(tileW, tileH));
-            if (ImGui::IsItemClicked()) {
-              if (isDir) {
-                nextCwd = p;
-                cwdChanged = true;
+          // ---- Gizmo update (consumes mouse before picking) ----------------------
+          Vec3 dPos = Vec3::Zero();
+          Quaternion dRot = Quaternion::Identity();
+          Vec3 dScale = Vec3::One();
+          bool gizmoConsumed = false;
+          if (m_gizmo.IsActive())
+          {
+            gizmoConsumed = m_gizmo.Update(m_window, cam, screenW, screenH,
+                                           dPos, dRot, dScale);
+
+            // --- Surface snap (Ctrl) and Grid snap (Shift) ---
+            if (m_gizmo.GetMode() == GizmoMode::Translate)
+            {
+              const bool ctrlHeld =
+                  glfwGetKey(m_window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+                  glfwGetKey(m_window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
+                  glfwGetKey(m_window, GLFW_KEY_LEFT_SUPER) == GLFW_PRESS ||
+                  glfwGetKey(m_window, GLFW_KEY_RIGHT_SUPER) == GLFW_PRESS;
+              const bool shiftHeldSnap =
+                  glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+                  glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
+
+              GizmoAxis dragAxis = m_gizmo.GetDragAxis();
+              const int primIdx = PrimaryIdx();
+
+              if (ctrlHeld && dragAxis != GizmoAxis::None &&
+                  primIdx >= 0 && primIdx < static_cast<int>(m_document.objects.size()))
+              {
+
+                const auto &selfObj = m_document.objects[primIdx];
+                Vec3 selfCenter = selfObj.position;
+                Vec3 selfHalf = selfObj.scale;
+                if (m_liveRegistry)
+                  TryPropWorldAabb(*m_liveRegistry, selfObj, selfCenter, selfHalf);
+                Vec3 rawPos = selfCenter + dPos;
+
+                int axisIdx = (dragAxis == GizmoAxis::X) ? 0 : (dragAxis == GizmoAxis::Y) ? 1
+                                                                                          : 2;
+
+                float bestDist = std::numeric_limits<float>::max();
+                float bestOffset = 0.0f;
+                bool didSnap = false;
+
+                for (int oi = 0; oi < static_cast<int>(m_document.objects.size()); ++oi)
+                {
+                  if (IsSelected(oi))
+                    continue;
+                  const auto &other = m_document.objects[oi];
+                  Vec3 otherCenter = other.position;
+                  Vec3 otherHalfV = other.scale;
+                  if (m_liveRegistry)
+                    TryPropWorldAabb(*m_liveRegistry, other, otherCenter, otherHalfV);
+                  float otherHalf = otherHalfV[axisIdx];
+                  float selfHalf1 = selfHalf[axisIdx];
+
+                  const float selfFaces[2] = {rawPos[axisIdx] - selfHalf1,
+                                              rawPos[axisIdx] + selfHalf1};
+                  const float otherFaces[2] = {otherCenter[axisIdx] - otherHalf,
+                                               otherCenter[axisIdx] + otherHalf};
+
+                  for (int sf = 0; sf < 2; ++sf)
+                  {
+                    for (int of = 0; of < 2; ++of)
+                    {
+                      float gap = std::abs(selfFaces[sf] - otherFaces[of]);
+                      if (gap < bestDist)
+                      {
+                        bestDist = gap;
+                        bestOffset = otherFaces[of] - selfFaces[sf];
+                        didSnap = true;
+                      }
+                    }
+                  }
+                }
+
+                if (didSnap)
+                {
+                  Vec3 snappedCenter = rawPos;
+                  snappedCenter[axisIdx] += bestOffset;
+                  Vec3 centerToOrigin = selfObj.position - selfCenter;
+                  dPos = snappedCenter + centerToOrigin - selfObj.position;
+
+                  Vec3 axisDir = m_gizmo.AxisDir(dragAxis);
+                  Vec3 facePoint = selfObj.position + dPos;
+                  DebugDraw::Line(facePoint - axisDir * 0.3f,
+                                  facePoint + axisDir * 0.3f,
+                                  {1.0f, 1.0f, 0.0f, 1.0f});
+                }
+              }
+
+              if (shiftHeldSnap && dPos.LengthSq() > 1e-12f &&
+                  primIdx >= 0 && primIdx < static_cast<int>(m_document.objects.size()))
+              {
+
+                constexpr float kGridSize = 0.5f;
+                const auto &selfObj = m_document.objects[primIdx];
+                Vec3 rawPos = selfObj.position + dPos;
+
+                rawPos.x = std::round(rawPos.x / kGridSize) * kGridSize;
+                rawPos.y = std::round(rawPos.y / kGridSize) * kGridSize;
+                rawPos.z = std::round(rawPos.z / kGridSize) * kGridSize;
+                dPos = rawPos - selfObj.position;
               }
             }
 
-            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-              ImGui::SetTooltip("%s", p.generic_string().c_str());
+            // Detect any non-trivial delta
+            float dRotXYZSq = dRot.x * dRot.x + dRot.y * dRot.y + dRot.z * dRot.z;
+            bool anyDelta = dPos.LengthSq() > 1e-10f || dRotXYZSq > 1e-8f || std::abs(dScale.x - 1.0f) > 1e-6f || std::abs(dScale.y - 1.0f) > 1e-6f || std::abs(dScale.z - 1.0f) > 1e-6f;
+            if (anyDelta)
+            {
+              if (!m_gizmoHistoryPending)
+              {
+                BeginHistoryTransaction(CaptureHistorySnapshot());
+                m_gizmoHistoryPending = true;
+              }
+              for (int si : m_selectedIndices)
+              {
+                if (si < 0 || si >= static_cast<int>(m_document.objects.size()))
+                  continue;
+                auto &applyObj = m_document.objects[si];
 
-            const ImVec2 rMin = ImGui::GetItemRectMin();
-            const ImVec2 rMax = ImGui::GetItemRectMax();
-            ImDrawList* dl = ImGui::GetWindowDrawList();
-            const bool hovered = ImGui::IsItemHovered();
-            const ImU32 hoverBg = ImGui::ColorConvertFloat4ToU32(ImVec4(0.22f, 0.30f, 0.42f, 0.28f));
-            if (hovered) {
-              dl->AddRectFilled(ImVec2(rMin.x + 2.0f, rMin.y + 2.0f), ImVec2(rMax.x - 2.0f, rMax.y - 2.0f),
-                                hoverBg, 8.0f);
+                // Capture pre-delta state so we can propagate to children below.
+                const Vec3 oldObjPos = applyObj.position;
+                const Quaternion oldObjRot = Quaternion::FromEuler(ToRadians(applyObj.pitch),
+                                                                   ToRadians(applyObj.yaw),
+                                                                   ToRadians(applyObj.roll));
+
+                applyObj.position = applyObj.position + dPos;
+                applyObj.scale.x *= dScale.x;
+                applyObj.scale.y *= dScale.y;
+                applyObj.scale.z *= dScale.z;
+                Quaternion nextRot = oldObjRot;
+                if (dRotXYZSq > 1e-8f)
+                {
+                  nextRot = (dRot * oldObjRot).Normalized();
+                  Vec3 euler = nextRot.ToEuler();
+                  applyObj.pitch = ToDegrees(euler.x);
+                  applyObj.yaw = ToDegrees(euler.y);
+                  applyObj.roll = ToDegrees(euler.z);
+                }
+                m_document.dirty = true;
+                if (m_transformCb)
+                  m_transformCb(applyObj);
+
+                // Propagate the same delta to all hierarchy children of this object,
+                // skipping any children that are themselves directly selected (they
+                // already receive the delta above and must not be moved twice).
+                PropagateHierarchyTransformDelta(
+                    m_document, si, oldObjPos, oldObjRot,
+                    applyObj.position, nextRot, m_transformCb, m_selectedIndices);
+              }
             }
-
-            const float iconX = rMin.x + (tileW - iconW) * 0.5f;
-            const float iconY = rMin.y + 10.0f;
-            if (isDir) {
-              const ImU32 tabCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.30f, 0.68f, 0.92f, 1.0f));
-              const ImU32 bodyCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.25f, 0.60f, 0.86f, 1.0f));
-              const ImU32 edgeCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.18f, 0.45f, 0.66f, 1.0f));
-              dl->AddRectFilled(ImVec2(iconX + 5.0f, iconY), ImVec2(iconX + iconW * 0.56f, iconY + 10.0f), tabCol,
-                                4.0f, ImDrawFlags_RoundCornersTop);
-              dl->AddRectFilled(ImVec2(iconX, iconY + 7.0f), ImVec2(iconX + iconW, iconY + iconH), bodyCol, 6.0f);
-              dl->AddRect(ImVec2(iconX, iconY + 7.0f), ImVec2(iconX + iconW, iconY + iconH), edgeCol, 6.0f);
-            } else {
-              const ImU32 pageCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.86f, 0.90f, 0.96f, 1.0f));
-              const ImU32 foldCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.74f, 0.80f, 0.90f, 1.0f));
-              const ImU32 edgeCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.58f, 0.65f, 0.76f, 1.0f));
-              const ImVec2 p0(iconX + 8.0f, iconY);
-              const ImVec2 p1(iconX + iconW - 8.0f, iconY + iconH);
-              dl->AddRectFilled(p0, p1, pageCol, 4.0f);
-              dl->AddRect(p0, p1, edgeCol, 4.0f);
-              dl->AddTriangleFilled(ImVec2(p1.x - 14.0f, p0.y), ImVec2(p1.x, p0.y), ImVec2(p1.x, p0.y + 14.0f),
-                                    foldCol);
+            if (m_gizmoHistoryPending && m_gizmo.GetDragAxis() == GizmoAxis::None)
+            {
+              FinalizeHistoryTransaction();
+              m_gizmoHistoryPending = false;
             }
-
-            std::string label = name;
-            const float maxLabelW = tileW - 10.0f;
-            if (ImGui::CalcTextSize(label.c_str()).x > maxLabelW) {
-              while (!label.empty() && ImGui::CalcTextSize((label + "...").c_str()).x > maxLabelW)
-                label.pop_back();
-              label += "...";
-            }
-
-            const ImVec2 labelSz = ImGui::CalcTextSize(label.c_str());
-            const float labelX = rMin.x + std::max(4.0f, (tileW - labelSz.x) * 0.5f);
-            const float labelY = iconY + iconH + 10.0f;
-            dl->AddText(ImVec2(labelX, labelY), ImGui::GetColorU32(ImGuiCol_Text), label.c_str());
-
-            ImGui::PopID();
-
-            ++itemIndex;
-            if ((itemIndex % columns) != 0)
-              ImGui::SameLine(0.0f, spacing);
           }
-        }
 
-        if (cwdChanged) {
-          m_projectBrowserCwd = std::move(nextCwd);
-          m_projectBrowserCwdValid = true;
-          m_savedProjectBrowserCwd = m_projectBrowserCwd;
-          MarkWorkspaceStateDirty();
-        }
-
-        ImGui::EndChild();
-      } else {
-        ImGui::TextDisabled("Set project root (host app) to browse files.");
-      }
-      ImGui::EndTabItem();
-    }
-    if (ImGui::BeginTabItem("Console")) {
-      int nInfo = 0;
-      int nWarn = 0;
-      int nErr = 0;
-      LogBuffer::Instance().GetCounts(&nInfo, &nWarn, &nErr);
-      if (ImGui::SmallButton("Clear"))
-        LogBuffer::Instance().Clear();
-      ImGui::SameLine();
-      if (ImGui::Checkbox("Info", &m_consoleShowInfo))
-        MarkWorkspaceStateDirty();
-      ImGui::SameLine();
-      if (ImGui::Checkbox("Warn", &m_consoleShowWarn))
-        MarkWorkspaceStateDirty();
-      ImGui::SameLine();
-      if (ImGui::Checkbox("Error", &m_consoleShowError))
-        MarkWorkspaceStateDirty();
-      ImGui::SameLine();
-      ImGui::TextDisabled("I:%d W:%d E:%d", nInfo, nWarn, nErr);
-
-      ImGui::Separator();
-      ImGui::BeginChild("##console_scroll", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
-      LogBuffer& logBuf = LogBuffer::Instance();
-      const uint64_t rev = logBuf.Revision();
-      if (rev != m_consoleLogRevision) {
-        logBuf.CopyLinesTo(&m_consoleLinesCache);
-        m_consoleLogRevision = rev;
-      }
-
-      m_consoleVisibleScratch.clear();
-      for (int i = 0; i < static_cast<int>(m_consoleLinesCache.size()); ++i) {
-        const LogLine& entry = m_consoleLinesCache[static_cast<size_t>(i)];
-        if (entry.level == LogLevel::Info && !m_consoleShowInfo)
-          continue;
-        if (entry.level == LogLevel::Warn && !m_consoleShowWarn)
-          continue;
-        if (entry.level == LogLevel::Error && !m_consoleShowError)
-          continue;
-        m_consoleVisibleScratch.push_back(i);
-      }
-
-      // No ImGuiListClipper here: wrapped ImGui::Text rows have variable height and can confuse
-      // the clipper (hang or broken scroll). LogBuffer caps lines (~1k); a linear pass is fine.
-      EditorTrace("Console draw visible=%d cached=%zu rev=%llu",
-                  static_cast<int>(m_consoleVisibleScratch.size()), m_consoleLinesCache.size(),
-                  static_cast<unsigned long long>(rev));
-
-      for (int row = 0; row < static_cast<int>(m_consoleVisibleScratch.size()); ++row) {
-        const LogLine& entry =
-            m_consoleLinesCache[static_cast<size_t>(m_consoleVisibleScratch[static_cast<size_t>(row)])];
-        char timeBuf[32];
-        FormatLogTime(entry, timeBuf, sizeof(timeBuf));
-        const char* levelStr =
-            entry.level == LogLevel::Info ? "INFO" : entry.level == LogLevel::Warn ? "WARN" : "ERR";
-        ImVec4 color(0.85f, 0.9f, 1.0f, 1.0f);
-        if (entry.level == LogLevel::Warn)
-          color = ImVec4(1.0f, 0.85f, 0.4f, 1.0f);
-        else if (entry.level == LogLevel::Error)
-          color = ImVec4(1.0f, 0.45f, 0.4f, 1.0f);
-
-        char lineBuf[1024];
-        std::snprintf(lineBuf, sizeof(lineBuf), "[%s] %s (%s:%d) %s", timeBuf, levelStr,
-                      entry.file.c_str(), entry.line, entry.message.c_str());
-
-        ImGui::PushStyleColor(ImGuiCol_Text, color);
-        ImGui::TextUnformatted(lineBuf);
-        ImGui::PopStyleColor();
-      }
-      ImGui::EndChild();
-      ImGui::EndTabItem();
-    }
-    if (ImGui::BeginTabItem("MCP")) {
-      DrawMcpTab();
-      ImGui::EndTabItem();
-    }
-    ImGui::EndTabBar();
-  }
-
-  ImGui::End();
-}
-
-void EditorLayer::DrawMcpTab() {
-  const Mcp::McpStatusSnapshot status = m_mcpController.GetStatusSnapshot();
-  auto copyToClipboard = [&](const std::string& label, const std::string& text) {
-    glfwSetClipboardString(m_window, text.c_str());
-    m_clipboardToastLabel = label;
-    m_clipboardToastTime = 1.5f;
-  };
-
-  if (m_mcpSelectedActivityIndex >= static_cast<int>(status.recentActivity.size()))
-    m_mcpSelectedActivityIndex = status.recentActivity.empty() ? 0 : static_cast<int>(status.recentActivity.size()) - 1;
-
-  ImGui::Text("Status: %s", status.running ? "Running" : "Stopped");
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Enabled: %s", status.enabled ? "Yes" : "No");
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Endpoint: %s", status.endpointUrl.c_str());
-
-  ImGui::Text("Requests: %llu", static_cast<unsigned long long>(status.totalRequests));
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Success: %llu", static_cast<unsigned long long>(status.successCount));
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Failed: %llu", static_cast<unsigned long long>(status.failureCount));
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Active: %d", status.activeRequests);
-
-  ImGui::Text("Tools: %d", static_cast<int>(status.toolCount));
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Resources: %d", static_cast<int>(status.resourceCount));
-  ImGui::SameLine();
-  ImGui::TextDisabled("|");
-  ImGui::SameLine();
-  ImGui::Text("Last Request: %s", status.lastRequestTime.empty() ? "-" : status.lastRequestTime.c_str());
-
-  if (!status.topTool.empty() || !status.topResource.empty()) {
-    ImGui::Text("Top Tool: %s", status.topTool.empty() ? "-" : status.topTool.c_str());
-    ImGui::SameLine();
-    ImGui::TextDisabled("|");
-    ImGui::SameLine();
-    ImGui::Text("Top Resource: %s", status.topResource.empty() ? "-" : status.topResource.c_str());
-  }
-
-  if (!status.lastError.empty()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
-    ImGui::TextWrapped("%s", status.lastError.c_str());
-    ImGui::PopStyleColor();
-  }
-
-  ImGui::SeparatorText("Quick Actions");
-  if (ImGui::Button("Open Settings")) {
-    m_settingsOpen = true;
-    m_mcpSettingsDraft = m_mcpController.GetSettings();
-    m_mcpSettingsError.clear();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Copy Endpoint"))
-    copyToClipboard("MCP endpoint copied", status.endpointUrl);
-  ImGui::SameLine();
-  if (ImGui::Button("Clear Request Log"))
-    m_mcpController.ClearActivityLog();
-
-  ImGui::SeparatorText("Clients");
-  if (ImGui::BeginTable("##mcp_clients", 3, ImGuiTableFlags_SizingStretchSame)) {
-    ImGui::TableNextRow();
-
-    auto drawClientCard = [&](const char* title,
-                              const char* pathLabel,
-                              const char* pathValue,
-                              const char* hint,
-                              const std::string& snippet,
-                              const char* toastLabel) {
-      ImGui::TableNextColumn();
-      ImGui::BeginChild(title, ImVec2(0, 132.0f), true);
-      ImGui::TextUnformatted(title);
-      ImGui::Separator();
-      ImGui::TextWrapped("%s", hint);
-      ImGui::TextDisabled("%s", pathLabel);
-      ImGui::TextWrapped("%s", pathValue);
-      if (ImGui::Button((std::string("Copy Config##") + title).c_str()))
-        copyToClipboard(toastLabel, snippet);
-      ImGui::EndChild();
-    };
-
-    drawClientCard("Codex",
-                   "Config path",
-                   "~/.codex/config.toml or .codex/config.toml",
-                   "Use the built-in MCP server entry so /mcp can discover Horo Engine automatically.",
-                   m_mcpController.BuildCodexConfigSnippet(),
-                   "Codex MCP config copied");
-    drawClientCard("Claude",
-                   "Config path",
-                   "~/.claude.json or .mcp.json",
-                   "Claude Code can connect over HTTP MCP using the endpoint shown above.",
-                   m_mcpController.BuildClaudeConfigSnippet(),
-                   "Claude MCP config copied");
-    drawClientCard("VS Code",
-                   "Config path",
-                   ".vscode/mcp.json or user mcp.json",
-                   "VS Code MCP can be set per workspace or globally from the Command Palette.",
-                   m_mcpController.BuildVsCodeConfigSnippet(),
-                   "VS Code MCP config copied");
-    ImGui::EndTable();
-  }
-
-  ImGui::SeparatorText("Live Requests");
-  if (ImGui::BeginTable("##mcp_requests", 6,
-                        ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_ScrollY |
-                            ImGuiTableFlags_Resizable,
-                        ImVec2(0.0f, 200.0f))) {
-    ImGui::TableSetupColumn("Time", ImGuiTableColumnFlags_WidthFixed, 80.0f);
-    ImGui::TableSetupColumn("Target", ImGuiTableColumnFlags_WidthStretch, 1.6f);
-    ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 64.0f);
-    ImGui::TableSetupColumn("Ms", ImGuiTableColumnFlags_WidthFixed, 58.0f);
-    ImGui::TableSetupColumn("Request", ImGuiTableColumnFlags_WidthStretch, 2.0f);
-    ImGui::TableSetupColumn("Response", ImGuiTableColumnFlags_WidthStretch, 2.0f);
-    ImGui::TableHeadersRow();
-    for (int i = 0; i < static_cast<int>(status.recentActivity.size()); ++i) {
-      const Mcp::McpActivityEntry& entry = status.recentActivity[static_cast<size_t>(i)];
-      ImGui::TableNextRow();
-      ImGui::TableSetColumnIndex(0);
-      const bool selected = i == m_mcpSelectedActivityIndex;
-      const std::string selectableLabel = entry.timeText + "##mcp_req_" + std::to_string(i);
-      if (ImGui::Selectable(selectableLabel.c_str(), selected, ImGuiSelectableFlags_SpanAllColumns))
-        m_mcpSelectedActivityIndex = i;
-      ImGui::TableSetColumnIndex(1);
-      ImGui::TextUnformatted(entry.target.c_str());
-      ImGui::TableSetColumnIndex(2);
-      ImGui::TextColored(entry.ok ? ImVec4(0.75f, 0.95f, 0.75f, 1.0f) : ImVec4(1.0f, 0.55f, 0.5f, 1.0f),
-                         "%s", entry.ok ? "OK" : "FAIL");
-      ImGui::TableSetColumnIndex(3);
-      ImGui::Text("%.1f", entry.durationMs);
-      ImGui::TableSetColumnIndex(4);
-      ImGui::TextWrapped("%s", entry.requestPreview.empty() ? "-" : entry.requestPreview.c_str());
-      ImGui::TableSetColumnIndex(5);
-      ImGui::TextWrapped("%s", entry.responsePreview.empty() ? "-" : entry.responsePreview.c_str());
-    }
-    ImGui::EndTable();
-  }
-
-  if (!status.recentActivity.empty()) {
-    const Mcp::McpActivityEntry& selected = status.recentActivity[static_cast<size_t>(m_mcpSelectedActivityIndex)];
-    ImGui::SeparatorText("Request Detail");
-    ImGui::Text("Timestamp: %s", selected.timestampText.c_str());
-    ImGui::SameLine();
-    ImGui::TextDisabled("|");
-    ImGui::SameLine();
-    ImGui::Text("Method: %s", selected.mcpMethod.empty() ? "-" : selected.mcpMethod.c_str());
-    ImGui::SameLine();
-    ImGui::TextDisabled("|");
-    ImGui::SameLine();
-    ImGui::Text("HTTP: %d", selected.httpStatus);
-    ImGui::Text("Operation: %s", selected.operation.empty() ? "-" : selected.operation.c_str());
-    ImGui::SameLine();
-    ImGui::TextDisabled("|");
-    ImGui::SameLine();
-    ImGui::Text("Request ID: %s", selected.requestId.empty() ? "-" : selected.requestId.c_str());
-    if (!selected.error.empty()) {
-      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.55f, 0.5f, 1.0f));
-      ImGui::TextWrapped("Error: %s", selected.error.c_str());
-      ImGui::PopStyleColor();
-    }
-  }
-
-  ImGui::SeparatorText("Catalog");
-  if (ImGui::BeginTable("##mcp_catalog", 2, ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders)) {
-    ImGui::TableSetupColumn("Tools", ImGuiTableColumnFlags_WidthStretch);
-    ImGui::TableSetupColumn("Resources", ImGuiTableColumnFlags_WidthStretch);
-    ImGui::TableHeadersRow();
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    ImGui::BeginChild("##mcp_tools_catalog", ImVec2(0, 132.0f), false);
-    for (const Mcp::McpCatalogEntry& entry : status.toolCatalog) {
-      ImGui::TextUnformatted(entry.name.c_str());
-      ImGui::TextDisabled("%s", entry.description.c_str());
-    }
-    ImGui::EndChild();
-    ImGui::TableSetColumnIndex(1);
-    ImGui::BeginChild("##mcp_resources_catalog", ImVec2(0, 132.0f), false);
-    for (const Mcp::McpCatalogEntry& entry : status.resourceCatalog) {
-      ImGui::Text("%s", entry.name.c_str());
-      ImGui::TextDisabled("%s", entry.description.c_str());
-    }
-    ImGui::EndChild();
-    ImGui::EndTable();
-  }
-}
-
-void EditorLayer::DrawSettingsModal() {
-  if (m_settingsOpen)
-    ImGui::OpenPopup("Editor Settings");
-
-  if (!ImGui::BeginPopupModal("Editor Settings", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-    return;
-
-  ImGui::TextDisabled("Built-in MCP");
-  ImGui::Checkbox("Enable built-in MCP", &m_mcpSettingsDraft.enabled);
-  ImGui::Checkbox("Auto-start when editor opens", &m_mcpSettingsDraft.autoStart);
-
-  int port = m_mcpSettingsDraft.port;
-  if (ImGui::InputInt("Port", &port))
-    m_mcpSettingsDraft.port = std::max(1, std::min(65535, port));
-
-  ImGui::Text("Host: %s", Mcp::kDefaultMcpHost);
-  m_mcpSettingsDraft.host = Mcp::kDefaultMcpHost;
-
-  const std::string endpoint =
-      "http://" + m_mcpSettingsDraft.host + ":" + std::to_string(m_mcpSettingsDraft.port) + "/mcp";
-  ImGui::TextWrapped("Endpoint: %s", endpoint.c_str());
-
-  if (!m_mcpSettingsError.empty()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
-    ImGui::TextWrapped("%s", m_mcpSettingsError.c_str());
-    ImGui::PopStyleColor();
-  }
-
-  ImGui::Separator();
-  if (ImGui::Button("Apply", ImVec2(120.0f, 0.0f))) {
-    std::string err;
-    if (m_mcpController.ApplySettings(m_mcpSettingsDraft, &err)) {
-      m_mcpSettingsDraft = m_mcpController.GetSettings();
-      m_mcpSettingsError.clear();
-      m_settingsOpen = false;
-      ImGui::CloseCurrentPopup();
-    } else {
-      m_mcpSettingsError = err;
-    }
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f))) {
-    m_settingsOpen = false;
-    m_mcpSettingsDraft = m_mcpController.GetSettings();
-    m_mcpSettingsError.clear();
-    ImGui::CloseCurrentPopup();
-  }
-
-  ImGui::EndPopup();
-}
-
-void EditorLayer::DrawViewGimbal(const Camera& cam) {
-  ImGuiIO& io = ImGui::GetIO();
-  const EditorViewGimbalMetrics& metrics = GetEditorViewGimbalMetrics();
-  const bool supportsWireframeOverlay = Renderer::GetBackendCapabilities().supportsWireframeOverlay;
-  if (!supportsWireframeOverlay)
-    m_wireframeMode = false;
-  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
-  const EditorViewGimbalLayout layout =
-      BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
-  const float wx = layout.gimbalRect.minX;
-  const float wy = layout.gimbalRect.minY;
-  const ImVec2 viewportPos = ImGui::GetWindowPos();
-  const ImVec2 btnLocalPos(layout.wireButtonRect.minX - viewportPos.x,
-                           layout.wireButtonRect.minY - viewportPos.y);
-  const ImVec2 gimbalLocalPos(layout.gimbalRect.minX - viewportPos.x,
-                              layout.gimbalRect.minY - viewportPos.y);
-  ImDrawList* dl = ImGui::GetWindowDrawList();
-
-  // Wireframe toggle button — top-aligned near the gimbal, centered inside its own framed box.
-  dl->AddRectFilled(ImVec2(layout.wireButtonRect.minX, layout.wireButtonRect.minY),
-                    ImVec2(layout.wireButtonRect.maxX, layout.wireButtonRect.maxY),
-                    IM_COL32(95, 95, 95, 220),
-                    0.0f);
-  const float btnPad = (metrics.buttonFrameSize - metrics.buttonSize) * 0.5f;
-  ImGui::SetCursorPos(ImVec2(btnLocalPos.x + btnPad, btnLocalPos.y + btnPad));
-  if (m_wireframeMode)
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.55f, 0.15f, 0.90f));
-  else
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.22f, 0.30f, 0.80f));
-  if (!supportsWireframeOverlay)
-    ImGui::BeginDisabled();
-  if (ImGui::Button("##wire_btn_toggle", ImVec2(metrics.buttonSize, metrics.buttonSize)))
-    m_wireframeMode = !m_wireframeMode;
-  if (!supportsWireframeOverlay)
-    ImGui::EndDisabled();
-  ImGui::PopStyleColor();
-  dl->AddText(ImVec2(layout.wireButtonRect.minX + metrics.titleOffsetX,
-                     layout.wireButtonRect.minY + metrics.titleOffsetY),
-              IM_COL32(230, 235, 245, 255),
-              "[W]");
-  if (ImGui::IsItemHovered()) {
-    if (supportsWireframeOverlay)
-      ImGui::SetTooltip("Toggle Wireframe");
-    else
-      ImGui::SetTooltip("Wireframe overlay is unavailable on the active render backend");
-  }
-
-  m_viewGizmoPickRect.valid = true;
-  m_viewGizmoPickRect.minX = layout.pickRect.minX;
-  m_viewGizmoPickRect.minY = layout.pickRect.minY;
-  m_viewGizmoPickRect.maxX = layout.pickRect.maxX;
-  m_viewGizmoPickRect.maxY = layout.pickRect.maxY;
-
-  dl->AddRectFilled(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
-                    ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
-                    IM_COL32(18, 18, 20, 200),
-                    0.0f);
-  dl->AddRect(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
-              ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
-              IM_COL32(90, 90, 90, 255),
-              0.0f,
-              0,
-              1.0f);
-  dl->AddText(ImVec2(wx + metrics.titleOffsetX, wy + metrics.titleOffsetY),
-              IM_COL32(240, 240, 240, 255),
-              "View");
-
-  const int idx = PrimaryIdx();
-
-  const float hitRegionWidth =
-      layout.gimbalRect.maxX - layout.gimbalRect.minX - 2.0f * metrics.contentOffsetX;
-  ImGui::SetCursorPos(ImVec2(gimbalLocalPos.x + metrics.contentOffsetX,
-                             gimbalLocalPos.y + metrics.contentOffsetY));
-  ImGui::InvisibleButton("##view_gimbal_hit", ImVec2(hitRegionWidth, metrics.hitRegionHeight));
-  const ImVec2 hitMin = ImGui::GetItemRectMin();
-  const ImVec2 hitMax = ImGui::GetItemRectMax();
-  const ImVec2 center = ImVec2((hitMin.x + hitMax.x) * 0.5f, (hitMin.y + hitMax.y) * 0.5f + 3.0f);
-  const bool canvasHovered = ImGui::IsItemHovered();
-  const bool canvasClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
-
-  constexpr float kShaftPx = 36.0f;
-  constexpr float kHitPx = 12.0f;
-  constexpr float kHitPxSq = kHitPx * kHitPx;
-
-  struct AxisDraw {
-    ViewSnap posSnap;
-    ViewSnap negSnap;
-    Vec3 worldPlus;
-    ImU32 col;
-    const char* label;
-  };
-  static const AxisDraw kAxes[] = {
-      {ViewSnap::Right, ViewSnap::Left, {1.0f, 0.0f, 0.0f}, IM_COL32(220, 72, 72, 255), "X"},
-      {ViewSnap::Top, ViewSnap::Bottom, {0.0f, 1.0f, 0.0f}, IM_COL32(88, 200, 96, 255), "Y"},
-      {ViewSnap::Front, ViewSnap::Back, {0.0f, 0.0f, 1.0f}, IM_COL32(82, 148, 255, 255), "Z"},
-  };
-
-  // Pre-compute screen directions and view-space depth once per frame.
-  // Shared by hover and draw loops — no redundant WorldAxisToScreenDir calls.
-  struct AxisCache {
-    float dx, dy;  // normalised screen direction of the +axis
-    float viewZ;   // view-space Z (positive = toward camera) for depth sort
-    int origIdx;
-  };
-  AxisCache cache[3];
-  for (int i = 0; i < 3; i++) {
-    float vz = 0.f;
-    WorldAxisToScreenDir(cam, kAxes[i].worldPlus, &cache[i].dx, &cache[i].dy, &vz);
-    cache[i].viewZ  = vz;
-    cache[i].origIdx = i;
-  }
-
-  ViewSnap hoverSnap = ViewSnap::None;
-
-  if (canvasHovered) {
-    const ImVec2 mouse = io.MousePos;
-    float bestD = kHitPxSq;  // was kHitPxSq * 4.f — that doubled the effective hit radius
-    const float cx = center.x, cy = center.y;
-    for (int i = 0; i < 3; i++) {
-      const AxisDraw& ad = kAxes[cache[i].origIdx];
-      const float px1 = cx + cache[i].dx * kShaftPx;
-      const float py1 = cy + cache[i].dy * kShaftPx;
-      const float px2 = cx - cache[i].dx * kShaftPx;
-      const float py2 = cy - cache[i].dy * kShaftPx;
-      const float d1 = DistSqPointSegment2D(mouse.x, mouse.y, cx, cy, px1, py1);
-      const float d2 = DistSqPointSegment2D(mouse.x, mouse.y, cx, cy, px2, py2);
-      if (d1 < bestD) { bestD = d1; hoverSnap = ad.posSnap; }
-      if (d2 < bestD) { bestD = d2; hoverSnap = ad.negSnap; }
-    }
-  }
-
-  // Sort ascending by view-space Z so background axes draw first (painter's algorithm).
-  std::sort(std::begin(cache), std::end(cache),
-            [](const AxisCache& a, const AxisCache& b) { return a.viewZ < b.viewZ; });
-
-  const float fs = ImGui::GetFontSize();
-  const float cx = center.x, cy = center.y;
-  for (int si = 0; si < 3; si++) {
-    const AxisCache& ac = cache[si];
-    const AxisDraw& ad = kAxes[ac.origIdx];
-    const float px1 = cx + ac.dx * kShaftPx;
-    const float py1 = cy + ac.dy * kShaftPx;
-    const float px2 = cx - ac.dx * kShaftPx;
-    const float py2 = cy - ac.dy * kShaftPx;
-
-    const bool hlPos = (hoverSnap == ad.posSnap);
-    const bool hlNeg = (hoverSnap == ad.negSnap);
-    ImU32 cPos = ad.col;
-    ImU32 cNeg = ad.col;
-    switch (ad.posSnap) {
-      case ViewSnap::Right: cNeg = IM_COL32(150, 48, 48, 255); break;
-      case ViewSnap::Top:   cNeg = IM_COL32(58, 145, 64, 255); break;
-      case ViewSnap::Front: cNeg = IM_COL32(52, 100, 190, 255); break;
-      default: break;
-    }
-    if (hlPos) cPos = IM_COL32(255, 255, 200, 255);
-    if (hlNeg) cNeg = IM_COL32(255, 255, 200, 255);
-
-    dl->AddLine(center, ImVec2(px1, py1), cPos, hlPos ? 4.0f : 3.0f);
-    dl->AddLine(center, ImVec2(px2, py2), cNeg, hlNeg ? 4.0f : 2.5f);
-    dl->AddCircleFilled(ImVec2(px1, py1), hlPos ? 5.0f : 4.0f, cPos, 10);
-    dl->AddCircleFilled(ImVec2(px2, py2), hlNeg ? 4.5f : 3.5f, cNeg, 10);
-
-    // Offset label along the axis direction so it doesn't overlap the circle
-    // regardless of which way the axis is pointing on screen.
-    const float tDist = (hlPos ? 5.0f : 4.0f) + 3.0f;
-    dl->AddText(ImVec2(px1 + ac.dx * tDist - fs * 0.3f,
-                       py1 + ac.dy * tDist - fs * 0.5f),
-                cPos, ad.label);
-  }
-
-  if (canvasClicked && hoverSnap != ViewSnap::None)
-    m_pendingViewSnap = hoverSnap;
-
-  if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
-    dl->AddText(ImVec2(wx + metrics.titleOffsetX,
-                       layout.gimbalRect.maxY - metrics.pivotTextOffsetY),
-                IM_COL32(150, 150, 150, 255),
-                "Pivot: origin");
-}
-
-// ---- Hierarchy panel ---------------------------------------------------------
-
-// Short icon prefix shown before each object in the hierarchy tree.
-static const char* ObjectTypeIcon(SceneObjectType type) {
-  switch (type) {
-    case SceneObjectType::Prop:   return "[>]";
-    case SceneObjectType::Light:  return "[*]";
-    case SceneObjectType::Camera: return "[C]";
-    default:                      return "[=]";  // Panel / board
-  }
-}
-
-void EditorLayer::DrawObjectList() {
-  ImGuiIO& io = ImGui::GetIO();
-  const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
-  const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
-  const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
-  const float hierarchyHeight = std::max(220.0f, (workBottom - kEditorToolbarH) * kHierarchySectionRatio);
-  ImGui::SetNextWindowPos(ImVec2(0.0f, kEditorToolbarH), ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2(leftDockW, hierarchyHeight), ImGuiCond_Always);
-  ImGui::Begin(kEditorHierarchyWindow, nullptr, kMainPanelWindowFlags);
-
-  // Search bar (applies to primary scene)
-  char searchBuf[256] = {};
-  std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_objectSearchQuery.c_str());
-  ImGui::PushItemFlag(ImGuiItemFlags_NoTabStop, true);
-  if (ImGui::InputTextWithHint("##object_search", "Search objects...", searchBuf, sizeof(searchBuf)))
-    m_objectSearchQuery = searchBuf;
-  ImGui::PopItemFlag();
-  ImGui::Separator();
-
-  // Primary scene
-  DrawSceneHeader(m_document, true, -1);
-
-  // Right-click empty space → add object to primary scene
-  if (ImGui::BeginPopupContextWindow("obj_ctx_empty",
-                                     ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems)) {
-    if (ImGui::BeginMenu("Add")) {
-      if (ImGui::MenuItem("Panel"))
-        AddObject(SceneObjectType::Panel);
-      if (ImGui::MenuItem("Prop"))
-        AddObject(SceneObjectType::Prop);
-      if (ImGui::MenuItem("Light"))
-        AddObject(SceneObjectType::Light);
-      if (ImGui::MenuItem("Camera"))
-        AddObject(SceneObjectType::Camera);
-      ImGui::EndMenu();
-    }
-    ImGui::EndPopup();
-  }
-
-  if (m_renameObjectOpen) {
-    ImGui::OpenPopup("Rename Object");
-    m_renameObjectOpen = false;
-  }
-  if (ImGui::BeginPopupModal("Rename Object", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    char nameBuf[256] = {};
-    std::snprintf(nameBuf, sizeof(nameBuf), "%s", m_renameObjectDraft.c_str());
-    if (ImGui::InputText("New ID", nameBuf, sizeof(nameBuf), ImGuiInputTextFlags_EnterReturnsTrue)) {
-      m_renameObjectDraft = nameBuf;
-    } else if (std::strncmp(nameBuf, m_renameObjectDraft.c_str(), sizeof(nameBuf)) != 0) {
-      m_renameObjectDraft = nameBuf;
-    }
-
-    if (!m_renameObjectError.empty())
-      ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "%s", m_renameObjectError.c_str());
-
-    bool applyRequested = false;
-    if (ImGui::Button("Apply"))
-      applyRequested = true;
-    ImGui::SameLine();
-    if (ImGui::Button("Cancel")) {
-      m_renameObjectError.clear();
-      m_renameObjectIndex = -1;
-      ImGui::CloseCurrentPopup();
-    }
-
-    if (applyRequested) {
-      if (m_renameObjectIndex < 0 || m_renameObjectIndex >= static_cast<int>(m_document.objects.size())) {
-        m_renameObjectError = "Selected object is no longer valid.";
-      } else if (m_renameObjectDraft.empty()) {
-        m_renameObjectError = "ID cannot be empty.";
-      } else {
-        const int existingIdx = FindObjectIndexById(m_document, m_renameObjectDraft);
-        if (existingIdx >= 0 && existingIdx != m_renameObjectIndex) {
-          m_renameObjectError = "ID already exists.";
-        } else {
-          SceneObject& target = m_document.objects[static_cast<size_t>(m_renameObjectIndex)];
-          const std::string oldId = target.id;
-          const std::string newId = m_renameObjectDraft;
-          if (oldId != newId) {
-            target.id = newId;
-            for (auto& other : m_document.objects) {
-              auto p = other.props.find("parentId");
-              if (p != other.props.end() && p->second == oldId)
-                p->second = newId;
-              auto f = other.props.find("followTargetId");
-              if (f != other.props.end() && f->second == oldId)
-                f->second = newId;
-            }
-            m_document.dirty = true;
+          if (gizmoConsumed)
+          {
+            // Update m_prevMouseL so HandlePicking doesn't see a phantom click
+            // on the frame when the gizmo releases.
+            m_prevMouseL = glfwGetMouseButton(m_window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS;
           }
-          m_renameObjectError.clear();
-          m_renameObjectIndex = -1;
-          ImGui::CloseCurrentPopup();
+          else
+          {
+            HandlePicking(cam, screenW, screenH);
+          }
+
+          // Del key — delete all selected objects immediately
+          bool currDel = glfwGetKey(m_window, GLFW_KEY_DELETE) == GLFW_PRESS;
+          if (ShouldRequestDeleteSelection(currDel, m_prevDel, !m_selectedIndices.empty()))
+            RequestDeleteSelectedObjects();
+          m_prevDel = currDel;
         }
+
+        ApplyPendingViewSnap(cam);
+        PublishMcpSnapshot();
+      }
+
+      ImGuiIO &io = ImGui::GetIO();
+      return m_active && !m_flyMode && (io.WantCaptureMouse || io.WantCaptureKeyboard);
+    }
+
+    void EditorLayer::SetHotReloadOverlay(
+        bool active, float progress01, float spinnerAngleRad, const std::string &label)
+    {
+      m_hotReloadOverlayActive = active;
+      m_hotReloadOverlayProgress = std::max(0.0f, std::min(1.0f, progress01));
+      m_hotReloadOverlaySpinner = spinnerAngleRad;
+      m_hotReloadOverlayLabel = label;
+    }
+
+    void EditorLayer::ProcessDeferredFilePicks()
+    {
+      const DeferredFilePick pick = m_deferredFilePick;
+      if (pick == DeferredFilePick::None)
+        return;
+      m_deferredFilePick = DeferredFilePick::None;
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+      (void)pick;
+      return;
+#endif
+
+      switch (pick)
+      {
+      case DeferredFilePick::None:
+        break;
+      case DeferredFilePick::ImportObjBulk:
+      {
+        m_assetImportError.clear();
+        const std::string chosen = PickObjFilePath();
+        if (chosen.empty())
+          break;
+        if (m_assetDraftGuid.empty())
+          m_assetDraftGuid = GenerateAssetGuid();
+        if (m_assetDraftId.empty())
+          m_assetDraftId = AssetIdFromImportedPath(chosen);
+        if (m_assetDraftDisplayName.empty())
+          m_assetDraftDisplayName = m_assetDraftId;
+        AssetImportResult importResult =
+            m_assetImportService.ImportAssetFromSource(chosen, m_assetDraftId, m_assetDraftGuid, m_assetDraftDisplayName);
+        if (importResult.ok)
+        {
+          m_assetDraftMesh = importResult.asset.mesh;
+          m_assetDraftAlbedoMap = importResult.asset.albedoMap;
+          m_assetDraftRenderScale = importResult.asset.renderScale;
+          m_assetImportError.clear();
+        }
+        else if (!importResult.error.empty())
+          m_assetImportError = importResult.error;
+        break;
+      }
+      case DeferredFilePick::NewAssetAlbedo:
+      {
+        if (m_assetDraftGuid.empty())
+          m_assetDraftGuid = GenerateAssetGuid();
+        if (m_assetDraftId.empty())
+          m_assetDraftId = "draft_asset";
+        if (m_assetDraftDisplayName.empty())
+          m_assetDraftDisplayName = m_assetDraftId;
+        AssetDef draftAsset;
+        draftAsset.guid = m_assetDraftGuid;
+        draftAsset.displayName = m_assetDraftDisplayName;
+        draftAsset.mesh = m_assetDraftMesh;
+        draftAsset.renderScale =
+            m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
+        draftAsset.albedoMap = m_assetDraftAlbedoMap;
+        std::string err;
+        if (m_assetImportService.ImportTextureForAsset(PickTextureFilePath(), m_assetDraftId, &draftAsset, &err))
+          m_assetDraftAlbedoMap = draftAsset.albedoMap;
+        else if (!err.empty())
+          LOG_WARN("Texture browse: %s", err.c_str());
+        break;
+      }
+      case DeferredFilePick::SelectedAssetAlbedo:
+      {
+        const std::string id = m_selectedAssetId;
+        if (id.empty() || m_document.assets.find(id) == m_document.assets.end())
+          break;
+        std::string err;
+        if (m_assetImportService.ImportTextureForAsset(PickTextureFilePath(), id, &m_document.assets[id], &err))
+        {
+          m_document.dirty = true;
+        }
+        else if (!err.empty())
+          LOG_WARN("Texture browse: %s", err.c_str());
+        break;
+      }
       }
     }
 
-    ImGui::EndPopup();
-  }
+    void EditorLayer::Render(const Camera &cam, int screenW, int screenH)
+    {
+      ProcessDeferredFilePicks();
+      if (!m_active)
+      {
+        m_albedoDraftDrop.Clear();
+        m_albedoSelDrop.Clear();
+        m_viewGizmoPickRect.Clear();
+        m_viewportPanelRect = {};
+      }
+      m_viewGizmoPickRect.Clear();
+      ProcessPendingPathDrops();
 
-  ImGui::End();
-}
+      if (m_imguiBackendInitialized)
+        BeginEditorImGuiFrame(Renderer::GetBackendId());
+      ImGui::NewFrame();
 
-// Renders a Unity-style collapsible scene header, then the objects tree under it.
-void EditorLayer::DrawSceneHeader(SceneDocument& doc, bool isPrimary, int additionalIndex) {
-  // Build label: sceneName + dirty indicator for primary scene
-  std::string label = doc.sceneName.empty() ? "Scene" : doc.sceneName;
-  if (isPrimary && doc.dirty)
-    label += " *";
+      const EditorHistorySnapshot frameHistoryBefore = m_active ? CaptureHistorySnapshot()
+                                                                : EditorHistorySnapshot{};
+      const size_t undoHistorySizeBeforeRender = m_undoHistory.size();
+      const size_t redoHistorySizeBeforeRender = m_redoHistory.size();
 
-  // Tint the primary scene header slightly to distinguish it
-  if (isPrimary)
-    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0.18f, 0.33f, 0.52f, 1.0f));
+      if (m_active)
+      {
+        DrawToolbar();
+        DrawDockspace();
+        DrawViewportPanel(cam, screenW, screenH);
+        DrawObjectList();
+        DrawAssetsPanel();
+        DrawPropertiesPanel();
+        DrawBottomDock();
+        DrawStatusBar();
+        DrawHelpPopup();
+        DrawCommandPalettePopup();
+        DrawQuickOpenPopup();
+        DrawSettingsModal();
+        DrawDeleteConfirmModals();
+        DrawExitConfirmModal();
+        if (!m_playMode)
+        {
+          DrawSelectionHighlight(); // queues to DebugDraw
+          if (m_gizmo.IsActive())
+            m_gizmo.Draw(cam, screenW, screenH); // queues to DebugDraw
+        }
+      }
+      DrawHotReloadOverlay();
+      DrawClipboardToast();
+      SaveWorkspaceStateIfNeeded(false);
 
-  ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-  char nodeId[32];
-  std::snprintf(nodeId, sizeof(nodeId), isPrimary ? "##scene_primary" : "##scene_%d", additionalIndex);
-  const bool open = ImGui::TreeNodeEx(
-      nodeId,
-      ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth |
-          ImGuiTreeNodeFlags_DefaultOpen,
-      "%s", label.c_str());
+      if (m_active &&
+          !m_historyTransactionOpen &&
+          m_undoHistory.size() == undoHistorySizeBeforeRender &&
+          m_redoHistory.size() == redoHistorySizeBeforeRender)
+      {
+        CommitHistoryChange(frameHistoryBefore);
+      }
 
-  if (isPrimary)
-    ImGui::PopStyleColor();
+      // Wireframe pass: clears solid scene and draws edges; must happen before
+      // DebugDraw::Flush so selection highlight/gizmo render on top.
+      if (m_active && !m_playMode)
+        DrawWireframeOverlay(cam);
 
-  // Scene header context menu
-  char ctxId[40];
-  std::snprintf(ctxId, sizeof(ctxId), isPrimary ? "scene_hdr_ctx_p" : "scene_hdr_ctx_%d",
-                additionalIndex);
-  if (ImGui::BeginPopupContextItem(ctxId)) {
-    if (isPrimary) {
-      if (ImGui::BeginMenu("Add")) {
+      // Flush any queued debug primitives (selection box, gizmo, etc.) before ImGui
+      DebugDraw::Flush(cam);
+
+      ImGui::Render();
+      if (m_imguiBackendInitialized)
+        RenderEditorImGuiDrawData(Renderer::GetBackendId(), ImGui::GetDrawData());
+    }
+
+    void EditorLayer::DrawDockspace()
+    {
+      if (!m_resetDockLayoutRequested)
+        return;
+
+      ImGui::LoadIniSettingsFromMemory("", 0);
+      if (!m_imguiIniPath.empty())
+      {
+        std::error_code ec;
+        std::filesystem::remove(ResolveEditorLayoutPath(), ec);
+        ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
+      }
+      m_hasPersistedDockLayout = false;
+      m_resetDockLayoutRequested = false;
+    }
+
+    void EditorLayer::RefreshViewportPanelRect()
+    {
+      const ImVec2 winPos = ImGui::GetWindowPos();
+      const ImVec2 innerMin = ImGui::GetWindowContentRegionMin();
+      const ImVec2 innerMax = ImGui::GetWindowContentRegionMax();
+      m_viewportPanelRect.minX = winPos.x + innerMin.x;
+      m_viewportPanelRect.minY = winPos.y + innerMin.y;
+      m_viewportPanelRect.maxX = winPos.x + innerMax.x;
+      m_viewportPanelRect.maxY = winPos.y + innerMax.y;
+    }
+
+    void EditorLayer::DrawViewportPanel(const Camera &cam, int screenW, int screenH)
+    {
+      static std::string s_lastViewportRenderError;
+      struct ViewportAssetDropContext
+      {
+        EditorLayer *editor = nullptr;
+        const Camera *camera = nullptr;
+        int screenW = 0;
+        int screenH = 0;
+      };
+
+      ImGuiIO &io = ImGui::GetIO();
+      const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
+      const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+      const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
+      const EditorViewportRect defaultRect =
+          BuildEditorViewportRect(io.DisplaySize.x,
+                                  io.DisplaySize.y,
+                                  kEditorToolbarH,
+                                  kEditorStatusH,
+                                  bottomDockH,
+                                  leftDockW,
+                                  rightDockW);
+      ImGui::SetNextWindowPos(ImVec2(defaultRect.minX, defaultRect.minY), ImGuiCond_Always);
+      ImGui::SetNextWindowSize(ImVec2(defaultRect.maxX - defaultRect.minX,
+                                      defaultRect.maxY - defaultRect.minY),
+                               ImGuiCond_Always);
+      ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+      ImGui::SetNextWindowBgAlpha(0.06f);
+      m_viewportPanelRect = {};
+      if (ImGui::Begin(kEditorViewportWindow,
+                       nullptr,
+                       kMainPanelWindowFlags | ImGuiWindowFlags_NoScrollbar |
+                           ImGuiWindowFlags_NoScrollWithMouse))
+      {
+        RefreshViewportPanelRect();
+        const ImVec2 viewportImageStart = ImGui::GetCursorPos();
+        const ImVec2 dropTargetSize = ImGui::GetContentRegionAvail();
+        const float targetW = std::max(0.0f, dropTargetSize.x);
+        const float targetH = std::max(0.0f, dropTargetSize.y);
+
+        bool drewViewportImage = false;
+        if (targetW > 0.0f && targetH > 0.0f)
+        {
+          std::string viewportError;
+          RenderTargetHandle viewportHandle;
+          const uint32_t viewportWidth = static_cast<uint32_t>(std::max(1.0f, std::floor(targetW)));
+          const uint32_t viewportHeight = static_cast<uint32_t>(std::max(1.0f, std::floor(targetH)));
+          if (Renderer::EnsureEditorViewportRenderTarget(viewportWidth, viewportHeight, &viewportError) &&
+              Renderer::TryGetEditorViewportRenderTargetHandle(&viewportHandle, false, &viewportError))
+          {
+            const ImTextureID textureId = ToImTextureId(viewportHandle);
+            if (textureId != (ImTextureID)0)
+            {
+              ImGui::Image(textureId, ImVec2(targetW, targetH));
+              drewViewportImage = true;
+            }
+          }
+
+          if (!drewViewportImage && Renderer::GetBackendId() == RenderBackendId::Vulkan &&
+              !viewportError.empty())
+          {
+            if (viewportError != s_lastViewportRenderError)
+            {
+              LOG_WARN("[Editor] Vulkan viewport render target unavailable: %s", viewportError.c_str());
+              s_lastViewportRenderError = viewportError;
+            }
+          }
+          else if (drewViewportImage)
+            s_lastViewportRenderError.clear();
+        }
+
+        if (!drewViewportImage)
+          ImGui::Dummy(ImVec2(targetW, targetH));
+
+        ImGui::SetCursorPos(viewportImageStart);
+        ViewportAssetDropContext dropContext{this, &cam, screenW, screenH};
+        DrawViewportAssetDropTarget(
+            m_playMode,
+            dropTargetSize.x,
+            dropTargetSize.y,
+            &dropContext,
+            [](void *userData, const char *assetIdText) -> bool
+            {
+              auto *context = static_cast<ViewportAssetDropContext *>(userData);
+              if (!context || !context->editor || !context->camera || !assetIdText)
+                return false;
+
+              EditorLayer &editor = *context->editor;
+              const std::string assetId(assetIdText);
+              if (editor.m_document.assets.find(assetId) == editor.m_document.assets.end())
+              {
+                LOG_WARN("[Editor] Viewport drop rejected: missing asset '%s'", assetId.c_str());
+                return false;
+              }
+
+              Vec3 dropPos = Vec3::Zero();
+              if (!editor.TryBuildViewportDropPosition(
+                      *context->camera, context->screenW, context->screenH, assetId, &dropPos))
+              {
+                LOG_WARN("[Editor] Viewport drop rejected: camera ray did not hit a placement surface");
+                return false;
+              }
+
+              std::string createError;
+              if (!editor.CreateObjectFromAsset(
+                      assetId, std::string(), &dropPos, nullptr, nullptr, &createError))
+              {
+                LOG_WARN("[Editor] Viewport drop failed: %s", createError.c_str());
+                return false;
+              }
+              return true;
+            });
+
+        if (!m_playMode)
+          DrawViewGimbal(cam);
+      }
+      ImGui::End();
+      ImGui::PopStyleVar();
+    }
+
+    void EditorLayer::DrawClipboardToast()
+    {
+      if (m_clipboardToastTime <= 0.0f)
+        return;
+
+      ImGuiIO &io = ImGui::GetIO();
+      ImDrawList *draw = ImGui::GetForegroundDrawList();
+
+      const ImVec2 size(230.0f, 32.0f);
+      const ImVec2 pos(io.DisplaySize.x - size.x - 14.0f, io.DisplaySize.y - size.y - 14.0f);
+      const ImVec2 max(pos.x + size.x, pos.y + size.y);
+
+      draw->AddRectFilled(pos, max, IM_COL32(12, 18, 28, 215), 8.0f);
+      draw->AddRect(pos, max, IM_COL32(90, 190, 255, 185), 8.0f, 0, 1.0f);
+      const char *label = m_clipboardToastLabel.empty() ? "Reference copied" : m_clipboardToastLabel.c_str();
+      draw->AddText(ImVec2(pos.x + 10.0f, pos.y + 9.0f), IM_COL32(220, 235, 255, 255), label);
+    }
+
+    void EditorLayer::DrawHotReloadOverlay()
+    {
+      if (!m_hotReloadOverlayActive)
+        return;
+
+      ImGuiIO &io = ImGui::GetIO();
+      ImDrawList *draw = ImGui::GetForegroundDrawList();
+
+      const ImVec2 panelSize(280.0f, 74.0f);
+      const ImVec2 panelPos((io.DisplaySize.x - panelSize.x) * 0.5f, 18.0f);
+      const ImVec2 panelMax(panelPos.x + panelSize.x, panelPos.y + panelSize.y);
+
+      draw->AddRectFilled(panelPos, panelMax, IM_COL32(10, 14, 22, 215), 10.0f);
+      draw->AddRect(panelPos, panelMax, IM_COL32(70, 120, 190, 180), 10.0f, 0, 1.0f);
+
+      const ImVec2 spinnerCenter(panelPos.x + 24.0f, panelPos.y + panelSize.y * 0.5f);
+      const float spinnerR = 10.0f;
+      draw->AddCircle(spinnerCenter, spinnerR, IM_COL32(80, 90, 120, 200), 24, 2.0f);
+
+      const float arcStart = m_hotReloadOverlaySpinner;
+      const float arcEnd = arcStart + 2.5f;
+      draw->PathArcTo(spinnerCenter, spinnerR, arcStart, arcEnd, 24);
+      draw->PathStroke(IM_COL32(110, 210, 255, 255), false, 3.0f);
+
+      const char *label = m_hotReloadOverlayLabel.empty() ? "Hot Reload" : m_hotReloadOverlayLabel.c_str();
+      draw->AddText(ImVec2(panelPos.x + 44.0f, panelPos.y + 14.0f), IM_COL32(230, 240, 255, 255), label);
+
+      const ImVec2 barMin(panelPos.x + 44.0f, panelPos.y + 42.0f);
+      const ImVec2 barMax(panelMax.x - 16.0f, panelPos.y + 56.0f);
+      draw->AddRectFilled(barMin, barMax, IM_COL32(26, 32, 46, 255), 4.0f);
+
+      const float w = (barMax.x - barMin.x) * m_hotReloadOverlayProgress;
+      if (w > 1.0f)
+        draw->AddRectFilled(barMin, ImVec2(barMin.x + w, barMax.y), IM_COL32(90, 190, 255, 255), 4.0f);
+    }
+
+    // ---- Toolbar -----------------------------------------------------------------
+
+    void EditorLayer::DrawToolbar()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      ImGui::SetNextWindowPos(ImVec2(0, 0));
+      ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kEditorToolbarH));
+      ImGui::SetNextWindowBgAlpha(0.85f);
+      ImGui::Begin("##toolbar",
+                   nullptr,
+                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+      ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "EDITOR");
+      ImGui::SameLine();
+      ImGui::Separator();
+      ImGui::SameLine();
+
+      const bool hasSelectedAsset = !m_selectedAssetId.empty() &&
+                                    m_document.assets.find(m_selectedAssetId) != m_document.assets.end();
+      const bool hasSelection = !m_selectedIndices.empty();
+      const int primaryIdx = PrimaryIdx();
+      const bool hasSingleSelection = CanEditSingleSelection(
+          static_cast<int>(m_selectedIndices.size()),
+          primaryIdx,
+          static_cast<int>(m_document.objects.size()));
+
+      if (ImGui::Button("File"))
+        ImGui::OpenPopup("##toolbar_file_popup");
+      if (ImGui::BeginPopup("##toolbar_file_popup"))
+      {
+        if (ImGui::MenuItem("New Scene"))
+          RequestSceneAction(PendingSceneAction::NewScene);
+        if (ImGui::MenuItem("Open Scene..."))
+          RequestSceneAction(PendingSceneAction::OpenSceneFile);
+        if (ImGui::MenuItem("Reset Layout"))
+          m_resetDockLayoutRequested = true;
+        ImGui::Separator();
+        if (ImGui::MenuItem("Settings..."))
+        {
+          m_settingsOpen = true;
+          m_mcpSettingsDraft = m_mcpController.GetSettings();
+          m_mcpSettingsError.clear();
+        }
+        ImGui::EndPopup();
+      }
+      ImGui::SameLine();
+
+      if (ImGui::Button("Add"))
+        ImGui::OpenPopup("##toolbar_add_popup");
+      if (ImGui::BeginPopup("##toolbar_add_popup"))
+      {
         if (ImGui::MenuItem("Panel"))
           AddObject(SceneObjectType::Panel);
         if (ImGui::MenuItem("Prop"))
@@ -3402,3536 +2685,5184 @@ void EditorLayer::DrawSceneHeader(SceneDocument& doc, bool isPrimary, int additi
           AddObject(SceneObjectType::Light);
         if (ImGui::MenuItem("Camera"))
           AddObject(SceneObjectType::Camera);
-        ImGui::EndMenu();
-      }
-      ImGui::Separator();
-      std::string saveErr;
-      if (ImGui::MenuItem("Save Scene"))
-        SaveDocument(&saveErr);
-    } else {
-      std::string saveErr;
-      if (ImGui::MenuItem("Save Scene"))
-        SaveAdditionalScene(additionalIndex, &saveErr);
-      ImGui::Separator();
-      if (ImGui::MenuItem("Close Scene"))
-        CloseAdditionalScene(additionalIndex);
-    }
-    ImGui::EndPopup();
-  }
 
-  // Drop onto scene header → unparent the dragged object (make it a root)
-  if (isPrimary && ImGui::BeginDragDropTarget()) {
-    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("SCENE_OBJECT_INDEX")) {
-      if (payload->DataSize == sizeof(int)) {
-        const int src = *static_cast<const int*>(payload->Data);
-        if (src >= 0 && src < static_cast<int>(doc.objects.size())) {
-          doc.objects[static_cast<size_t>(src)].props.erase("parentId");
-          doc.dirty = true;
+        ImGui::Separator();
+        if (!hasSelectedAsset)
+          ImGui::BeginDisabled();
+        if (ImGui::MenuItem("Prop from Selected Asset"))
+          AddObjectFromSelectedAsset();
+        if (!hasSelectedAsset)
+          ImGui::EndDisabled();
+        ImGui::EndPopup();
+      }
+      ImGui::SameLine();
+
+      if (ImGui::Button("Edit"))
+        ImGui::OpenPopup("##toolbar_edit_popup");
+      if (ImGui::BeginPopup("##toolbar_edit_popup"))
+      {
+        if (!CanUndoHistory())
+          ImGui::BeginDisabled();
+        if (ImGui::MenuItem("Undo", "Ctrl/Cmd+Z"))
+          UndoHistory();
+        if (!CanUndoHistory())
+          ImGui::EndDisabled();
+        if (!CanRedoHistory())
+          ImGui::BeginDisabled();
+        if (ImGui::MenuItem("Redo", "Ctrl/Cmd+Shift+Z / Ctrl+Y"))
+          RedoHistory();
+        if (!CanRedoHistory())
+          ImGui::EndDisabled();
+        ImGui::Separator();
+        if (!hasSelection)
+          ImGui::BeginDisabled();
+        if (!hasSingleSelection)
+          ImGui::BeginDisabled();
+        if (ImGui::MenuItem("Rename..."))
+          OpenRenameObjectModal(primaryIdx);
+        if (ImGui::MenuItem("Create Prefab"))
+        {
+          std::string prefabError;
+          if (!CreatePrefabFromSelection(&prefabError))
+            LOG_ERROR("[Editor] Create prefab failed: %s", prefabError.c_str());
+        }
+        if (!hasSingleSelection)
+          ImGui::EndDisabled();
+        if (ImGui::MenuItem("Duplicate"))
+          DuplicateSelectedObjects();
+        if (ImGui::MenuItem("Delete"))
+          RequestDeleteSelectedObjects();
+        ImGui::Separator();
+        if (!hasSingleSelection)
+          ImGui::BeginDisabled();
+        if (ImGui::MenuItem("Copy Ref", "Ctrl/Cmd+Shift+C"))
+        {
+          const int idx = PrimaryIdx();
+          if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+          {
+            const std::string ref = BuildSelectionRefCode(m_document.objects[static_cast<size_t>(idx)], idx);
+            ImGui::SetClipboardText(ref.c_str());
+            m_clipboardToastLabel = "Reference copied";
+            m_clipboardToastTime = 1.5f;
+          }
+        }
+        if (!hasSingleSelection)
+          ImGui::EndDisabled();
+        if (!hasSelection)
+          ImGui::EndDisabled();
+        ImGui::EndPopup();
+      }
+      ImGui::SameLine();
+
+      if (ImGui::Button("View"))
+        ImGui::OpenPopup("##toolbar_view_popup");
+      if (ImGui::BeginPopup("##toolbar_view_popup"))
+      {
+        const bool flyBefore = m_flyMode;
+        if (ImGui::MenuItem("Fly Mode", "Tab", m_flyMode))
+        {
+          m_flyMode = !m_flyMode;
+          m_flyCamInitialized = false;
+          m_prevCursorInit = false;
+          glfwSetInputMode(m_window, GLFW_CURSOR,
+                           m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
+        }
+        if (flyBefore || m_flyMode)
+          ImGui::TextDisabled("WASD + mouse");
+        if (ImGui::MenuItem("Help", "? / F1"))
+          m_helpOpen = true;
+        if (ImGui::MenuItem("Quick Open", "Ctrl/Cmd+P"))
+          m_quickOpenOpen = true;
+        if (ImGui::MenuItem("Command Palette", "Ctrl/Cmd+Shift+P"))
+        {
+          m_commandPaletteOpen = true;
+          m_commandPaletteQuery.clear();
+        }
+        if (ImGui::MenuItem("Reset Layout"))
+          m_resetDockLayoutRequested = true;
+        ImGui::EndPopup();
+      }
+      ImGui::SameLine();
+      ImGui::TextDisabled("Copy Ref: Ctrl/Cmd+Shift+C");
+      ImGui::SameLine();
+      ImGui::Separator();
+      ImGui::SameLine();
+      if (!m_playMode)
+      {
+        if (ImGui::Button("Play"))
+        {
+          m_playMode = true;
+          if (m_flyMode)
+          {
+            m_flyMode = false;
+            m_flyCamInitialized = false;
+            m_prevCursorInit = false;
+          }
+          glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
         }
       }
-    }
-    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_ID")) {
-      const std::string assetId(static_cast<const char*>(payload->Data));
-      std::string createError;
-      if (!CreateObjectFromAsset(assetId, std::string(), nullptr, nullptr, nullptr, &createError))
-        LOG_WARN("[Editor] Hierarchy root asset drop failed: %s", createError.c_str());
-    }
-    ImGui::EndDragDropTarget();
-  }
-
-  if (open) {
-    DrawObjectsTree(doc, isPrimary);
-    ImGui::TreePop();
-  }
-}
-
-// Renders the tree of objects inside a scene, plus runtime entities for the primary scene.
-void EditorLayer::DrawObjectsTree(SceneDocument& doc, bool isPrimary) {
-  // Search filter applies only to the primary scene
-  const std::string& query = isPrimary ? m_objectSearchQuery : "";
-
-  int shownObjectCount = 0;
-
-  if (!query.empty()) {
-    // Flat filtered list (search mode, primary scene only)
-    for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i) {
-      ImGui::PushID(i);
-      auto& obj = doc.objects[static_cast<size_t>(i)];
-      if (!ObjectMatchesQuickOpenQuery(obj, query)) {
-        ImGui::PopID();
-        continue;
-      }
-      const char* icon = ObjectTypeIcon(obj.type);
-      const char* typeName = ObjectTypeLabel(obj.type);
-
-      char selectableId[32];
-      std::snprintf(selectableId, sizeof(selectableId), "##obj_%d", i);
-
-      const float lineH = ImGui::GetTextLineHeight();
-      const float rowH = obj.assetId.empty() ? lineH : lineH * 2.0f + 2.0f;
-
-      if (ImGui::Selectable(selectableId, IsSelected(i), 0, ImVec2(0, rowH))) {
-        auto& selIo = ImGui::GetIO();
-        if (selIo.KeyShift && m_lastClickedHierarchyIdx >= 0) {
-          const int lo = std::min(m_lastClickedHierarchyIdx, i);
-          const int hi = std::max(m_lastClickedHierarchyIdx, i);
-          m_selectedIndices.clear();
-          for (int ri = lo; ri <= hi; ++ri)
-            m_selectedIndices.push_back(ri);
-        } else if (selIo.KeyCtrl || selIo.KeySuper) {
-          ToggleSelect(i);
-          m_lastClickedHierarchyIdx = i;
-        } else {
-          m_selectedIndices = {i};
-          m_lastClickedHierarchyIdx = i;
+      else
+      {
+        if (ImGui::Button("Stop"))
+        {
+          m_playMode = false;
+          glfwSetInputMode(m_window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
         }
       }
       ImGui::SameLine();
+
+      // Right-aligned controls
+      const float rightW = 300.0f;
+      ImGui::SetCursorPosX(io.DisplaySize.x - rightW);
+
+      if (ImGui::Button("Load"))
       {
-        const ImVec2 pos = ImGui::GetCursorScreenPos();
-        ImGui::BeginGroup();
-        ImGui::TextDisabled("%s %s", icon, typeName);
-        ImGui::SameLine(0.0f, 4.0f);
-        ImGui::Text("%s", obj.id.c_str());
-        if (!obj.assetId.empty()) {
-          ImGui::SetCursorScreenPos(ImVec2(pos.x, pos.y + lineH + 2.0f));
-          ImGui::TextDisabled("  > %s", obj.assetId.c_str());
+        RequestSceneAction(PendingSceneAction::LoadSceneFromDisk);
+      }
+      ImGui::SameLine();
+
+      {
+        const bool canSave = m_document.dirty;
+        if (!canSave)
+          ImGui::BeginDisabled();
+        if (ImGui::Button("Save"))
+        {
+          std::string saveError;
+          if (!SaveDocument(&saveError))
+            LOG_ERROR("EditorLayer: save failed: %s", saveError.c_str());
         }
-        ImGui::EndGroup();
+        if (!canSave)
+          ImGui::EndDisabled();
+      }
+      ImGui::SameLine();
+
+      if (ImGui::Button("Close editor"))
+      {
+        RequestSceneAction(PendingSceneAction::CloseEditor);
       }
 
-      if (isPrimary && ImGui::BeginDragDropTarget()) {
-        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_ID")) {
-          const std::string assetId(static_cast<const char*>(payload->Data));
-          std::string createError;
-          if (!CreateObjectFromAsset(assetId, obj.id, nullptr, nullptr, nullptr, &createError))
-            LOG_WARN("[Editor] Hierarchy child asset drop failed: %s", createError.c_str());
-        }
-        ImGui::EndDragDropTarget();
+      ImGui::End();
+    }
+
+    void EditorLayer::DrawStatusBar()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const EditorStatusText status = BuildEditorStatusText(
+          EditorStatusSnapshot{static_cast<int>(m_selectedIndices.size()), m_document.dirty, m_flyMode, m_wantsReload});
+
+      ImGui::SetNextWindowPos(ImVec2(0.0f, io.DisplaySize.y - kEditorStatusH));
+      ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kEditorStatusH));
+      ImGui::SetNextWindowBgAlpha(0.82f);
+      ImGui::Begin("##editor_statusbar",
+                   nullptr,
+                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus);
+
+      ImGui::TextDisabled("Sel: %d", status.selectionCount);
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::TextDisabled("Dirty: %s", status.dirtyText);
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::TextDisabled("Fly: %s", status.flyText);
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::TextDisabled("Reload: %s", status.reloadText);
+
+      ImGui::End();
+    }
+
+    const std::vector<std::pair<std::filesystem::path, bool>> *EditorLayer::GetProjectDirListing(
+        const std::filesystem::path &absPath)
+    {
+      namespace fs = std::filesystem;
+      std::error_code existsEc;
+      if (!fs::is_directory(absPath, existsEc) || existsEc)
+        return nullptr;
+
+      const std::string key = absPath.generic_string();
+      const uint32_t frame = static_cast<uint32_t>(ImGui::GetFrameCount());
+      auto it = m_projectDirCache.find(key);
+      if (it != m_projectDirCache.end())
+      {
+        const uint32_t age = frame - it->second.cachedAtFrame;
+        if (age < kProjectListingCacheFrames)
+          return &it->second.entries;
       }
 
-      if (ImGui::BeginPopupContextItem("obj_ctx")) {
-        if (ImGui::BeginMenu("Add")) {
+      std::vector<std::pair<fs::path, bool>> sorted;
+      std::error_code ec;
+      for (fs::directory_iterator dit(absPath, fs::directory_options::skip_permission_denied, ec), end;
+           !ec && dit != end;
+           dit.increment(ec))
+      {
+        const fs::directory_entry ent = *dit;
+        const std::string name = ent.path().filename().string();
+        if (Editor::IsHiddenDotEntry(name))
+          continue;
+        std::error_code typEc;
+        const bool isDir = ent.is_directory(typEc);
+        if (isDir && !typEc && Editor::IsBlockedProjectDirName(name, &m_projectExtraBlocklist))
+          continue;
+        sorted.emplace_back(ent.path(), isDir && !typEc);
+      }
+      std::sort(sorted.begin(), sorted.end(), [](const auto &a, const auto &b)
+                {
+    if (a.second != b.second)
+      return a.second > b.second;
+    return a.first.filename() < b.first.filename(); });
+
+      ProjectDirCache slot;
+      slot.cachedAtFrame = frame;
+      slot.entries = std::move(sorted);
+      m_projectDirCache[key] = std::move(slot);
+      return &m_projectDirCache.at(key).entries;
+    }
+
+    void EditorLayer::DrawProjectTreeRecursive(const std::filesystem::path &absPath,
+                                               const std::filesystem::path & /*displayRoot*/)
+    {
+      namespace fs = std::filesystem;
+      const auto *listing = GetProjectDirListing(absPath);
+      if (!listing)
+        return;
+
+      for (const auto &ent : *listing)
+      {
+        const fs::path &p = ent.first;
+        const bool isDir = ent.second;
+        const std::string name = p.filename().string();
+        if (isDir)
+        {
+          if (ImGui::TreeNodeEx(name.c_str(), 0))
+          {
+            DrawProjectTreeRecursive(p, absPath);
+            ImGui::TreePop();
+          }
+        }
+        else
+        {
+          ImGui::BulletText("%s", name.c_str());
+        }
+      }
+    }
+
+    static void FormatLogTime(const LogLine &entry, char *buf, size_t bufSize)
+    {
+      using clock = std::chrono::system_clock;
+      const std::time_t t = clock::to_time_t(entry.time);
+      std::tm tmBuf{};
+#ifdef _WIN32
+      localtime_s(&tmBuf, &t);
+#else
+      localtime_r(&t, &tmBuf);
+#endif
+      std::strftime(buf, bufSize, "%H:%M:%S", &tmBuf);
+    }
+
+    void EditorLayer::DrawBottomDock()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
+      const float dockTop = io.DisplaySize.y - kEditorStatusH - bottomDockH;
+      ImGui::SetNextWindowPos(ImVec2(0.0f, dockTop), ImGuiCond_Always);
+      ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, bottomDockH), ImGuiCond_Always);
+      ImGui::Begin(kEditorWorkspaceWindow, nullptr, kMainPanelWindowFlags);
+
+      if (ImGui::BeginTabBar("##bottom_tabs", ImGuiTabBarFlags_None))
+      {
+        if (ImGui::BeginTabItem("Project"))
+        {
+          if (m_projectBrowserRootValid &&
+              std::filesystem::is_directory(m_projectBrowserRoot))
+          {
+            if (!m_projectBrowserCwdValid ||
+                !std::filesystem::is_directory(m_projectBrowserCwd) ||
+                m_projectBrowserCwd.empty())
+            {
+              m_projectBrowserCwd = m_projectBrowserRoot;
+              m_projectBrowserCwdValid = true;
+            }
+
+            ImGui::BeginChild("##project_tiles", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
+
+            bool cwdChanged = false;
+            std::filesystem::path nextCwd = m_projectBrowserCwd;
+            const std::string rootLabel = m_projectBrowserRoot.filename().string().empty()
+                                              ? m_projectBrowserRoot.generic_string()
+                                              : m_projectBrowserRoot.filename().string();
+            if (ImGui::SmallButton(rootLabel.c_str()))
+            {
+              nextCwd = m_projectBrowserRoot;
+              cwdChanged = true;
+            }
+
+            std::error_code relEc;
+            const std::filesystem::path relPath =
+                std::filesystem::relative(m_projectBrowserCwd, m_projectBrowserRoot, relEc);
+            if (!relEc && !relPath.empty() && relPath != ".")
+            {
+              std::filesystem::path crumb = m_projectBrowserRoot;
+              for (const auto &part : relPath)
+              {
+                ImGui::SameLine();
+                ImGui::TextUnformatted(">");
+                ImGui::SameLine();
+                crumb /= part;
+                const std::string partLabel = part.string();
+                if (ImGui::SmallButton(partLabel.c_str()))
+                {
+                  nextCwd = crumb;
+                  cwdChanged = true;
+                }
+              }
+            }
+
+            ImGui::Separator();
+
+            const auto *listing = GetProjectDirListing(m_projectBrowserCwd);
+            if (!listing)
+            {
+              ImGui::TextDisabled("Cannot read '%s'", m_projectBrowserCwd.generic_string().c_str());
+            }
+            else
+            {
+              const float spacing = 10.0f;
+              const float minTileW = 120.0f;
+              const float tileH = 104.0f;
+              const float iconW = 64.0f;
+              const float iconH = 42.0f;
+              const float availW = std::max(0.0f, ImGui::GetContentRegionAvail().x);
+              const int columns = std::max(1, static_cast<int>((availW + spacing) / (minTileW + spacing)));
+              const float tileW = std::max(minTileW,
+                                           (availW - spacing * static_cast<float>(columns - 1)) /
+                                               static_cast<float>(columns));
+
+              int itemIndex = 0;
+              for (const auto &ent : *listing)
+              {
+                const std::filesystem::path &p = ent.first;
+                const bool isDir = ent.second;
+                const std::string name = p.filename().string();
+
+                ImGui::PushID(p.generic_string().c_str());
+                ImGui::InvisibleButton("##project_item_btn", ImVec2(tileW, tileH));
+                if (ImGui::IsItemClicked())
+                {
+                  if (isDir)
+                  {
+                    nextCwd = p;
+                    cwdChanged = true;
+                  }
+                }
+
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+                  ImGui::SetTooltip("%s", p.generic_string().c_str());
+
+                const ImVec2 rMin = ImGui::GetItemRectMin();
+                const ImVec2 rMax = ImGui::GetItemRectMax();
+                ImDrawList *dl = ImGui::GetWindowDrawList();
+                const bool hovered = ImGui::IsItemHovered();
+                const ImU32 hoverBg = ImGui::ColorConvertFloat4ToU32(ImVec4(0.22f, 0.30f, 0.42f, 0.28f));
+                if (hovered)
+                {
+                  dl->AddRectFilled(ImVec2(rMin.x + 2.0f, rMin.y + 2.0f), ImVec2(rMax.x - 2.0f, rMax.y - 2.0f),
+                                    hoverBg, 8.0f);
+                }
+
+                const float iconX = rMin.x + (tileW - iconW) * 0.5f;
+                const float iconY = rMin.y + 10.0f;
+                if (isDir)
+                {
+                  const ImU32 tabCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.30f, 0.68f, 0.92f, 1.0f));
+                  const ImU32 bodyCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.25f, 0.60f, 0.86f, 1.0f));
+                  const ImU32 edgeCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.18f, 0.45f, 0.66f, 1.0f));
+                  dl->AddRectFilled(ImVec2(iconX + 5.0f, iconY), ImVec2(iconX + iconW * 0.56f, iconY + 10.0f), tabCol,
+                                    4.0f, ImDrawFlags_RoundCornersTop);
+                  dl->AddRectFilled(ImVec2(iconX, iconY + 7.0f), ImVec2(iconX + iconW, iconY + iconH), bodyCol, 6.0f);
+                  dl->AddRect(ImVec2(iconX, iconY + 7.0f), ImVec2(iconX + iconW, iconY + iconH), edgeCol, 6.0f);
+                }
+                else
+                {
+                  const ImU32 pageCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.86f, 0.90f, 0.96f, 1.0f));
+                  const ImU32 foldCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.74f, 0.80f, 0.90f, 1.0f));
+                  const ImU32 edgeCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.58f, 0.65f, 0.76f, 1.0f));
+                  const ImVec2 p0(iconX + 8.0f, iconY);
+                  const ImVec2 p1(iconX + iconW - 8.0f, iconY + iconH);
+                  dl->AddRectFilled(p0, p1, pageCol, 4.0f);
+                  dl->AddRect(p0, p1, edgeCol, 4.0f);
+                  dl->AddTriangleFilled(ImVec2(p1.x - 14.0f, p0.y), ImVec2(p1.x, p0.y), ImVec2(p1.x, p0.y + 14.0f),
+                                        foldCol);
+                }
+
+                std::string label = name;
+                const float maxLabelW = tileW - 10.0f;
+                if (ImGui::CalcTextSize(label.c_str()).x > maxLabelW)
+                {
+                  while (!label.empty() && ImGui::CalcTextSize((label + "...").c_str()).x > maxLabelW)
+                    label.pop_back();
+                  label += "...";
+                }
+
+                const ImVec2 labelSz = ImGui::CalcTextSize(label.c_str());
+                const float labelX = rMin.x + std::max(4.0f, (tileW - labelSz.x) * 0.5f);
+                const float labelY = iconY + iconH + 10.0f;
+                dl->AddText(ImVec2(labelX, labelY), ImGui::GetColorU32(ImGuiCol_Text), label.c_str());
+
+                ImGui::PopID();
+
+                ++itemIndex;
+                if ((itemIndex % columns) != 0)
+                  ImGui::SameLine(0.0f, spacing);
+              }
+            }
+
+            if (cwdChanged)
+            {
+              m_projectBrowserCwd = std::move(nextCwd);
+              m_projectBrowserCwdValid = true;
+              m_savedProjectBrowserCwd = m_projectBrowserCwd;
+              MarkWorkspaceStateDirty();
+            }
+
+            ImGui::EndChild();
+          }
+          else
+          {
+            ImGui::TextDisabled("Set project root (host app) to browse files.");
+          }
+          ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Console"))
+        {
+          int nInfo = 0;
+          int nWarn = 0;
+          int nErr = 0;
+          LogBuffer::Instance().GetCounts(&nInfo, &nWarn, &nErr);
+          if (ImGui::SmallButton("Clear"))
+            LogBuffer::Instance().Clear();
+          ImGui::SameLine();
+          if (ImGui::Checkbox("Info", &m_consoleShowInfo))
+            MarkWorkspaceStateDirty();
+          ImGui::SameLine();
+          if (ImGui::Checkbox("Warn", &m_consoleShowWarn))
+            MarkWorkspaceStateDirty();
+          ImGui::SameLine();
+          if (ImGui::Checkbox("Error", &m_consoleShowError))
+            MarkWorkspaceStateDirty();
+          ImGui::SameLine();
+          ImGui::TextDisabled("I:%d W:%d E:%d", nInfo, nWarn, nErr);
+
+          ImGui::Separator();
+          ImGui::BeginChild("##console_scroll", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
+          LogBuffer &logBuf = LogBuffer::Instance();
+          const uint64_t rev = logBuf.Revision();
+          if (rev != m_consoleLogRevision)
+          {
+            logBuf.CopyLinesTo(&m_consoleLinesCache);
+            m_consoleLogRevision = rev;
+          }
+
+          m_consoleVisibleScratch.clear();
+          for (int i = 0; i < static_cast<int>(m_consoleLinesCache.size()); ++i)
+          {
+            const LogLine &entry = m_consoleLinesCache[static_cast<size_t>(i)];
+            if (entry.level == LogLevel::Info && !m_consoleShowInfo)
+              continue;
+            if (entry.level == LogLevel::Warn && !m_consoleShowWarn)
+              continue;
+            if (entry.level == LogLevel::Error && !m_consoleShowError)
+              continue;
+            m_consoleVisibleScratch.push_back(i);
+          }
+
+          // No ImGuiListClipper here: wrapped ImGui::Text rows have variable height and can confuse
+          // the clipper (hang or broken scroll). LogBuffer caps lines (~1k); a linear pass is fine.
+          EditorTrace("Console draw visible=%d cached=%zu rev=%llu",
+                      static_cast<int>(m_consoleVisibleScratch.size()), m_consoleLinesCache.size(),
+                      static_cast<unsigned long long>(rev));
+
+          for (int row = 0; row < static_cast<int>(m_consoleVisibleScratch.size()); ++row)
+          {
+            const LogLine &entry =
+                m_consoleLinesCache[static_cast<size_t>(m_consoleVisibleScratch[static_cast<size_t>(row)])];
+            char timeBuf[32];
+            FormatLogTime(entry, timeBuf, sizeof(timeBuf));
+            const char *levelStr =
+                entry.level == LogLevel::Info ? "INFO" : entry.level == LogLevel::Warn ? "WARN"
+                                                                                       : "ERR";
+            ImVec4 color(0.85f, 0.9f, 1.0f, 1.0f);
+            if (entry.level == LogLevel::Warn)
+              color = ImVec4(1.0f, 0.85f, 0.4f, 1.0f);
+            else if (entry.level == LogLevel::Error)
+              color = ImVec4(1.0f, 0.45f, 0.4f, 1.0f);
+
+            char lineBuf[1024];
+            std::snprintf(lineBuf, sizeof(lineBuf), "[%s] %s (%s:%d) %s", timeBuf, levelStr,
+                          entry.file.c_str(), entry.line, entry.message.c_str());
+
+            ImGui::PushStyleColor(ImGuiCol_Text, color);
+            ImGui::TextUnformatted(lineBuf);
+            ImGui::PopStyleColor();
+          }
+          ImGui::EndChild();
+          ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("MCP"))
+        {
+          DrawMcpTab();
+          ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+      }
+
+      ImGui::End();
+    }
+
+    void EditorLayer::DrawMcpTab()
+    {
+      const Mcp::McpStatusSnapshot status = m_mcpController.GetStatusSnapshot();
+      auto copyToClipboard = [&](const std::string &label, const std::string &text)
+      {
+        glfwSetClipboardString(m_window, text.c_str());
+        m_clipboardToastLabel = label;
+        m_clipboardToastTime = 1.5f;
+      };
+
+      if (m_mcpSelectedActivityIndex >= static_cast<int>(status.recentActivity.size()))
+        m_mcpSelectedActivityIndex = status.recentActivity.empty() ? 0 : static_cast<int>(status.recentActivity.size()) - 1;
+
+      ImGui::Text("Status: %s", status.running ? "Running" : "Stopped");
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Enabled: %s", status.enabled ? "Yes" : "No");
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Endpoint: %s", status.endpointUrl.c_str());
+
+      ImGui::Text("Requests: %llu", static_cast<unsigned long long>(status.totalRequests));
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Success: %llu", static_cast<unsigned long long>(status.successCount));
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Failed: %llu", static_cast<unsigned long long>(status.failureCount));
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Active: %d", status.activeRequests);
+
+      ImGui::Text("Tools: %d", static_cast<int>(status.toolCount));
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Resources: %d", static_cast<int>(status.resourceCount));
+      ImGui::SameLine();
+      ImGui::TextDisabled("|");
+      ImGui::SameLine();
+      ImGui::Text("Last Request: %s", status.lastRequestTime.empty() ? "-" : status.lastRequestTime.c_str());
+
+      if (!status.topTool.empty() || !status.topResource.empty())
+      {
+        ImGui::Text("Top Tool: %s", status.topTool.empty() ? "-" : status.topTool.c_str());
+        ImGui::SameLine();
+        ImGui::TextDisabled("|");
+        ImGui::SameLine();
+        ImGui::Text("Top Resource: %s", status.topResource.empty() ? "-" : status.topResource.c_str());
+      }
+
+      if (!status.lastError.empty())
+      {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
+        ImGui::TextWrapped("%s", status.lastError.c_str());
+        ImGui::PopStyleColor();
+      }
+
+      ImGui::SeparatorText("Quick Actions");
+      if (ImGui::Button("Open Settings"))
+      {
+        m_settingsOpen = true;
+        m_mcpSettingsDraft = m_mcpController.GetSettings();
+        m_mcpSettingsError.clear();
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Copy Endpoint"))
+        copyToClipboard("MCP endpoint copied", status.endpointUrl);
+      ImGui::SameLine();
+      if (ImGui::Button("Clear Request Log"))
+        m_mcpController.ClearActivityLog();
+
+      ImGui::SeparatorText("Clients");
+      if (ImGui::BeginTable("##mcp_clients", 3, ImGuiTableFlags_SizingStretchSame))
+      {
+        ImGui::TableNextRow();
+
+        auto drawClientCard = [&](const char *title,
+                                  const char *pathLabel,
+                                  const char *pathValue,
+                                  const char *hint,
+                                  const std::string &snippet,
+                                  const char *toastLabel)
+        {
+          ImGui::TableNextColumn();
+          ImGui::BeginChild(title, ImVec2(0, 132.0f), true);
+          ImGui::TextUnformatted(title);
+          ImGui::Separator();
+          ImGui::TextWrapped("%s", hint);
+          ImGui::TextDisabled("%s", pathLabel);
+          ImGui::TextWrapped("%s", pathValue);
+          if (ImGui::Button((std::string("Copy Config##") + title).c_str()))
+            copyToClipboard(toastLabel, snippet);
+          ImGui::EndChild();
+        };
+
+        drawClientCard("Codex",
+                       "Config path",
+                       "~/.codex/config.toml or .codex/config.toml",
+                       "Use the built-in MCP server entry so /mcp can discover Horo Engine automatically.",
+                       m_mcpController.BuildCodexConfigSnippet(),
+                       "Codex MCP config copied");
+        drawClientCard("Claude",
+                       "Config path",
+                       "~/.claude.json or .mcp.json",
+                       "Claude Code can connect over HTTP MCP using the endpoint shown above.",
+                       m_mcpController.BuildClaudeConfigSnippet(),
+                       "Claude MCP config copied");
+        drawClientCard("VS Code",
+                       "Config path",
+                       ".vscode/mcp.json or user mcp.json",
+                       "VS Code MCP can be set per workspace or globally from the Command Palette.",
+                       m_mcpController.BuildVsCodeConfigSnippet(),
+                       "VS Code MCP config copied");
+        ImGui::EndTable();
+      }
+
+      ImGui::SeparatorText("Live Requests");
+      if (ImGui::BeginTable("##mcp_requests", 6,
+                            ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_ScrollY |
+                                ImGuiTableFlags_Resizable,
+                            ImVec2(0.0f, 200.0f)))
+      {
+        ImGui::TableSetupColumn("Time", ImGuiTableColumnFlags_WidthFixed, 80.0f);
+        ImGui::TableSetupColumn("Target", ImGuiTableColumnFlags_WidthStretch, 1.6f);
+        ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 64.0f);
+        ImGui::TableSetupColumn("Ms", ImGuiTableColumnFlags_WidthFixed, 58.0f);
+        ImGui::TableSetupColumn("Request", ImGuiTableColumnFlags_WidthStretch, 2.0f);
+        ImGui::TableSetupColumn("Response", ImGuiTableColumnFlags_WidthStretch, 2.0f);
+        ImGui::TableHeadersRow();
+        for (int i = 0; i < static_cast<int>(status.recentActivity.size()); ++i)
+        {
+          const Mcp::McpActivityEntry &entry = status.recentActivity[static_cast<size_t>(i)];
+          ImGui::TableNextRow();
+          ImGui::TableSetColumnIndex(0);
+          const bool selected = i == m_mcpSelectedActivityIndex;
+          const std::string selectableLabel = entry.timeText + "##mcp_req_" + std::to_string(i);
+          if (ImGui::Selectable(selectableLabel.c_str(), selected, ImGuiSelectableFlags_SpanAllColumns))
+            m_mcpSelectedActivityIndex = i;
+          ImGui::TableSetColumnIndex(1);
+          ImGui::TextUnformatted(entry.target.c_str());
+          ImGui::TableSetColumnIndex(2);
+          ImGui::TextColored(entry.ok ? ImVec4(0.75f, 0.95f, 0.75f, 1.0f) : ImVec4(1.0f, 0.55f, 0.5f, 1.0f),
+                             "%s", entry.ok ? "OK" : "FAIL");
+          ImGui::TableSetColumnIndex(3);
+          ImGui::Text("%.1f", entry.durationMs);
+          ImGui::TableSetColumnIndex(4);
+          ImGui::TextWrapped("%s", entry.requestPreview.empty() ? "-" : entry.requestPreview.c_str());
+          ImGui::TableSetColumnIndex(5);
+          ImGui::TextWrapped("%s", entry.responsePreview.empty() ? "-" : entry.responsePreview.c_str());
+        }
+        ImGui::EndTable();
+      }
+
+      if (!status.recentActivity.empty())
+      {
+        const Mcp::McpActivityEntry &selected = status.recentActivity[static_cast<size_t>(m_mcpSelectedActivityIndex)];
+        ImGui::SeparatorText("Request Detail");
+        ImGui::Text("Timestamp: %s", selected.timestampText.c_str());
+        ImGui::SameLine();
+        ImGui::TextDisabled("|");
+        ImGui::SameLine();
+        ImGui::Text("Method: %s", selected.mcpMethod.empty() ? "-" : selected.mcpMethod.c_str());
+        ImGui::SameLine();
+        ImGui::TextDisabled("|");
+        ImGui::SameLine();
+        ImGui::Text("HTTP: %d", selected.httpStatus);
+        ImGui::Text("Operation: %s", selected.operation.empty() ? "-" : selected.operation.c_str());
+        ImGui::SameLine();
+        ImGui::TextDisabled("|");
+        ImGui::SameLine();
+        ImGui::Text("Request ID: %s", selected.requestId.empty() ? "-" : selected.requestId.c_str());
+        if (!selected.error.empty())
+        {
+          ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.55f, 0.5f, 1.0f));
+          ImGui::TextWrapped("Error: %s", selected.error.c_str());
+          ImGui::PopStyleColor();
+        }
+      }
+
+      ImGui::SeparatorText("Catalog");
+      if (ImGui::BeginTable("##mcp_catalog", 2, ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders))
+      {
+        ImGui::TableSetupColumn("Tools", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("Resources", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableHeadersRow();
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::BeginChild("##mcp_tools_catalog", ImVec2(0, 132.0f), false);
+        for (const Mcp::McpCatalogEntry &entry : status.toolCatalog)
+        {
+          ImGui::TextUnformatted(entry.name.c_str());
+          ImGui::TextDisabled("%s", entry.description.c_str());
+        }
+        ImGui::EndChild();
+        ImGui::TableSetColumnIndex(1);
+        ImGui::BeginChild("##mcp_resources_catalog", ImVec2(0, 132.0f), false);
+        for (const Mcp::McpCatalogEntry &entry : status.resourceCatalog)
+        {
+          ImGui::Text("%s", entry.name.c_str());
+          ImGui::TextDisabled("%s", entry.description.c_str());
+        }
+        ImGui::EndChild();
+        ImGui::EndTable();
+      }
+    }
+
+    void EditorLayer::DrawSettingsModal()
+    {
+      if (m_settingsOpen)
+        ImGui::OpenPopup("Editor Settings");
+
+      if (!ImGui::BeginPopupModal("Editor Settings", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        return;
+
+      ImGui::TextDisabled("Built-in MCP");
+      ImGui::Checkbox("Enable built-in MCP", &m_mcpSettingsDraft.enabled);
+      ImGui::Checkbox("Auto-start when editor opens", &m_mcpSettingsDraft.autoStart);
+
+      int port = m_mcpSettingsDraft.port;
+      if (ImGui::InputInt("Port", &port))
+        m_mcpSettingsDraft.port = std::max(1, std::min(65535, port));
+
+      ImGui::Text("Host: %s", Mcp::kDefaultMcpHost);
+      m_mcpSettingsDraft.host = Mcp::kDefaultMcpHost;
+
+      const std::string endpoint =
+          "http://" + m_mcpSettingsDraft.host + ":" + std::to_string(m_mcpSettingsDraft.port) + "/mcp";
+      ImGui::TextWrapped("Endpoint: %s", endpoint.c_str());
+
+      if (!m_mcpSettingsError.empty())
+      {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
+        ImGui::TextWrapped("%s", m_mcpSettingsError.c_str());
+        ImGui::PopStyleColor();
+      }
+
+      ImGui::Separator();
+      if (ImGui::Button("Apply", ImVec2(120.0f, 0.0f)))
+      {
+        std::string err;
+        if (m_mcpController.ApplySettings(m_mcpSettingsDraft, &err))
+        {
+          m_mcpSettingsDraft = m_mcpController.GetSettings();
+          m_mcpSettingsError.clear();
+          m_settingsOpen = false;
+          ImGui::CloseCurrentPopup();
+        }
+        else
+        {
+          m_mcpSettingsError = err;
+        }
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f)))
+      {
+        m_settingsOpen = false;
+        m_mcpSettingsDraft = m_mcpController.GetSettings();
+        m_mcpSettingsError.clear();
+        ImGui::CloseCurrentPopup();
+      }
+
+      ImGui::EndPopup();
+    }
+
+    void EditorLayer::DrawViewGimbal(const Camera &cam)
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const EditorViewGimbalMetrics &metrics = GetEditorViewGimbalMetrics();
+      const bool supportsWireframeOverlay = Renderer::GetBackendCapabilities().supportsWireframeOverlay;
+      if (!supportsWireframeOverlay)
+        m_wireframeMode = false;
+      const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+      const EditorViewGimbalLayout layout =
+          BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
+      const float wx = layout.gimbalRect.minX;
+      const float wy = layout.gimbalRect.minY;
+      const ImVec2 viewportPos = ImGui::GetWindowPos();
+      const ImVec2 btnLocalPos(layout.wireButtonRect.minX - viewportPos.x,
+                               layout.wireButtonRect.minY - viewportPos.y);
+      const ImVec2 gimbalLocalPos(layout.gimbalRect.minX - viewportPos.x,
+                                  layout.gimbalRect.minY - viewportPos.y);
+      ImDrawList *dl = ImGui::GetWindowDrawList();
+
+      // Wireframe toggle button — top-aligned near the gimbal, centered inside its own framed box.
+      dl->AddRectFilled(ImVec2(layout.wireButtonRect.minX, layout.wireButtonRect.minY),
+                        ImVec2(layout.wireButtonRect.maxX, layout.wireButtonRect.maxY),
+                        IM_COL32(95, 95, 95, 220),
+                        0.0f);
+      const float btnPad = (metrics.buttonFrameSize - metrics.buttonSize) * 0.5f;
+      ImGui::SetCursorPos(ImVec2(btnLocalPos.x + btnPad, btnLocalPos.y + btnPad));
+      if (m_wireframeMode)
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.55f, 0.15f, 0.90f));
+      else
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.18f, 0.22f, 0.30f, 0.80f));
+      if (!supportsWireframeOverlay)
+        ImGui::BeginDisabled();
+      if (ImGui::Button("##wire_btn_toggle", ImVec2(metrics.buttonSize, metrics.buttonSize)))
+        m_wireframeMode = !m_wireframeMode;
+      if (!supportsWireframeOverlay)
+        ImGui::EndDisabled();
+      ImGui::PopStyleColor();
+      dl->AddText(ImVec2(layout.wireButtonRect.minX + metrics.titleOffsetX,
+                         layout.wireButtonRect.minY + metrics.titleOffsetY),
+                  IM_COL32(230, 235, 245, 255),
+                  "[W]");
+      if (ImGui::IsItemHovered())
+      {
+        if (supportsWireframeOverlay)
+          ImGui::SetTooltip("Toggle Wireframe");
+        else
+          ImGui::SetTooltip("Wireframe overlay is unavailable on the active render backend");
+      }
+
+      m_viewGizmoPickRect.valid = true;
+      m_viewGizmoPickRect.minX = layout.pickRect.minX;
+      m_viewGizmoPickRect.minY = layout.pickRect.minY;
+      m_viewGizmoPickRect.maxX = layout.pickRect.maxX;
+      m_viewGizmoPickRect.maxY = layout.pickRect.maxY;
+
+      dl->AddRectFilled(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
+                        ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
+                        IM_COL32(18, 18, 20, 200),
+                        0.0f);
+      dl->AddRect(ImVec2(layout.gimbalRect.minX, layout.gimbalRect.minY),
+                  ImVec2(layout.gimbalRect.maxX, layout.gimbalRect.maxY),
+                  IM_COL32(90, 90, 90, 255),
+                  0.0f,
+                  0,
+                  1.0f);
+      dl->AddText(ImVec2(wx + metrics.titleOffsetX, wy + metrics.titleOffsetY),
+                  IM_COL32(240, 240, 240, 255),
+                  "View");
+
+      const int idx = PrimaryIdx();
+
+      const float hitRegionWidth =
+          layout.gimbalRect.maxX - layout.gimbalRect.minX - 2.0f * metrics.contentOffsetX;
+      ImGui::SetCursorPos(ImVec2(gimbalLocalPos.x + metrics.contentOffsetX,
+                                 gimbalLocalPos.y + metrics.contentOffsetY));
+      ImGui::InvisibleButton("##view_gimbal_hit", ImVec2(hitRegionWidth, metrics.hitRegionHeight));
+      const ImVec2 hitMin = ImGui::GetItemRectMin();
+      const ImVec2 hitMax = ImGui::GetItemRectMax();
+      const ImVec2 center = ImVec2((hitMin.x + hitMax.x) * 0.5f, (hitMin.y + hitMax.y) * 0.5f + 3.0f);
+      const bool canvasHovered = ImGui::IsItemHovered();
+      const bool canvasClicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
+
+      constexpr float kShaftPx = 36.0f;
+      constexpr float kHitPx = 12.0f;
+      constexpr float kHitPxSq = kHitPx * kHitPx;
+
+      struct AxisDraw
+      {
+        ViewSnap posSnap;
+        ViewSnap negSnap;
+        Vec3 worldPlus;
+        ImU32 col;
+        const char *label;
+      };
+      static const AxisDraw kAxes[] = {
+          {ViewSnap::Right, ViewSnap::Left, {1.0f, 0.0f, 0.0f}, IM_COL32(220, 72, 72, 255), "X"},
+          {ViewSnap::Top, ViewSnap::Bottom, {0.0f, 1.0f, 0.0f}, IM_COL32(88, 200, 96, 255), "Y"},
+          {ViewSnap::Front, ViewSnap::Back, {0.0f, 0.0f, 1.0f}, IM_COL32(82, 148, 255, 255), "Z"},
+      };
+
+      // Pre-compute screen directions and view-space depth once per frame.
+      // Shared by hover and draw loops — no redundant WorldAxisToScreenDir calls.
+      struct AxisCache
+      {
+        float dx, dy; // normalised screen direction of the +axis
+        float viewZ;  // view-space Z (positive = toward camera) for depth sort
+        int origIdx;
+      };
+      AxisCache cache[3];
+      for (int i = 0; i < 3; i++)
+      {
+        float vz = 0.f;
+        WorldAxisToScreenDir(cam, kAxes[i].worldPlus, &cache[i].dx, &cache[i].dy, &vz);
+        cache[i].viewZ = vz;
+        cache[i].origIdx = i;
+      }
+
+      ViewSnap hoverSnap = ViewSnap::None;
+
+      if (canvasHovered)
+      {
+        const ImVec2 mouse = io.MousePos;
+        float bestD = kHitPxSq; // was kHitPxSq * 4.f — that doubled the effective hit radius
+        const float cx = center.x, cy = center.y;
+        for (int i = 0; i < 3; i++)
+        {
+          const AxisDraw &ad = kAxes[cache[i].origIdx];
+          const float px1 = cx + cache[i].dx * kShaftPx;
+          const float py1 = cy + cache[i].dy * kShaftPx;
+          const float px2 = cx - cache[i].dx * kShaftPx;
+          const float py2 = cy - cache[i].dy * kShaftPx;
+          const float d1 = DistSqPointSegment2D(mouse.x, mouse.y, cx, cy, px1, py1);
+          const float d2 = DistSqPointSegment2D(mouse.x, mouse.y, cx, cy, px2, py2);
+          if (d1 < bestD)
+          {
+            bestD = d1;
+            hoverSnap = ad.posSnap;
+          }
+          if (d2 < bestD)
+          {
+            bestD = d2;
+            hoverSnap = ad.negSnap;
+          }
+        }
+      }
+
+      // Sort ascending by view-space Z so background axes draw first (painter's algorithm).
+      std::sort(std::begin(cache), std::end(cache),
+                [](const AxisCache &a, const AxisCache &b)
+                { return a.viewZ < b.viewZ; });
+
+      const float fs = ImGui::GetFontSize();
+      const float cx = center.x, cy = center.y;
+      for (int si = 0; si < 3; si++)
+      {
+        const AxisCache &ac = cache[si];
+        const AxisDraw &ad = kAxes[ac.origIdx];
+        const float px1 = cx + ac.dx * kShaftPx;
+        const float py1 = cy + ac.dy * kShaftPx;
+        const float px2 = cx - ac.dx * kShaftPx;
+        const float py2 = cy - ac.dy * kShaftPx;
+
+        const bool hlPos = (hoverSnap == ad.posSnap);
+        const bool hlNeg = (hoverSnap == ad.negSnap);
+        ImU32 cPos = ad.col;
+        ImU32 cNeg = ad.col;
+        switch (ad.posSnap)
+        {
+        case ViewSnap::Right:
+          cNeg = IM_COL32(150, 48, 48, 255);
+          break;
+        case ViewSnap::Top:
+          cNeg = IM_COL32(58, 145, 64, 255);
+          break;
+        case ViewSnap::Front:
+          cNeg = IM_COL32(52, 100, 190, 255);
+          break;
+        default:
+          break;
+        }
+        if (hlPos)
+          cPos = IM_COL32(255, 255, 200, 255);
+        if (hlNeg)
+          cNeg = IM_COL32(255, 255, 200, 255);
+
+        dl->AddLine(center, ImVec2(px1, py1), cPos, hlPos ? 4.0f : 3.0f);
+        dl->AddLine(center, ImVec2(px2, py2), cNeg, hlNeg ? 4.0f : 2.5f);
+        dl->AddCircleFilled(ImVec2(px1, py1), hlPos ? 5.0f : 4.0f, cPos, 10);
+        dl->AddCircleFilled(ImVec2(px2, py2), hlNeg ? 4.5f : 3.5f, cNeg, 10);
+
+        // Offset label along the axis direction so it doesn't overlap the circle
+        // regardless of which way the axis is pointing on screen.
+        const float tDist = (hlPos ? 5.0f : 4.0f) + 3.0f;
+        dl->AddText(ImVec2(px1 + ac.dx * tDist - fs * 0.3f,
+                           py1 + ac.dy * tDist - fs * 0.5f),
+                    cPos, ad.label);
+      }
+
+      if (canvasClicked && hoverSnap != ViewSnap::None)
+        m_pendingViewSnap = hoverSnap;
+
+      if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
+        dl->AddText(ImVec2(wx + metrics.titleOffsetX,
+                           layout.gimbalRect.maxY - metrics.pivotTextOffsetY),
+                    IM_COL32(150, 150, 150, 255),
+                    "Pivot: origin");
+    }
+
+    // ---- Hierarchy panel ---------------------------------------------------------
+
+    // Short icon prefix shown before each object in the hierarchy tree.
+    static const char *ObjectTypeIcon(SceneObjectType type)
+    {
+      switch (type)
+      {
+      case SceneObjectType::Prop:
+        return "[>]";
+      case SceneObjectType::Light:
+        return "[*]";
+      case SceneObjectType::Camera:
+        return "[C]";
+      default:
+        return "[=]"; // Panel / board
+      }
+    }
+
+    void EditorLayer::DrawObjectList()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
+      const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
+      const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
+      const float hierarchyHeight = std::max(220.0f, (workBottom - kEditorToolbarH) * kHierarchySectionRatio);
+      ImGui::SetNextWindowPos(ImVec2(0.0f, kEditorToolbarH), ImGuiCond_Always);
+      ImGui::SetNextWindowSize(ImVec2(leftDockW, hierarchyHeight), ImGuiCond_Always);
+      ImGui::Begin(kEditorHierarchyWindow, nullptr, kMainPanelWindowFlags);
+
+      // Search bar (applies to primary scene)
+      char searchBuf[256] = {};
+      std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_objectSearchQuery.c_str());
+      ImGui::PushItemFlag(ImGuiItemFlags_NoTabStop, true);
+      if (ImGui::InputTextWithHint("##object_search", "Search objects...", searchBuf, sizeof(searchBuf)))
+        m_objectSearchQuery = searchBuf;
+      ImGui::PopItemFlag();
+      ImGui::Separator();
+
+      // Primary scene
+      DrawSceneHeader(m_document, true, -1);
+
+      // Right-click empty space → add object to primary scene
+      if (ImGui::BeginPopupContextWindow("obj_ctx_empty",
+                                         ImGuiPopupFlags_MouseButtonRight | ImGuiPopupFlags_NoOpenOverItems))
+      {
+        if (ImGui::BeginMenu("Add"))
+        {
           if (ImGui::MenuItem("Panel"))
-            AddObject(SceneObjectType::Panel, obj.id);
+            AddObject(SceneObjectType::Panel);
           if (ImGui::MenuItem("Prop"))
-            AddObject(SceneObjectType::Prop, obj.id);
+            AddObject(SceneObjectType::Prop);
           if (ImGui::MenuItem("Light"))
-            AddObject(SceneObjectType::Light, obj.id);
+            AddObject(SceneObjectType::Light);
           if (ImGui::MenuItem("Camera"))
-            AddObject(SceneObjectType::Camera, obj.id);
+            AddObject(SceneObjectType::Camera);
           ImGui::EndMenu();
-        }
-        ImGui::Separator();
-        if (ImGui::MenuItem("Rename..."))
-          OpenRenameObjectModal(i);
-        if (ImGui::MenuItem("Duplicate")) {
-          m_selectedIndices = {i};
-          DuplicatePrimarySelection();
-        }
-        if (ImGui::MenuItem("Delete")) {
-          m_selectedIndices = {i};
-          RequestDeleteSelectedObjects();
         }
         ImGui::EndPopup();
       }
 
-      ++shownObjectCount;
-      ImGui::PopID();
-    }
-
-    if (shownObjectCount == 0 && !doc.objects.empty()) {
-      ImGui::TextDisabled("No objects match '%s'", query.c_str());
-      if (ImGui::Button("Clear Search"))
-        m_objectSearchQuery.clear();
-    }
-  } else {
-    // Tree view
-    std::unordered_map<std::string, int> idToIndex;
-    idToIndex.reserve(doc.objects.size());
-    for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
-      idToIndex[doc.objects[static_cast<size_t>(i)].id] = i;
-
-    std::vector<std::vector<int>> children(doc.objects.size());
-    std::vector<int> roots;
-    roots.reserve(doc.objects.size());
-    for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i) {
-      const SceneObject& obj = doc.objects[static_cast<size_t>(i)];
-      int p = -1;
-      const auto pIt = idToIndex.find(GetParentId(obj));
-      if (pIt != idToIndex.end())
-        p = pIt->second;
-      if (p >= 0 && p != i)
-        children[static_cast<size_t>(p)].push_back(i);
-      else
-        roots.push_back(i);
-    }
-
-    std::function<void(int)> drawNode;
-    drawNode = [&](int idx) {
-      if (idx < 0 || idx >= static_cast<int>(doc.objects.size()))
-        return;
-      SceneObject& obj = doc.objects[static_cast<size_t>(idx)];
-      ++shownObjectCount;
-
-      ImGui::PushID(idx);
-      const bool hasChildren = !children[static_cast<size_t>(idx)].empty();
-      ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth;
-      if (!hasChildren)
-        flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
-      if (isPrimary && IsSelected(idx))
-        flags |= ImGuiTreeNodeFlags_Selected;
-
-      const char* icon = ObjectTypeIcon(obj.type);
-      std::string nodeLabel = std::string(icon) + " " + obj.id;
-      if (!obj.assetId.empty())
-        nodeLabel += "  [" + obj.assetId + "]";
-
-      const bool open = ImGui::TreeNodeEx("##obj_tree", flags, "%s", nodeLabel.c_str());
-
-      if (isPrimary && ImGui::IsItemClicked()) {
-        auto& treeIo = ImGui::GetIO();
-        if (treeIo.KeyShift && m_lastClickedHierarchyIdx >= 0) {
-          const int lo = std::min(m_lastClickedHierarchyIdx, idx);
-          const int hi = std::max(m_lastClickedHierarchyIdx, idx);
-          m_selectedIndices.clear();
-          for (int ri = lo; ri <= hi; ++ri)
-            m_selectedIndices.push_back(ri);
-        } else if (treeIo.KeyCtrl || treeIo.KeySuper) {
-          ToggleSelect(idx);
-          m_lastClickedHierarchyIdx = idx;
-        } else {
-          m_selectedIndices = {idx};
-          m_lastClickedHierarchyIdx = idx;
-        }
+      if (m_renameObjectOpen)
+      {
+        ImGui::OpenPopup("Rename Object");
+        m_renameObjectOpen = false;
       }
-
-      if (isPrimary) {
-        if (ImGui::BeginDragDropSource()) {
-          ImGui::SetDragDropPayload("SCENE_OBJECT_INDEX", &idx, sizeof(int));
-          ImGui::TextUnformatted(obj.id.c_str());
-          ImGui::EndDragDropSource();
+      if (ImGui::BeginPopupModal("Rename Object", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+      {
+        char nameBuf[256] = {};
+        std::snprintf(nameBuf, sizeof(nameBuf), "%s", m_renameObjectDraft.c_str());
+        if (ImGui::InputText("New ID", nameBuf, sizeof(nameBuf), ImGuiInputTextFlags_EnterReturnsTrue))
+        {
+          m_renameObjectDraft = nameBuf;
         }
-        if (ImGui::BeginDragDropTarget()) {
-          if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("SCENE_OBJECT_INDEX")) {
-            if (payload->DataSize == sizeof(int)) {
-              const int src = *static_cast<const int*>(payload->Data);
-              const bool valid = src >= 0 && src < static_cast<int>(doc.objects.size()) &&
-                                 src != idx && !IsDescendantOf(doc, idx, src);
-              if (valid) {
-                doc.objects[static_cast<size_t>(src)].props["parentId"] = obj.id;
-                doc.dirty = true;
+        else if (std::strncmp(nameBuf, m_renameObjectDraft.c_str(), sizeof(nameBuf)) != 0)
+        {
+          m_renameObjectDraft = nameBuf;
+        }
+
+        if (!m_renameObjectError.empty())
+          ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "%s", m_renameObjectError.c_str());
+
+        bool applyRequested = false;
+        if (ImGui::Button("Apply"))
+          applyRequested = true;
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel"))
+        {
+          m_renameObjectError.clear();
+          m_renameObjectIndex = -1;
+          ImGui::CloseCurrentPopup();
+        }
+
+        if (applyRequested)
+        {
+          if (m_renameObjectIndex < 0 || m_renameObjectIndex >= static_cast<int>(m_document.objects.size()))
+          {
+            m_renameObjectError = "Selected object is no longer valid.";
+          }
+          else if (m_renameObjectDraft.empty())
+          {
+            m_renameObjectError = "ID cannot be empty.";
+          }
+          else
+          {
+            const int existingIdx = FindObjectIndexById(m_document, m_renameObjectDraft);
+            if (existingIdx >= 0 && existingIdx != m_renameObjectIndex)
+            {
+              m_renameObjectError = "ID already exists.";
+            }
+            else
+            {
+              SceneObject &target = m_document.objects[static_cast<size_t>(m_renameObjectIndex)];
+              const std::string oldId = target.id;
+              const std::string newId = m_renameObjectDraft;
+              if (oldId != newId)
+              {
+                target.id = newId;
+                for (auto &other : m_document.objects)
+                {
+                  auto p = other.props.find("parentId");
+                  if (p != other.props.end() && p->second == oldId)
+                    p->second = newId;
+                  auto f = other.props.find("followTargetId");
+                  if (f != other.props.end() && f->second == oldId)
+                    f->second = newId;
+                }
+                m_document.dirty = true;
               }
+              m_renameObjectError.clear();
+              m_renameObjectIndex = -1;
+              ImGui::CloseCurrentPopup();
             }
           }
-          if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_ID")) {
-            const std::string assetId(static_cast<const char*>(payload->Data));
-            std::string createError;
-            if (!CreateObjectFromAsset(assetId, obj.id, nullptr, nullptr, nullptr, &createError))
-              LOG_WARN("[Editor] Hierarchy child asset drop failed: %s", createError.c_str());
-          }
-          ImGui::EndDragDropTarget();
         }
 
-        if (ImGui::BeginPopupContextItem("obj_ctx")) {
-          if (ImGui::BeginMenu("Add")) {
+        ImGui::EndPopup();
+      }
+
+      ImGui::End();
+    }
+
+    // Renders a Unity-style collapsible scene header, then the objects tree under it.
+    void EditorLayer::DrawSceneHeader(SceneDocument &doc, bool isPrimary, int additionalIndex)
+    {
+      // Build label: sceneName + dirty indicator for primary scene
+      std::string label = doc.sceneName.empty() ? "Scene" : doc.sceneName;
+      if (isPrimary && doc.dirty)
+        label += " *";
+
+      // Tint the primary scene header slightly to distinguish it
+      if (isPrimary)
+        ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0.18f, 0.33f, 0.52f, 1.0f));
+
+      ImGui::SetNextItemOpen(true, ImGuiCond_Once);
+      char nodeId[32];
+      std::snprintf(nodeId, sizeof(nodeId), isPrimary ? "##scene_primary" : "##scene_%d", additionalIndex);
+      const bool open = ImGui::TreeNodeEx(
+          nodeId,
+          ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth |
+              ImGuiTreeNodeFlags_DefaultOpen,
+          "%s", label.c_str());
+
+      if (isPrimary)
+        ImGui::PopStyleColor();
+
+      // Scene header context menu
+      char ctxId[40];
+      std::snprintf(ctxId, sizeof(ctxId), isPrimary ? "scene_hdr_ctx_p" : "scene_hdr_ctx_%d",
+                    additionalIndex);
+      if (ImGui::BeginPopupContextItem(ctxId))
+      {
+        if (isPrimary)
+        {
+          if (ImGui::BeginMenu("Add"))
+          {
             if (ImGui::MenuItem("Panel"))
-              AddObject(SceneObjectType::Panel, obj.id);
+              AddObject(SceneObjectType::Panel);
             if (ImGui::MenuItem("Prop"))
-              AddObject(SceneObjectType::Prop, obj.id);
+              AddObject(SceneObjectType::Prop);
             if (ImGui::MenuItem("Light"))
-              AddObject(SceneObjectType::Light, obj.id);
+              AddObject(SceneObjectType::Light);
             if (ImGui::MenuItem("Camera"))
-              AddObject(SceneObjectType::Camera, obj.id);
+              AddObject(SceneObjectType::Camera);
             ImGui::EndMenu();
           }
           ImGui::Separator();
-          if (ImGui::MenuItem("Rename..."))
-            OpenRenameObjectModal(idx);
-          if (ImGui::MenuItem("Duplicate")) {
-            m_selectedIndices = {idx};
-            DuplicatePrimarySelection();
-          }
-          if (ImGui::MenuItem("Delete")) {
-            m_selectedIndices = {idx};
-            RequestDeleteSelectedObjects();
-          }
-          ImGui::Separator();
-          const bool hasParent = !GetParentId(obj).empty();
-          if (ImGui::MenuItem("Unparent", nullptr, false, hasParent)) {
-            obj.props.erase("parentId");
-            doc.dirty = true;
-          }
-          ImGui::EndPopup();
+          std::string saveErr;
+          if (ImGui::MenuItem("Save Scene"))
+            SaveDocument(&saveErr);
         }
+        else
+        {
+          std::string saveErr;
+          if (ImGui::MenuItem("Save Scene"))
+            SaveAdditionalScene(additionalIndex, &saveErr);
+          ImGui::Separator();
+          if (ImGui::MenuItem("Close Scene"))
+            CloseAdditionalScene(additionalIndex);
+        }
+        ImGui::EndPopup();
       }
 
-      if (open && hasChildren) {
-        for (int childIdx : children[static_cast<size_t>(idx)])
-          drawNode(childIdx);
-        ImGui::TreePop();
-      }
-
-      ImGui::PopID();
-    };
-
-    for (int rootIdx : roots)
-      drawNode(rootIdx);
-
-    if (doc.objects.empty()) {
-      ImGui::TextDisabled("No objects in scene");
-      if (isPrimary)
-        ImGui::TextDisabled("Tip: right-click or use Assets panel.");
-    }
-
-    if (isPrimary) {
-      const ImVec2 avail = ImGui::GetContentRegionAvail();
-      ImGui::InvisibleButton("##hierarchy_root_asset_drop",
-                             ImVec2(std::max(avail.x, 1.0f), 24.0f));
-      if (ImGui::BeginDragDropTarget()) {
-        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_ID")) {
-          const std::string assetId(static_cast<const char*>(payload->Data));
+      // Drop onto scene header → unparent the dragged object (make it a root)
+      if (isPrimary && ImGui::BeginDragDropTarget())
+      {
+        if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("SCENE_OBJECT_INDEX"))
+        {
+          if (payload->DataSize == sizeof(int))
+          {
+            const int src = *static_cast<const int *>(payload->Data);
+            if (src >= 0 && src < static_cast<int>(doc.objects.size()))
+            {
+              doc.objects[static_cast<size_t>(src)].props.erase("parentId");
+              doc.dirty = true;
+            }
+          }
+        }
+        if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("ASSET_ID"))
+        {
+          const std::string assetId(static_cast<const char *>(payload->Data));
           std::string createError;
           if (!CreateObjectFromAsset(assetId, std::string(), nullptr, nullptr, nullptr, &createError))
             LOG_WARN("[Editor] Hierarchy root asset drop failed: %s", createError.c_str());
         }
         ImGui::EndDragDropTarget();
       }
+
+      if (open)
+      {
+        DrawObjectsTree(doc, isPrimary);
+        ImGui::TreePop();
+      }
     }
 
-    // Runtime entities: ECS entities that have no corresponding editor object (primary only)
-    if (isPrimary && m_liveRegistry) {
-      std::unordered_set<Entity> docEntities;
-      for (const auto& obj : doc.objects) {
-        const auto it = obj.props.find("_eid");
-        if (it != obj.props.end()) {
-          try {
-            docEntities.insert(static_cast<Entity>(std::stoul(it->second)));
-          } catch (...) {}
-        }
-      }
+    // Renders the tree of objects inside a scene, plus runtime entities for the primary scene.
+    void EditorLayer::DrawObjectsTree(SceneDocument &doc, bool isPrimary)
+    {
+      // Search filter applies only to the primary scene
+      const std::string &query = isPrimary ? m_objectSearchQuery : "";
 
-      std::vector<Entity> runtimeEntities;
-      for (Entity e : m_liveRegistry->GetEntities<TransformComponent>()) {
-        if (docEntities.find(e) == docEntities.end())
-          runtimeEntities.push_back(e);
-      }
+      int shownObjectCount = 0;
 
-      if (!runtimeEntities.empty()) {
-        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.65f, 0.65f, 0.65f, 1.0f));
-        if (ImGui::TreeNodeEx("##runtime_entities",
-                              ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth,
-                              "[rt] Runtime (%zu)", runtimeEntities.size())) {
-          for (Entity e : runtimeEntities) {
-            ImGui::PushID(static_cast<int>(e));
-            ImGui::TreeNodeEx(
-                "##rt_ent",
-                ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen |
-                    ImGuiTreeNodeFlags_SpanAvailWidth,
-                "[>] Entity %u", static_cast<unsigned>(e));
+      if (!query.empty())
+      {
+        // Flat filtered list (search mode, primary scene only)
+        for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
+        {
+          ImGui::PushID(i);
+          auto &obj = doc.objects[static_cast<size_t>(i)];
+          if (!ObjectMatchesQuickOpenQuery(obj, query))
+          {
             ImGui::PopID();
+            continue;
           }
-          ImGui::TreePop();
+          const char *icon = ObjectTypeIcon(obj.type);
+          const char *typeName = ObjectTypeLabel(obj.type);
+
+          char selectableId[32];
+          std::snprintf(selectableId, sizeof(selectableId), "##obj_%d", i);
+
+          const float lineH = ImGui::GetTextLineHeight();
+          const float rowH = obj.assetId.empty() ? lineH : lineH * 2.0f + 2.0f;
+
+          if (ImGui::Selectable(selectableId, IsSelected(i), 0, ImVec2(0, rowH)))
+          {
+            auto &selIo = ImGui::GetIO();
+            if (selIo.KeyShift && m_lastClickedHierarchyIdx >= 0)
+            {
+              const int lo = std::min(m_lastClickedHierarchyIdx, i);
+              const int hi = std::max(m_lastClickedHierarchyIdx, i);
+              m_selectedIndices.clear();
+              for (int ri = lo; ri <= hi; ++ri)
+                m_selectedIndices.push_back(ri);
+            }
+            else if (selIo.KeyCtrl || selIo.KeySuper)
+            {
+              ToggleSelect(i);
+              m_lastClickedHierarchyIdx = i;
+            }
+            else
+            {
+              m_selectedIndices = {i};
+              m_lastClickedHierarchyIdx = i;
+            }
+          }
+          ImGui::SameLine();
+          {
+            const ImVec2 pos = ImGui::GetCursorScreenPos();
+            ImGui::BeginGroup();
+            ImGui::TextDisabled("%s %s", icon, typeName);
+            ImGui::SameLine(0.0f, 4.0f);
+            ImGui::Text("%s", obj.id.c_str());
+            if (!obj.assetId.empty())
+            {
+              ImGui::SetCursorScreenPos(ImVec2(pos.x, pos.y + lineH + 2.0f));
+              ImGui::TextDisabled("  > %s", obj.assetId.c_str());
+            }
+            ImGui::EndGroup();
+          }
+
+          if (isPrimary && ImGui::BeginDragDropTarget())
+          {
+            if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("ASSET_ID"))
+            {
+              const std::string assetId(static_cast<const char *>(payload->Data));
+              std::string createError;
+              if (!CreateObjectFromAsset(assetId, obj.id, nullptr, nullptr, nullptr, &createError))
+                LOG_WARN("[Editor] Hierarchy child asset drop failed: %s", createError.c_str());
+            }
+            ImGui::EndDragDropTarget();
+          }
+
+          if (ImGui::BeginPopupContextItem("obj_ctx"))
+          {
+            if (ImGui::BeginMenu("Add"))
+            {
+              if (ImGui::MenuItem("Panel"))
+                AddObject(SceneObjectType::Panel, obj.id);
+              if (ImGui::MenuItem("Prop"))
+                AddObject(SceneObjectType::Prop, obj.id);
+              if (ImGui::MenuItem("Light"))
+                AddObject(SceneObjectType::Light, obj.id);
+              if (ImGui::MenuItem("Camera"))
+                AddObject(SceneObjectType::Camera, obj.id);
+              ImGui::EndMenu();
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem("Rename..."))
+              OpenRenameObjectModal(i);
+            if (ImGui::MenuItem("Duplicate"))
+            {
+              m_selectedIndices = {i};
+              DuplicatePrimarySelection();
+            }
+            if (ImGui::MenuItem("Delete"))
+            {
+              m_selectedIndices = {i};
+              RequestDeleteSelectedObjects();
+            }
+            ImGui::EndPopup();
+          }
+
+          ++shownObjectCount;
+          ImGui::PopID();
         }
-        ImGui::PopStyleColor();
+
+        if (shownObjectCount == 0 && !doc.objects.empty())
+        {
+          ImGui::TextDisabled("No objects match '%s'", query.c_str());
+          if (ImGui::Button("Clear Search"))
+            m_objectSearchQuery.clear();
+        }
+      }
+      else
+      {
+        // Tree view
+        std::unordered_map<std::string, int> idToIndex;
+        idToIndex.reserve(doc.objects.size());
+        for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
+          idToIndex[doc.objects[static_cast<size_t>(i)].id] = i;
+
+        std::vector<std::vector<int>> children(doc.objects.size());
+        std::vector<int> roots;
+        roots.reserve(doc.objects.size());
+        for (int i = 0; i < static_cast<int>(doc.objects.size()); ++i)
+        {
+          const SceneObject &obj = doc.objects[static_cast<size_t>(i)];
+          int p = -1;
+          const auto pIt = idToIndex.find(GetParentId(obj));
+          if (pIt != idToIndex.end())
+            p = pIt->second;
+          if (p >= 0 && p != i)
+            children[static_cast<size_t>(p)].push_back(i);
+          else
+            roots.push_back(i);
+        }
+
+        std::function<void(int)> drawNode;
+        drawNode = [&](int idx)
+        {
+          if (idx < 0 || idx >= static_cast<int>(doc.objects.size()))
+            return;
+          SceneObject &obj = doc.objects[static_cast<size_t>(idx)];
+          ++shownObjectCount;
+
+          ImGui::PushID(idx);
+          const bool hasChildren = !children[static_cast<size_t>(idx)].empty();
+          ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth;
+          if (!hasChildren)
+            flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+          if (isPrimary && IsSelected(idx))
+            flags |= ImGuiTreeNodeFlags_Selected;
+
+          const char *icon = ObjectTypeIcon(obj.type);
+          std::string nodeLabel = std::string(icon) + " " + obj.id;
+          if (!obj.assetId.empty())
+            nodeLabel += "  [" + obj.assetId + "]";
+
+          const bool open = ImGui::TreeNodeEx("##obj_tree", flags, "%s", nodeLabel.c_str());
+
+          if (isPrimary && ImGui::IsItemClicked())
+          {
+            auto &treeIo = ImGui::GetIO();
+            if (treeIo.KeyShift && m_lastClickedHierarchyIdx >= 0)
+            {
+              const int lo = std::min(m_lastClickedHierarchyIdx, idx);
+              const int hi = std::max(m_lastClickedHierarchyIdx, idx);
+              m_selectedIndices.clear();
+              for (int ri = lo; ri <= hi; ++ri)
+                m_selectedIndices.push_back(ri);
+            }
+            else if (treeIo.KeyCtrl || treeIo.KeySuper)
+            {
+              ToggleSelect(idx);
+              m_lastClickedHierarchyIdx = idx;
+            }
+            else
+            {
+              m_selectedIndices = {idx};
+              m_lastClickedHierarchyIdx = idx;
+            }
+          }
+
+          if (isPrimary)
+          {
+            if (ImGui::BeginDragDropSource())
+            {
+              ImGui::SetDragDropPayload("SCENE_OBJECT_INDEX", &idx, sizeof(int));
+              ImGui::TextUnformatted(obj.id.c_str());
+              ImGui::EndDragDropSource();
+            }
+            if (ImGui::BeginDragDropTarget())
+            {
+              if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("SCENE_OBJECT_INDEX"))
+              {
+                if (payload->DataSize == sizeof(int))
+                {
+                  const int src = *static_cast<const int *>(payload->Data);
+                  const bool valid = src >= 0 && src < static_cast<int>(doc.objects.size()) &&
+                                     src != idx && !IsDescendantOf(doc, idx, src);
+                  if (valid)
+                  {
+                    doc.objects[static_cast<size_t>(src)].props["parentId"] = obj.id;
+                    doc.dirty = true;
+                  }
+                }
+              }
+              if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("ASSET_ID"))
+              {
+                const std::string assetId(static_cast<const char *>(payload->Data));
+                std::string createError;
+                if (!CreateObjectFromAsset(assetId, obj.id, nullptr, nullptr, nullptr, &createError))
+                  LOG_WARN("[Editor] Hierarchy child asset drop failed: %s", createError.c_str());
+              }
+              ImGui::EndDragDropTarget();
+            }
+
+            if (ImGui::BeginPopupContextItem("obj_ctx"))
+            {
+              if (ImGui::BeginMenu("Add"))
+              {
+                if (ImGui::MenuItem("Panel"))
+                  AddObject(SceneObjectType::Panel, obj.id);
+                if (ImGui::MenuItem("Prop"))
+                  AddObject(SceneObjectType::Prop, obj.id);
+                if (ImGui::MenuItem("Light"))
+                  AddObject(SceneObjectType::Light, obj.id);
+                if (ImGui::MenuItem("Camera"))
+                  AddObject(SceneObjectType::Camera, obj.id);
+                ImGui::EndMenu();
+              }
+              ImGui::Separator();
+              if (ImGui::MenuItem("Rename..."))
+                OpenRenameObjectModal(idx);
+              if (ImGui::MenuItem("Duplicate"))
+              {
+                m_selectedIndices = {idx};
+                DuplicatePrimarySelection();
+              }
+              if (ImGui::MenuItem("Delete"))
+              {
+                m_selectedIndices = {idx};
+                RequestDeleteSelectedObjects();
+              }
+              ImGui::Separator();
+              const bool hasParent = !GetParentId(obj).empty();
+              if (ImGui::MenuItem("Unparent", nullptr, false, hasParent))
+              {
+                obj.props.erase("parentId");
+                doc.dirty = true;
+              }
+              ImGui::EndPopup();
+            }
+          }
+
+          if (open && hasChildren)
+          {
+            for (int childIdx : children[static_cast<size_t>(idx)])
+              drawNode(childIdx);
+            ImGui::TreePop();
+          }
+
+          ImGui::PopID();
+        };
+
+        for (int rootIdx : roots)
+          drawNode(rootIdx);
+
+        if (doc.objects.empty())
+        {
+          ImGui::TextDisabled("No objects in scene");
+          if (isPrimary)
+            ImGui::TextDisabled("Tip: right-click or use Assets panel.");
+        }
+
+        if (isPrimary)
+        {
+          const ImVec2 avail = ImGui::GetContentRegionAvail();
+          ImGui::InvisibleButton("##hierarchy_root_asset_drop",
+                                 ImVec2(std::max(avail.x, 1.0f), 24.0f));
+          if (ImGui::BeginDragDropTarget())
+          {
+            if (const ImGuiPayload *payload = ImGui::AcceptDragDropPayload("ASSET_ID"))
+            {
+              const std::string assetId(static_cast<const char *>(payload->Data));
+              std::string createError;
+              if (!CreateObjectFromAsset(assetId, std::string(), nullptr, nullptr, nullptr, &createError))
+                LOG_WARN("[Editor] Hierarchy root asset drop failed: %s", createError.c_str());
+            }
+            ImGui::EndDragDropTarget();
+          }
+        }
+
+        // Runtime entities: ECS entities that have no corresponding editor object (primary only)
+        if (isPrimary && m_liveRegistry)
+        {
+          std::unordered_set<Entity> docEntities;
+          for (const auto &obj : doc.objects)
+          {
+            const auto it = obj.props.find("_eid");
+            if (it != obj.props.end())
+            {
+              try
+              {
+                docEntities.insert(static_cast<Entity>(std::stoul(it->second)));
+              }
+              catch (...)
+              {
+              }
+            }
+          }
+
+          std::vector<Entity> runtimeEntities;
+          for (Entity e : m_liveRegistry->GetEntities<TransformComponent>())
+          {
+            if (docEntities.find(e) == docEntities.end())
+              runtimeEntities.push_back(e);
+          }
+
+          if (!runtimeEntities.empty())
+          {
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.65f, 0.65f, 0.65f, 1.0f));
+            if (ImGui::TreeNodeEx("##runtime_entities",
+                                  ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth,
+                                  "[rt] Runtime (%zu)", runtimeEntities.size()))
+            {
+              for (Entity e : runtimeEntities)
+              {
+                ImGui::PushID(static_cast<int>(e));
+                ImGui::TreeNodeEx(
+                    "##rt_ent",
+                    ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen |
+                        ImGuiTreeNodeFlags_SpanAvailWidth,
+                    "[>] Entity %u", static_cast<unsigned>(e));
+                ImGui::PopID();
+              }
+              ImGui::TreePop();
+            }
+            ImGui::PopStyleColor();
+          }
+        }
       }
     }
-  }
-}
 
-// ---- Multi-scene helpers -----------------------------------------------------
+    // ---- Multi-scene helpers -----------------------------------------------------
 
-void EditorLayer::AddNewScene() {
-  SceneDocument newDoc;
-  newDoc.sceneId = "scene";
-  newDoc.sceneName = "Scene";
-  newDoc.dirty = true;
-  m_document = std::move(newDoc);
-  m_selectedIndices.clear();
-  m_selectedAssetId.clear();
-}
-
-void EditorLayer::OpenAdditionalSceneFile() {
-#ifdef _WIN32
-  char filePath[MAX_PATH] = {};
-  OPENFILENAMEA ofn = {};
-  ofn.lStructSize = sizeof(ofn);
-  ofn.hwndOwner = nullptr;
-  ofn.lpstrFilter = "Scene Files\0*.horo;*.json\0All Files\0*.*\0";
-  ofn.lpstrFile = filePath;
-  ofn.nMaxFile = MAX_PATH;
-  ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
-  if (GetOpenFileNameA(&ofn)) {
-    try {
-      SceneDocument doc = SceneSerializer::LoadFromFile(filePath);
-      ApplyLoadedDocument(std::move(doc), false);
-    } catch (const std::exception& e) {
-      LOG_ERROR("EditorLayer: failed to open scene '{}': {}", filePath, e.what());
+    void EditorLayer::AddNewScene()
+    {
+      SceneDocument newDoc;
+      newDoc.sceneId = "scene";
+      newDoc.sceneName = "Scene";
+      newDoc.dirty = true;
+      m_document = std::move(newDoc);
+      m_selectedIndices.clear();
+      m_selectedAssetId.clear();
     }
-  }
+
+    void EditorLayer::OpenAdditionalSceneFile()
+    {
+#ifdef _WIN32
+      char filePath[MAX_PATH] = {};
+      OPENFILENAMEA ofn = {};
+      ofn.lStructSize = sizeof(ofn);
+      ofn.hwndOwner = nullptr;
+      ofn.lpstrFilter = "Scene Files\0*.horo;*.json\0All Files\0*.*\0";
+      ofn.lpstrFile = filePath;
+      ofn.nMaxFile = MAX_PATH;
+      ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+      if (GetOpenFileNameA(&ofn))
+      {
+        try
+        {
+          SceneDocument doc = SceneSerializer::LoadFromFile(filePath);
+          ApplyLoadedDocument(std::move(doc), false);
+        }
+        catch (const std::exception &e)
+        {
+          LOG_ERROR("EditorLayer: failed to open scene '{}': {}", filePath, e.what());
+        }
+      }
 #endif
-}
+    }
 
-void EditorLayer::CloseAdditionalScene(int index) {
-  if (index < 0 || index >= static_cast<int>(m_additionalScenes.size()))
-    return;
-  m_additionalScenes.erase(m_additionalScenes.begin() + index);
-}
+    void EditorLayer::CloseAdditionalScene(int index)
+    {
+      if (index < 0 || index >= static_cast<int>(m_additionalScenes.size()))
+        return;
+      m_additionalScenes.erase(m_additionalScenes.begin() + index);
+    }
 
-bool EditorLayer::SaveAdditionalScene(int index, std::string* outError) {
-  if (index < 0 || index >= static_cast<int>(m_additionalScenes.size()))
-    return false;
-  SceneDocument& doc = m_additionalScenes[static_cast<size_t>(index)];
-  if (doc.filePath.empty()) {
-    if (outError)
-      *outError = "No file path — use Save As.";
-    return false;
-  }
-  try {
-    SceneSerializer::SaveToFile(doc, doc.filePath);
-    doc.dirty = false;
-    return true;
-  } catch (const std::exception& e) {
-    if (outError)
-      *outError = e.what();
-    return false;
-  }
-}
+    bool EditorLayer::SaveAdditionalScene(int index, std::string *outError)
+    {
+      if (index < 0 || index >= static_cast<int>(m_additionalScenes.size()))
+        return false;
+      SceneDocument &doc = m_additionalScenes[static_cast<size_t>(index)];
+      if (doc.filePath.empty())
+      {
+        if (outError)
+          *outError = "No file path — use Save As.";
+        return false;
+      }
+      try
+      {
+        SceneSerializer::SaveToFile(doc, doc.filePath);
+        doc.dirty = false;
+        return true;
+      }
+      catch (const std::exception &e)
+      {
+        if (outError)
+          *outError = e.what();
+        return false;
+      }
+    }
 
-void EditorLayer::DrawAssetsPanel() {
-  ImGuiIO& io = ImGui::GetIO();
-  const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
-  const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
-  const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
-  const float hierarchyHeight = std::max(220.0f, (workBottom - kEditorToolbarH) * kHierarchySectionRatio);
-  const float assetsTop = kEditorToolbarH + hierarchyHeight + 4.0f;
-  ImGui::SetNextWindowPos(ImVec2(0.0f, assetsTop), ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2(leftDockW, std::max(180.0f, workBottom - assetsTop)), ImGuiCond_Always);
-  ImGui::Begin(kEditorAssetsWindow, nullptr, kMainPanelWindowFlags);
+    void EditorLayer::DrawAssetsPanel()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
+      const float leftDockW = ComputeEditorLeftDockWidth(io.DisplaySize.x);
+      const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
+      const float hierarchyHeight = std::max(220.0f, (workBottom - kEditorToolbarH) * kHierarchySectionRatio);
+      const float assetsTop = kEditorToolbarH + hierarchyHeight + 4.0f;
+      ImGui::SetNextWindowPos(ImVec2(0.0f, assetsTop), ImGuiCond_Always);
+      ImGui::SetNextWindowSize(ImVec2(leftDockW, std::max(180.0f, workBottom - assetsTop)), ImGuiCond_Always);
+      ImGui::Begin(kEditorAssetsWindow, nullptr, kMainPanelWindowFlags);
 
-  m_albedoDraftDrop.Clear();
-  m_albedoSelDrop.Clear();
+      m_albedoDraftDrop.Clear();
+      m_albedoSelDrop.Clear();
 
-  ImGui::TextDisabled("Assets");
-  ImGui::SameLine();
-  if (ImGui::Button("+", ImVec2(28.0f, 0.0f)))
-    m_openNewAssetHeader = true;
-  ImGui::SameLine();
-  ImGui::SetCursorPosX(std::max(0.0f, ImGui::GetWindowContentRegionMax().x - 74.0f));
-  if (ImGui::Button("Search", ImVec2(64.0f, 0.0f))) {
-    m_assetSearchOpen = true;
-    m_assetSearchQuery.clear();
-  }
-  ImGui::Separator();
-
-  std::vector<std::string> assetIds;
-  assetIds.reserve(m_document.assets.size());
-  for (const auto& [assetId, _] : m_document.assets)
-    assetIds.push_back(assetId);
-  std::sort(assetIds.begin(), assetIds.end());
-
-  if (m_assetSearchOpen) {
-    ImGui::SetNextWindowSize(ImVec2(460.0f, 0.0f), ImGuiCond_Appearing);
-    if (ImGui::BeginPopupModal("Asset Spotlight", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-      ImGui::TextDisabled("Search assets");
-      ImGui::SetNextItemWidth(420.0f);
-      char searchBuf[256] = {};
-      std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_assetSearchQuery.c_str());
-      if (ImGui::InputTextWithHint("##asset_search_input", "Type an asset id or mesh...", searchBuf, sizeof(searchBuf)))
-        m_assetSearchQuery = searchBuf;
-
+      ImGui::TextDisabled("Assets");
+      ImGui::SameLine();
+      if (ImGui::Button("+", ImVec2(28.0f, 0.0f)))
+        m_openNewAssetHeader = true;
+      ImGui::SameLine();
+      ImGui::SetCursorPosX(std::max(0.0f, ImGui::GetWindowContentRegionMax().x - 74.0f));
+      if (ImGui::Button("Search", ImVec2(64.0f, 0.0f)))
+      {
+        m_assetSearchOpen = true;
+        m_assetSearchQuery.clear();
+      }
       ImGui::Separator();
-      bool picked = false;
-      for (const auto& assetId : assetIds) {
+
+      std::vector<std::string> assetIds;
+      assetIds.reserve(m_document.assets.size());
+      for (const auto &[assetId, _] : m_document.assets)
+        assetIds.push_back(assetId);
+      std::sort(assetIds.begin(), assetIds.end());
+
+      if (m_assetSearchOpen)
+      {
+        ImGui::SetNextWindowSize(ImVec2(460.0f, 0.0f), ImGuiCond_Appearing);
+        if (ImGui::BeginPopupModal("Asset Spotlight", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+          ImGui::TextDisabled("Search assets");
+          ImGui::SetNextItemWidth(420.0f);
+          char searchBuf[256] = {};
+          std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_assetSearchQuery.c_str());
+          if (ImGui::InputTextWithHint("##asset_search_input", "Type an asset id or mesh...", searchBuf, sizeof(searchBuf)))
+            m_assetSearchQuery = searchBuf;
+
+          ImGui::Separator();
+          bool picked = false;
+          for (const auto &assetId : assetIds)
+          {
+            const auto assetIt = m_document.assets.find(assetId);
+            if (assetIt == m_document.assets.end())
+              continue;
+            const auto &asset = assetIt->second;
+
+            if (!AssetMatchesQuickOpenQuery(assetId, asset, m_assetSearchQuery))
+              continue;
+
+            if (ImGui::Selectable(assetId.c_str(), m_selectedAssetId == assetId))
+            {
+              m_selectedAssetId = assetId;
+              picked = true;
+            }
+            ImGui::SameLine();
+            ImGui::TextDisabled("mesh: %s", asset.mesh.c_str());
+          }
+
+          if (picked || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape))
+          {
+            m_assetSearchOpen = false;
+            ImGui::CloseCurrentPopup();
+          }
+          ImGui::EndPopup();
+        }
+        else
+        {
+          ImGui::OpenPopup("Asset Spotlight");
+        }
+      }
+
+      bool openNewAssetModal = m_openNewAssetHeader;
+      if (m_openNewAssetHeader)
+        m_openNewAssetHeader = false;
+
+      ImGui::BeginChild("##asset_grid", ImVec2(0, 0), false);
+
+      const float spacing = 8.0f;
+      const float minTileW = 130.0f;
+      const float availW = std::max(40.0f, ImGui::GetContentRegionAvail().x);
+      const int columns = std::max(1, static_cast<int>((availW + spacing) / (minTileW + spacing)));
+      const float tileW = (availW - spacing * static_cast<float>(columns - 1)) / static_cast<float>(columns);
+      const float thumbPad = 8.0f;
+      const float thumbSize = tileW - thumbPad * 2.0f;         // square preview area
+      const float tileH = thumbSize + thumbPad * 2.0f + 22.0f; // thumb + pads + label row
+
+      int shownAssetCount = 0;
+      for (const auto &assetId : assetIds)
+      {
         const auto assetIt = m_document.assets.find(assetId);
         if (assetIt == m_document.assets.end())
           continue;
-        const auto& asset = assetIt->second;
+        const auto &asset = assetIt->second;
 
         if (!AssetMatchesQuickOpenQuery(assetId, asset, m_assetSearchQuery))
           continue;
 
-        if (ImGui::Selectable(assetId.c_str(), m_selectedAssetId == assetId)) {
-          m_selectedAssetId = assetId;
-          picked = true;
+        ++shownAssetCount;
+
+        const int visibleIndex = shownAssetCount - 1;
+        const int col = visibleIndex % columns;
+        if (col > 0)
+          ImGui::SameLine(0.0f, spacing);
+
+        ImGui::PushID(assetId.c_str());
+        const bool isSelectedAsset = (m_selectedAssetId == assetId);
+        if (isSelectedAsset)
+          ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.14f, 0.24f, 0.34f, 0.70f));
+        ImGui::BeginChild("##asset_tile", ImVec2(tileW, tileH), ImGuiChildFlags_Borders,
+                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+        if (isSelectedAsset)
+          ImGui::PopStyleColor();
+
+        ImGui::InvisibleButton("##asset_tile_select", ImVec2(tileW - 2.0f, tileH - 2.0f));
+        if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+        {
+          m_selectedAssetId = isSelectedAsset ? std::string() : assetId;
         }
-        ImGui::SameLine();
-        ImGui::TextDisabled("mesh: %s", asset.mesh.c_str());
+
+        // Drag source: allows dropping onto the 3D viewport to create a prop
+        if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID))
+        {
+          ImGui::SetDragDropPayload("ASSET_ID", assetId.c_str(),
+                                    assetId.size() + 1);
+          ImGui::Text("+ %s", assetId.c_str());
+          ImGui::EndDragDropSource();
+        }
+
+        if (ImGui::BeginPopupContextItem("##asset_tile_ctx"))
+        {
+          if (ImGui::MenuItem("Add Prop"))
+          {
+            SceneObject obj = MakeObjectFromAsset(m_document, assetId, m_schema);
+            m_document.objects.push_back(std::move(obj));
+            m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+            m_document.dirty = true;
+            TriggerReload();
+          }
+          if (ImGui::MenuItem("Delete Asset"))
+            RequestDeleteAsset(assetId);
+          ImGui::EndPopup();
+        }
+
+        const ImVec2 tileMin = ImGui::GetWindowPos();
+        ImDrawList *dl = ImGui::GetWindowDrawList();
+        const ImVec2 thumbMin(tileMin.x + thumbPad, tileMin.y + thumbPad);
+        const ImVec2 thumbMax(thumbMin.x + thumbSize, thumbMin.y + thumbSize);
+
+        dl->AddRectFilled(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.13f, 0.18f, 0.95f)),
+                          6.0f);
+        dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
+
+        RenderTargetHandle previewHandle;
+        if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid())
+        {
+          const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
+          const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
+          dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
+        }
+        else
+        {
+          const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
+          const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));
+          const std::string ext = asset.mesh.empty() ? std::string("mesh") : ToLowerAscii(std::filesystem::path(asset.mesh).extension().string());
+          dl->AddText(ImVec2(thumbMin.x + 8.0f, thumbMin.y + 10.0f), labelCol, "No preview texture");
+          dl->AddText(ImVec2(thumbMin.x + 8.0f, thumbMin.y + 30.0f), meshCol, ext.c_str());
+        }
+
+        AssetMetadata tileMetadata;
+        const bool hasTileMetadata = LoadAssetMetadata(asset.guid, &tileMetadata, nullptr);
+        const bool hasDiagnostics = hasTileMetadata &&
+                                    (!tileMetadata.lastImportSucceeded || !tileMetadata.diagnostics.empty());
+
+        std::string nameLabel = asset.displayName.empty() ? assetId : asset.displayName;
+        if (hasDiagnostics)
+          nameLabel += " !";
+        const float maxLabelW = tileW - 14.0f;
+        if (ImGui::CalcTextSize(nameLabel.c_str()).x > maxLabelW)
+        {
+          while (!nameLabel.empty() && ImGui::CalcTextSize((nameLabel + "...").c_str()).x > maxLabelW)
+            nameLabel.pop_back();
+          nameLabel += "...";
+        }
+        const ImVec2 nameSz = ImGui::CalcTextSize(nameLabel.c_str());
+        const float nameX = tileMin.x + std::max(7.0f, (tileW - nameSz.x) * 0.5f);
+        const float nameY = thumbMax.y + 6.0f;
+        const ImU32 nameColor = hasDiagnostics ? IM_COL32(255, 120, 120, 255)
+                                               : ImGui::GetColorU32(ImGuiCol_Text);
+        dl->AddText(ImVec2(nameX, nameY), nameColor, nameLabel.c_str());
+
+        ImGui::EndChild();
+        ImGui::PopID();
       }
 
-      if (picked || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
-        m_assetSearchOpen = false;
-        ImGui::CloseCurrentPopup();
+      const FilteredListState assetState =
+          EvaluateFilteredListState(assetIds.size(), shownAssetCount, m_assetSearchQuery);
+      if (assetState != FilteredListState::None)
+      {
+        ImGui::Spacing();
+        if (assetState == FilteredListState::EmptyData)
+        {
+          ImGui::TextDisabled("Asset registry is empty");
+          ImGui::TextDisabled("Create your first asset to enable fast prop placement.");
+          if (ImGui::Button("Create First Asset"))
+            openNewAssetModal = true;
+        }
+        else if (assetState == FilteredListState::NoMatches)
+        {
+          ImGui::TextDisabled("No assets match '%s'", m_assetSearchQuery.c_str());
+          if (ImGui::Button("Clear Asset Search"))
+            m_assetSearchQuery.clear();
+        }
       }
-      ImGui::EndPopup();
-    } else {
-      ImGui::OpenPopup("Asset Spotlight");
-    }
-  }
 
-  bool openNewAssetModal = m_openNewAssetHeader;
-  if (m_openNewAssetHeader)
-    m_openNewAssetHeader = false;
+      ImGui::EndChild();
 
-  ImGui::BeginChild("##asset_grid", ImVec2(0, 0), false);
+      if (openNewAssetModal)
+        ImGui::OpenPopup("Create Asset");
+      ImGui::SetNextWindowSize(ImVec2(520.0f, 0.0f), ImGuiCond_Appearing);
+      if (ImGui::BeginPopupModal("Create Asset", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+      {
+        const float blockW = 470.0f;
+        ImGui::PushItemWidth(blockW);
 
-  const float spacing = 8.0f;
-  const float minTileW = 130.0f;
-  const float availW = std::max(40.0f, ImGui::GetContentRegionAvail().x);
-  const int columns = std::max(1, static_cast<int>((availW + spacing) / (minTileW + spacing)));
-  const float tileW = (availW - spacing * static_cast<float>(columns - 1)) / static_cast<float>(columns);
-  const float thumbPad = 8.0f;
-  const float thumbSize = tileW - thumbPad * 2.0f;  // square preview area
-  const float tileH = thumbSize + thumbPad * 2.0f + 22.0f;  // thumb + pads + label row
-
-  int shownAssetCount = 0;
-  for (const auto& assetId : assetIds) {
-    const auto assetIt = m_document.assets.find(assetId);
-    if (assetIt == m_document.assets.end())
-      continue;
-    const auto& asset = assetIt->second;
-
-    if (!AssetMatchesQuickOpenQuery(assetId, asset, m_assetSearchQuery))
-      continue;
-
-    ++shownAssetCount;
-
-    const int visibleIndex = shownAssetCount - 1;
-    const int col = visibleIndex % columns;
-    if (col > 0)
-      ImGui::SameLine(0.0f, spacing);
-
-    ImGui::PushID(assetId.c_str());
-    const bool isSelectedAsset = (m_selectedAssetId == assetId);
-    if (isSelectedAsset)
-      ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.14f, 0.24f, 0.34f, 0.70f));
-    ImGui::BeginChild("##asset_tile", ImVec2(tileW, tileH), ImGuiChildFlags_Borders,
-                      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
-    if (isSelectedAsset)
-      ImGui::PopStyleColor();
-
-    ImGui::InvisibleButton("##asset_tile_select", ImVec2(tileW - 2.0f, tileH - 2.0f));
-    if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) {
-      m_selectedAssetId = isSelectedAsset ? std::string() : assetId;
-    }
-
-    // Drag source: allows dropping onto the 3D viewport to create a prop
-    if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID)) {
-      ImGui::SetDragDropPayload("ASSET_ID", assetId.c_str(),
-                                assetId.size() + 1);
-      ImGui::Text("+ %s", assetId.c_str());
-      ImGui::EndDragDropSource();
-    }
-
-    if (ImGui::BeginPopupContextItem("##asset_tile_ctx")) {
-      if (ImGui::MenuItem("Add Prop")) {
-        SceneObject obj = MakeObjectFromAsset(m_document, assetId, m_schema);
-        m_document.objects.push_back(std::move(obj));
-        m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
-        m_document.dirty = true;
-        TriggerReload();
-      }
-      if (ImGui::MenuItem("Delete Asset"))
-        RequestDeleteAsset(assetId);
-      ImGui::EndPopup();
-    }
-
-    const ImVec2 tileMin = ImGui::GetWindowPos();
-    ImDrawList* dl = ImGui::GetWindowDrawList();
-    const ImVec2 thumbMin(tileMin.x + thumbPad, tileMin.y + thumbPad);
-    const ImVec2 thumbMax(thumbMin.x + thumbSize, thumbMin.y + thumbSize);
-
-    dl->AddRectFilled(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.13f, 0.18f, 0.95f)),
-                      6.0f);
-    dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
-
-    RenderTargetHandle previewHandle;
-    if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid()) {
-      const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
-      const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
-      dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
-    } else {
-      const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
-      const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));
-      const std::string ext = asset.mesh.empty() ? std::string("mesh") :
-                              ToLowerAscii(std::filesystem::path(asset.mesh).extension().string());
-      dl->AddText(ImVec2(thumbMin.x + 8.0f, thumbMin.y + 10.0f), labelCol, "No preview texture");
-      dl->AddText(ImVec2(thumbMin.x + 8.0f, thumbMin.y + 30.0f), meshCol, ext.c_str());
-    }
-
-    AssetMetadata tileMetadata;
-    const bool hasTileMetadata = LoadAssetMetadata(asset.guid, &tileMetadata, nullptr);
-    const bool hasDiagnostics = hasTileMetadata &&
-                                (!tileMetadata.lastImportSucceeded || !tileMetadata.diagnostics.empty());
-
-    std::string nameLabel = asset.displayName.empty() ? assetId : asset.displayName;
-    if (hasDiagnostics)
-      nameLabel += " !";
-    const float maxLabelW = tileW - 14.0f;
-    if (ImGui::CalcTextSize(nameLabel.c_str()).x > maxLabelW) {
-      while (!nameLabel.empty() && ImGui::CalcTextSize((nameLabel + "...").c_str()).x > maxLabelW)
-        nameLabel.pop_back();
-      nameLabel += "...";
-    }
-    const ImVec2 nameSz = ImGui::CalcTextSize(nameLabel.c_str());
-    const float nameX = tileMin.x + std::max(7.0f, (tileW - nameSz.x) * 0.5f);
-    const float nameY = thumbMax.y + 6.0f;
-    const ImU32 nameColor = hasDiagnostics ? IM_COL32(255, 120, 120, 255)
-                                           : ImGui::GetColorU32(ImGuiCol_Text);
-    dl->AddText(ImVec2(nameX, nameY), nameColor, nameLabel.c_str());
-
-    ImGui::EndChild();
-    ImGui::PopID();
-  }
-
-  const FilteredListState assetState =
-      EvaluateFilteredListState(assetIds.size(), shownAssetCount, m_assetSearchQuery);
-  if (assetState != FilteredListState::None) {
-    ImGui::Spacing();
-    if (assetState == FilteredListState::EmptyData) {
-      ImGui::TextDisabled("Asset registry is empty");
-      ImGui::TextDisabled("Create your first asset to enable fast prop placement.");
-      if (ImGui::Button("Create First Asset"))
-        openNewAssetModal = true;
-    } else if (assetState == FilteredListState::NoMatches) {
-      ImGui::TextDisabled("No assets match '%s'", m_assetSearchQuery.c_str());
-      if (ImGui::Button("Clear Asset Search"))
-        m_assetSearchQuery.clear();
-    }
-  }
-
-  ImGui::EndChild();
-
-  if (openNewAssetModal)
-    ImGui::OpenPopup("Create Asset");
-  ImGui::SetNextWindowSize(ImVec2(520.0f, 0.0f), ImGuiCond_Appearing);
-  if (ImGui::BeginPopupModal("Create Asset", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    const float blockW = 470.0f;
-    ImGui::PushItemWidth(blockW);
-
-    if (ImGui::Button("Import .obj...", ImVec2(blockW, 0.0f))) {
-      m_assetImportError.clear();
+        if (ImGui::Button("Import .obj...", ImVec2(blockW, 0.0f)))
+        {
+          m_assetImportError.clear();
 #if !defined(_WIN32) && !defined(__APPLE__)
-      m_assetImportError = "Import dialog is not supported on this platform yet.";
+          m_assetImportError = "Import dialog is not supported on this platform yet.";
 #else
-      m_deferredFilePick = DeferredFilePick::ImportObjBulk;
+          m_deferredFilePick = DeferredFilePick::ImportObjBulk;
 #endif
-    }
-    if (!m_assetImportError.empty()) {
-      ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + blockW);
-      ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_assetImportError.c_str());
-      ImGui::PopTextWrapPos();
-    }
-
-    ImGui::Spacing();
-
-    char idBuf[128] = {};
-    std::snprintf(idBuf, sizeof(idBuf), "%s", m_assetDraftId.c_str());
-    ImGui::TextDisabled("Asset ID");
-    if (ImGui::InputText("##draft_id", idBuf, sizeof(idBuf))) {
-      m_assetDraftId = idBuf;
-      if (m_assetDraftDisplayName.empty())
-        m_assetDraftDisplayName = m_assetDraftId;
-    }
-
-    char displayNameBuf[128] = {};
-    std::snprintf(displayNameBuf, sizeof(displayNameBuf), "%s", m_assetDraftDisplayName.c_str());
-    ImGui::TextDisabled("Display name");
-    if (ImGui::InputText("##draft_display_name", displayNameBuf, sizeof(displayNameBuf)))
-      m_assetDraftDisplayName = displayNameBuf;
-
-    if (!m_assetDraftGuid.empty()) {
-      ImGui::TextDisabled("GUID");
-      ImGui::TextWrapped("%s", m_assetDraftGuid.c_str());
-    }
-
-    char meshBuf[256] = {};
-    std::snprintf(meshBuf, sizeof(meshBuf), "%s", m_assetDraftMesh.c_str());
-    ImGui::TextDisabled("Mesh");
-    if (ImGui::InputText("##draft_mesh", meshBuf, sizeof(meshBuf)))
-      m_assetDraftMesh = meshBuf;
-
-    char scaleBuf[128] = {};
-    std::snprintf(scaleBuf, sizeof(scaleBuf), "%s", m_assetDraftRenderScale.c_str());
-    ImGui::TextDisabled("Render scale");
-    if (ImGui::InputText("##draft_scale", scaleBuf, sizeof(scaleBuf)))
-      m_assetDraftRenderScale = scaleBuf;
-
-    char albDraftBuf[512] = {};
-    std::snprintf(albDraftBuf, sizeof(albDraftBuf), "%s", m_assetDraftAlbedoMap.c_str());
-    ImGui::TextDisabled("Albedo map (optional)");
-    const ImVec2 draftAlbLabelMin = ImGui::GetItemRectMin();
-    const ImVec2 draftAlbLabelMax = ImGui::GetItemRectMax();
-    if (ImGui::InputText("##draft_albedo", albDraftBuf, sizeof(albDraftBuf)))
-      m_assetDraftAlbedoMap = albDraftBuf;
-    {
-      const ImVec2 fMin = ImGui::GetItemRectMin();
-      const ImVec2 fMax = ImGui::GetItemRectMax();
-      m_albedoDraftDrop.valid = true;
-      m_albedoDraftDrop.minX = std::min(draftAlbLabelMin.x, fMin.x);
-      m_albedoDraftDrop.minY = draftAlbLabelMin.y;
-      m_albedoDraftDrop.maxX = std::max(draftAlbLabelMax.x, fMax.x);
-      m_albedoDraftDrop.maxY = fMax.y;
-    }
-
-#if defined(_WIN32) || defined(__APPLE__)
-    if (ImGui::Button("Browse texture...##alb_pick_draft", ImVec2(blockW, 0.0f)))
-      m_deferredFilePick = DeferredFilePick::NewAssetAlbedo;
-#else
-    ImGui::BeginDisabled();
-    ImGui::Button("Browse texture...##alb_pick_draft", ImVec2(blockW, 0.0f));
-    ImGui::EndDisabled();
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-      ImGui::SetTooltip("Texture file dialog is not available on this platform.");
-#endif
-
-    ImGui::Spacing();
-
-    const bool canCreate = !m_assetDraftId.empty() && !m_assetDraftMesh.empty();
-    if (!canCreate)
-      ImGui::BeginDisabled();
-    if (ImGui::Button("Create Asset", ImVec2(150.0f, 0.0f))) {
-      AssetDef def;
-      def.mesh = m_assetDraftMesh;
-      def.renderScale = m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
-      def.albedoMap = m_assetDraftAlbedoMap;
-      def.guid = m_assetDraftGuid.empty() ? GenerateAssetGuid() : m_assetDraftGuid;
-      def.displayName = m_assetDraftDisplayName.empty() ? m_assetDraftId : m_assetDraftDisplayName;
-      m_document.assets[m_assetDraftId] = std::move(def);
-      std::string metadataError;
-      if (!m_assetImportService.SaveMetadataForAsset(m_assetDraftId, m_document.assets[m_assetDraftId], &metadataError) &&
-          !metadataError.empty()) {
-        LOG_WARN("Create Asset metadata sync: %s", metadataError.c_str());
-      }
-      m_selectedAssetId = m_assetDraftId;
-      m_assetDraftId.clear();
-      m_assetDraftGuid.clear();
-      m_assetDraftDisplayName.clear();
-      m_assetDraftMesh.clear();
-      m_assetDraftRenderScale = "1.0000,1.0000,1.0000";
-      m_assetDraftAlbedoMap.clear();
-      m_assetImportError.clear();
-      m_document.dirty = true;
-      TriggerReload();
-      ImGui::CloseCurrentPopup();
-    }
-    if (!canCreate)
-      ImGui::EndDisabled();
-
-    ImGui::SameLine();
-    if (ImGui::Button("Cancel", ImVec2(150.0f, 0.0f))) {
-      m_assetImportError.clear();
-      m_assetDraftGuid.clear();
-      m_assetDraftDisplayName.clear();
-      ImGui::CloseCurrentPopup();
-    }
-
-    ImGui::PopItemWidth();
-    ImGui::EndPopup();
-  }
-
-  ImGui::End();
-}
-
-void EditorLayer::DrawHelpPopup() {
-  if (!m_helpOpen)
-    return;
-  const std::span<const ShortcutRow> shortcuts = GetEditorShortcuts();
-
-  ImGuiIO& io = ImGui::GetIO();
-  ImGui::SetNextWindowSize(ImVec2(620.0f, 420.0f), ImGuiCond_FirstUseEver);
-  ImGui::SetNextWindowPos(ImVec2((io.DisplaySize.x - 620.0f) * 0.5f, (io.DisplaySize.y - 420.0f) * 0.5f),
-                          ImGuiCond_FirstUseEver);
-
-  if (!ImGui::Begin("Help - Keyboard Shortcuts", &m_helpOpen, ImGuiWindowFlags_NoCollapse)) {
-    ImGui::End();
-    return;
-  }
-
-  ImGui::TextDisabled("Search by category, command, or key");
-  char searchBuf[256] = {};
-  std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_helpSearchQuery.c_str());
-  if (ImGui::InputTextWithHint("##shortcut_search", "Find shortcut...", searchBuf, sizeof(searchBuf)))
-    m_helpSearchQuery = searchBuf;
-
-  ImGui::Separator();
-  ImGui::Columns(3, "shortcut_columns", false);
-  ImGui::SetColumnWidth(0, 130.0f);
-  ImGui::SetColumnWidth(1, 300.0f);
-  ImGui::TextUnformatted("Category");
-  ImGui::NextColumn();
-  ImGui::TextUnformatted("Command");
-  ImGui::NextColumn();
-  ImGui::TextUnformatted("Shortcut");
-  ImGui::NextColumn();
-  ImGui::Separator();
-
-  int shownCount = 0;
-  for (const auto& row : shortcuts) {
-    if (!MatchesShortcutQuery(row, m_helpSearchQuery))
-      continue;
-
-    ImGui::TextDisabled("%s", row.category);
-    ImGui::NextColumn();
-    ImGui::TextUnformatted(row.command);
-    ImGui::NextColumn();
-    ImGui::TextColored(ImVec4(0.65f, 0.85f, 1.0f, 1.0f), "%s", row.keys);
-    ImGui::NextColumn();
-    ++shownCount;
-  }
-
-  ImGui::Columns(1);
-  if (shownCount == 0)
-    ImGui::TextDisabled("No shortcut matches '%s'", m_helpSearchQuery.c_str());
-
-  ImGui::Separator();
-  ImGui::TextDisabled("Tip: press ? or F1 to close this window quickly.");
-  ImGui::End();
-}
-
-void EditorLayer::DrawCommandPalettePopup() {
-  if (m_commandPaletteOpen) {
-    ImGui::SetNextWindowSize(ImVec2(520.0f, 0.0f), ImGuiCond_Appearing);
-    if (!ImGui::IsPopupOpen("Command Palette"))
-      ImGui::OpenPopup("Command Palette");
-  }
-
-  if (!ImGui::BeginPopupModal("Command Palette", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-    return;
-
-  ImGui::TextDisabled("Search commands");
-  ImGui::SetNextItemWidth(480.0f);
-  char queryBuf[256] = {};
-  std::snprintf(queryBuf, sizeof(queryBuf), "%s", m_commandPaletteQuery.c_str());
-  if (ImGui::InputTextWithHint("##command_palette_input",
-                               "Type a command...",
-                               queryBuf,
-                               sizeof(queryBuf))) {
-    m_commandPaletteQuery = queryBuf;
-  }
-
-  ImGui::Separator();
-  bool executed = false;
-  int shownCount = 0;
-  for (const CommandPaletteRow& row : GetEditorCommands()) {
-    if (!MatchesCommandPaletteQuery(row, m_commandPaletteQuery))
-      continue;
-
-    const std::string label = std::string(row.command) + "##cmd_" + row.id;
-    if (ImGui::Selectable(label.c_str(), false)) {
-      ExecuteCommandPaletteAction(row.id);
-      executed = true;
-    }
-    ImGui::SameLine();
-    ImGui::TextDisabled("%s", row.keys);
-    ++shownCount;
-  }
-
-  if (shownCount == 0)
-    ImGui::TextDisabled("No command matches '%s'", m_commandPaletteQuery.c_str());
-
-  if (executed || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
-    m_commandPaletteOpen = false;
-    ImGui::CloseCurrentPopup();
-  }
-
-  ImGui::EndPopup();
-}
-
-void EditorLayer::DrawQuickOpenPopup() {
-  if (m_quickOpenOpen) {
-    ImGui::SetNextWindowSize(ImVec2(560.0f, 0.0f), ImGuiCond_Appearing);
-    if (!ImGui::IsPopupOpen("Quick Open"))
-      ImGui::OpenPopup("Quick Open");
-  }
-
-  if (!ImGui::BeginPopupModal("Quick Open", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-    return;
-
-  ImGui::TextDisabled("Open object or asset");
-  ImGui::SetNextItemWidth(520.0f);
-  char queryBuf[256] = {};
-  std::snprintf(queryBuf, sizeof(queryBuf), "%s", m_quickOpenQuery.c_str());
-  if (ImGui::InputTextWithHint("##quick_open_input", "Type id, type, asset, or mesh...", queryBuf, sizeof(queryBuf)))
-    m_quickOpenQuery = queryBuf;
-
-  ImGui::Separator();
-
-  bool picked = false;
-  int shownCount = 0;
-
-  ImGui::TextDisabled("Objects");
-  for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-    const auto& obj = m_document.objects[i];
-    const char* typeName = ObjectTypeLabel(obj.type);
-
-    if (!ObjectMatchesQuickOpenQuery(obj, m_quickOpenQuery))
-      continue;
-
-    const std::string label = "Object: " + obj.id + "##quick_open_obj_" + std::to_string(i);
-    if (ImGui::Selectable(label.c_str(), IsSelected(i))) {
-      m_selectedIndices = {i};
-      picked = true;
-    }
-    ImGui::SameLine();
-    if (obj.assetId.empty())
-      ImGui::TextDisabled("type: %s", typeName);
-    else
-      ImGui::TextDisabled("type: %s  |  asset: %s", typeName, obj.assetId.c_str());
-    ++shownCount;
-  }
-
-  ImGui::Spacing();
-  ImGui::TextDisabled("Assets");
-  for (const auto& [assetId, asset] : m_document.assets) {
-    if (!AssetMatchesQuickOpenQuery(assetId, asset, m_quickOpenQuery))
-      continue;
-
-    const std::string label = "Asset: " + assetId + "##quick_open_asset_" + assetId;
-    if (ImGui::Selectable(label.c_str(), m_selectedAssetId == assetId)) {
-      m_selectedAssetId = assetId;
-      picked = true;
-    }
-    ImGui::SameLine();
-    ImGui::TextDisabled("mesh: %s", asset.mesh.c_str());
-    ++shownCount;
-  }
-
-  if (shownCount == 0)
-    ImGui::TextDisabled("No match for '%s'", m_quickOpenQuery.c_str());
-
-  if (picked || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
-    m_quickOpenOpen = false;
-    ImGui::CloseCurrentPopup();
-  }
-
-  ImGui::EndPopup();
-}
-
-void EditorLayer::DrawDeleteConfirmModals() {
-  if (m_confirmDeleteObjectsOpen)
-    ImGui::OpenPopup("Confirm Delete Objects");
-
-  if (ImGui::BeginPopupModal("Confirm Delete Objects", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    int validCount = 0;
-    for (int idx : m_pendingDeleteObjectIndices)
-      if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-        ++validCount;
-
-    if (validCount <= 0) {
-      m_confirmDeleteObjectsOpen = false;
-      m_pendingDeleteObjectIndices.clear();
-      ImGui::CloseCurrentPopup();
-      ImGui::EndPopup();
-      return;
-    }
-
-    ImGui::Text("Delete %d selected object(s)?", validCount);
-    ImGui::TextDisabled("This action cannot be undone.");
-    ImGui::Separator();
-
-    if (ImGui::Button("Cancel", ImVec2(110.0f, 0.0f))) {
-      m_confirmDeleteObjectsOpen = false;
-      m_pendingDeleteObjectIndices.clear();
-      ImGui::CloseCurrentPopup();
-    }
-
-    ImGui::SameLine();
-    if (ImGui::Button("Delete", ImVec2(110.0f, 0.0f))) {
-      std::vector<int> sorted = m_pendingDeleteObjectIndices;
-      std::sort(sorted.rbegin(), sorted.rend());
-      for (int idx : sorted) {
-        if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-          m_document.objects.erase(m_document.objects.begin() + idx);
-      }
-      m_selectedIndices.clear();
-      m_document.dirty = true;
-      TriggerReload();
-
-      m_confirmDeleteObjectsOpen = false;
-      m_pendingDeleteObjectIndices.clear();
-      ImGui::CloseCurrentPopup();
-    }
-
-    ImGui::EndPopup();
-  }
-
-  if (m_confirmDeleteAssetOpen)
-    ImGui::OpenPopup("Confirm Delete Asset");
-
-  if (ImGui::BeginPopupModal("Confirm Delete Asset", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-    if (m_pendingDeleteAssetId.empty() ||
-        m_document.assets.find(m_pendingDeleteAssetId) == m_document.assets.end()) {
-      m_confirmDeleteAssetOpen = false;
-      m_pendingDeleteAssetId.clear();
-      m_pendingDeleteAssetError.clear();
-      ImGui::CloseCurrentPopup();
-      ImGui::EndPopup();
-      return;
-    }
-
-    const std::filesystem::path managedDirectory =
-        GetManagedImportedAssetDirectory(m_document.assets.at(m_pendingDeleteAssetId));
-
-    ImGui::Text("Delete asset '%s'?", m_pendingDeleteAssetId.c_str());
-    ImGui::TextDisabled("All object bindings to this asset will be cleared.");
-    if (!managedDirectory.empty()) {
-      ImGui::TextDisabled("Imported project files will also be removed:");
-      ImGui::TextWrapped("%s", managedDirectory.generic_string().c_str());
-    } else {
-      ImGui::TextDisabled("No managed imported asset folder was detected; only the asset record will be removed.");
-    }
-    if (!m_pendingDeleteAssetError.empty()) {
-      ImGui::Spacing();
-      ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 360.0f);
-      ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_pendingDeleteAssetError.c_str());
-      ImGui::PopTextWrapPos();
-    }
-    ImGui::Separator();
-
-    if (ImGui::Button("Cancel", ImVec2(110.0f, 0.0f))) {
-      m_confirmDeleteAssetOpen = false;
-      m_pendingDeleteAssetId.clear();
-      m_pendingDeleteAssetError.clear();
-      ImGui::CloseCurrentPopup();
-    }
-
-    ImGui::SameLine();
-    if (ImGui::Button("Delete", ImVec2(110.0f, 0.0f))) {
-      const AssetDeleteResult deleteResult = DeleteAssetDefinition(m_pendingDeleteAssetId);
-      if (!deleteResult.ok) {
-        m_pendingDeleteAssetError = deleteResult.error;
-      } else {
-        m_confirmDeleteAssetOpen = false;
-        m_pendingDeleteAssetId.clear();
-        m_pendingDeleteAssetError.clear();
-        ImGui::CloseCurrentPopup();
-      }
-    }
-
-    ImGui::EndPopup();
-  }
-}
-
-void EditorLayer::DrawExitConfirmModal() {
-  if (m_confirmExitOpen)
-    ImGui::OpenPopup("Unsaved Changes");
-
-  if (!ImGui::BeginPopupModal("Unsaved Changes", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-    return;
-
-  const char* actionLabel = "continue";
-  switch (m_pendingSceneAction) {
-    case PendingSceneAction::NewScene:
-      actionLabel = "create a new scene";
-      break;
-    case PendingSceneAction::OpenSceneFile:
-      actionLabel = "open another scene";
-      break;
-    case PendingSceneAction::LoadSceneFromDisk:
-      actionLabel = "load the scene from disk";
-      break;
-    case PendingSceneAction::ReloadSceneFromDisk:
-      actionLabel = "reload the scene";
-      break;
-    case PendingSceneAction::CloseEditor:
-      actionLabel = "exit editor mode";
-      break;
-    case PendingSceneAction::None:
-      break;
-  }
-
-  ImGui::TextUnformatted("You have unsaved changes.");
-  ImGui::TextDisabled("Save or discard them before you %s.", actionLabel);
-  ImGui::Separator();
-
-  if (!m_exitConfirmError.empty())
-    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", m_exitConfirmError.c_str());
-
-  if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f))) {
-    m_confirmExitOpen = false;
-    m_exitConfirmError.clear();
-    m_pendingSceneAction = PendingSceneAction::None;
-    ImGui::CloseCurrentPopup();
-  }
-
-  ImGui::SameLine();
-  if (ImGui::Button("Discard", ImVec2(120.0f, 0.0f))) {
-    if (m_pendingSceneAction == PendingSceneAction::CloseEditor)
-      DiscardUnsavedChanges();
-    m_confirmExitOpen = false;
-    m_exitConfirmError.clear();
-    ImGui::CloseCurrentPopup();
-    std::string actionError;
-    if (!ExecutePendingSceneAction(&actionError))
-      m_exitConfirmError = actionError;
-  }
-
-  ImGui::SameLine();
-  if (ImGui::Button("Save & Continue", ImVec2(120.0f, 0.0f))) {
-    std::string saveError;
-    if (SaveDocument(&saveError)) {
-      m_confirmExitOpen = false;
-      m_exitConfirmError.clear();
-      ImGui::CloseCurrentPopup();
-      std::string actionError;
-      if (!ExecutePendingSceneAction(&actionError))
-        m_exitConfirmError = actionError;
-    } else {
-      m_exitConfirmError = saveError;
-    }
-  }
-
-  ImGui::EndPopup();
-}
-
-// ---- Properties panel --------------------------------------------------------
-
-void EditorLayer::DrawPropertiesPanel() {
-  ImGuiIO& io = ImGui::GetIO();
-  const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
-  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
-  const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
-  ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - rightDockW, kEditorToolbarH), ImGuiCond_Always);
-  ImGui::SetNextWindowSize(ImVec2(rightDockW, std::max(260.0f, workBottom - kEditorToolbarH)),
-                           ImGuiCond_Always);
-  ImGui::Begin(kEditorPropertiesWindow, nullptr, kMainPanelWindowFlags);
-
-  // ---- Multi-selection summary ----
-  if (m_selectedIndices.size() > 1) {
-    ImGui::Text("%d objects selected", static_cast<int>(m_selectedIndices.size()));
-    ImGui::Separator();
-
-    std::string sharedAssetId;
-    bool hasSharedAssetId = true;
-    bool firstObject = true;
-    for (int idx : m_selectedIndices) {
-      if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
-        continue;
-      const SceneObject& selected = m_document.objects[static_cast<size_t>(idx)];
-      if (firstObject) {
-        sharedAssetId = selected.assetId;
-        firstObject = false;
-      } else if (sharedAssetId != selected.assetId) {
-        hasSharedAssetId = false;
-        break;
-      }
-    }
-
-    ImGui::TextDisabled("Asset");
-    if (firstObject) {
-      ImGui::TextDisabled("No valid selection");
-    } else if (hasSharedAssetId && sharedAssetId.empty()) {
-      ImGui::TextUnformatted("<none>");
-    } else if (hasSharedAssetId) {
-      ImGui::TextUnformatted(sharedAssetId.c_str());
-    } else {
-      ImGui::TextDisabled("Mixed");
-    }
-
-    std::vector<const char*> assetItems;
-    assetItems.reserve(m_document.assets.size() + 2);
-    assetItems.push_back("<keep current>");
-    assetItems.push_back("<clear>");
-    std::vector<std::string> assetIds;
-    assetIds.reserve(m_document.assets.size());
-    for (const auto& [assetId, _] : m_document.assets)
-      assetIds.push_back(assetId);
-    std::sort(assetIds.begin(), assetIds.end());
-    for (const std::string& assetId : assetIds)
-      assetItems.push_back(assetId.c_str());
-
-    ImGui::Combo("Batch Asset", &m_batchAssetChoice, assetItems.data(), static_cast<int>(assetItems.size()));
-    if (ImGui::Button("Apply Asset")) {
-      if (m_batchAssetChoice == 1) {
-        for (int idx : m_selectedIndices) {
-          if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-            m_document.objects[static_cast<size_t>(idx)].assetId.clear();
         }
-      } else if (m_batchAssetChoice > 1) {
-        const std::string selectedAssetId = assetIds[static_cast<size_t>(m_batchAssetChoice - 2)];
-        for (int idx : m_selectedIndices) {
-          if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-            m_document.objects[static_cast<size_t>(idx)].assetId = selectedAssetId;
+        if (!m_assetImportError.empty())
+        {
+          ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + blockW);
+          ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_assetImportError.c_str());
+          ImGui::PopTextWrapPos();
         }
-      }
-      if (m_batchAssetChoice > 0) {
-        SyncAssetScaleMetadata(&m_document);
-        m_document.dirty = true;
-        TriggerReload();
-      }
-    }
 
-    ImGui::Separator();
-    float moveBy[3] = {m_batchTranslateDraft.x, m_batchTranslateDraft.y, m_batchTranslateDraft.z};
-    if (ImGui::DragFloat3("Move By", moveBy, 0.05f))
-      m_batchTranslateDraft = {moveBy[0], moveBy[1], moveBy[2]};
+        ImGui::Spacing();
 
-    float rotateBy[3] = {m_batchRotateDraft.x, m_batchRotateDraft.y, m_batchRotateDraft.z};
-    if (ImGui::DragFloat3("Rotate By (P/Y/R)", rotateBy, 1.0f))
-      m_batchRotateDraft = {rotateBy[0], rotateBy[1], rotateBy[2]};
+        char idBuf[128] = {};
+        std::snprintf(idBuf, sizeof(idBuf), "%s", m_assetDraftId.c_str());
+        ImGui::TextDisabled("Asset ID");
+        if (ImGui::InputText("##draft_id", idBuf, sizeof(idBuf)))
+        {
+          m_assetDraftId = idBuf;
+          if (m_assetDraftDisplayName.empty())
+            m_assetDraftDisplayName = m_assetDraftId;
+        }
 
-    float scaleBy[3] = {m_batchScaleDraft.x, m_batchScaleDraft.y, m_batchScaleDraft.z};
-    if (ImGui::DragFloat3("Scale By", scaleBy, 0.02f, 0.01f, 20.0f))
-      m_batchScaleDraft = {scaleBy[0], scaleBy[1], scaleBy[2]};
-
-    if (ImGui::Button("Apply Batch Transform")) {
-      for (int idx : m_selectedIndices) {
-        if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
-          continue;
-        SceneObject& object = m_document.objects[static_cast<size_t>(idx)];
-        object.position = object.position + m_batchTranslateDraft;
-        object.pitch += m_batchRotateDraft.x;
-        object.yaw += m_batchRotateDraft.y;
-        object.roll += m_batchRotateDraft.z;
-        object.scale.x *= m_batchScaleDraft.x;
-        object.scale.y *= m_batchScaleDraft.y;
-        object.scale.z *= m_batchScaleDraft.z;
-        if (m_transformCb)
-          m_transformCb(object);
-      }
-      m_document.dirty = true;
-      TriggerReload();
-    }
-
-    ImGui::Separator();
-    if (ImGui::Button("Duplicate Selected")) {
-      DuplicateSelectedObjects();
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Delete Selected")) {
-      RequestDeleteSelectedObjects();
-    }
-    ImGui::End();
-    return;
-  }
-
-  int primaryIdx = PrimaryIdx();
-  if (primaryIdx < 0 || primaryIdx >= static_cast<int>(m_document.objects.size())) {
-    if (!m_selectedAssetId.empty()) {
-      auto assetIt = m_document.assets.find(m_selectedAssetId);
-      if (assetIt == m_document.assets.end()) {
-        m_selectedAssetId.clear();
-      } else {
-        ImGui::TextDisabled("Asset");
-        ImGui::TextUnformatted(m_selectedAssetId.c_str());
+        char displayNameBuf[128] = {};
+        std::snprintf(displayNameBuf, sizeof(displayNameBuf), "%s", m_assetDraftDisplayName.c_str());
         ImGui::TextDisabled("Display name");
-        ImGui::TextUnformatted(assetIt->second.displayName.c_str());
-        ImGui::TextDisabled("GUID");
-        ImGui::TextWrapped("%s", assetIt->second.guid.c_str());
+        if (ImGui::InputText("##draft_display_name", displayNameBuf, sizeof(displayNameBuf)))
+          m_assetDraftDisplayName = displayNameBuf;
 
-        AssetMetadata assetMetadata;
-        std::string metadataError;
-        const bool hasAssetMetadata = LoadAssetMetadata(assetIt->second.guid, &assetMetadata, &metadataError);
-        if (hasAssetMetadata) {
-          if (!assetMetadata.importerId.empty()) {
-            ImGui::TextDisabled("Importer");
-            ImGui::TextWrapped("%s", assetMetadata.importerId.c_str());
-          }
-          if (!assetMetadata.sourcePath.empty()) {
-            ImGui::TextDisabled("Source");
-            ImGui::TextWrapped("%s", assetMetadata.sourcePath.c_str());
-          }
-          if (!assetMetadata.lastImportReason.empty()) {
-            ImGui::TextDisabled("Last rebuild reason");
-            ImGui::TextWrapped("%s", assetMetadata.lastImportReason.c_str());
-          }
-          if (!assetMetadata.diagnostics.empty()) {
-            ImGui::TextDisabled("Diagnostics");
-            for (const AssetImportDiagnostic& diagnostic : assetMetadata.diagnostics) {
-              const ImVec4 color =
-                  diagnostic.severity == AssetDiagnosticSeverity::Error
-                      ? ImVec4(1.f, 0.4f, 0.4f, 1.f)
-                      : diagnostic.severity == AssetDiagnosticSeverity::Warning
-                            ? ImVec4(1.f, 0.8f, 0.35f, 1.f)
-                            : ImVec4(0.6f, 0.85f, 1.f, 1.f);
-              const std::string line = "[" + diagnostic.code + "] " + diagnostic.message;
-              ImGui::TextWrapped("%s", line.c_str());
-              const ImVec2 min = ImGui::GetItemRectMin();
-              const ImVec2 max = ImGui::GetItemRectMax();
-              ImGui::GetWindowDrawList()->AddRectFilled(
-                  ImVec2(min.x - 6.0f, min.y + 3.0f),
-                  ImVec2(min.x - 2.0f, max.y - 3.0f),
-                  ImGui::ColorConvertFloat4ToU32(color),
-                  1.0f);
-            }
-          }
+        if (!m_assetDraftGuid.empty())
+        {
+          ImGui::TextDisabled("GUID");
+          ImGui::TextWrapped("%s", m_assetDraftGuid.c_str());
         }
 
-        if (ImGui::Button("Deselect Asset", ImVec2(-1.0f, 0.0f))) {
-          m_selectedAssetId.clear();
-          ImGui::End();
-          return;
-        }
+        char meshBuf[256] = {};
+        std::snprintf(meshBuf, sizeof(meshBuf), "%s", m_assetDraftMesh.c_str());
+        ImGui::TextDisabled("Mesh");
+        if (ImGui::InputText("##draft_mesh", meshBuf, sizeof(meshBuf)))
+          m_assetDraftMesh = meshBuf;
 
-        if (hasAssetMetadata) {
-          if (ImGui::Button("Reimport Asset", ImVec2(-1.0f, 0.0f))) {
-            const AssetReimportResult reimportResult =
-                m_assetImportService.ReimportAssetWithDependents(&m_document,
-                                                                 assetIt->second.guid,
-                                                                 "Manual reimport from editor");
-            if (reimportResult.ok) {
-              m_document.dirty = true;
-              m_assetImportError.clear();
-              TriggerReload();
-            } else {
-              m_assetImportError = reimportResult.error;
-            }
-          }
-          if (!m_assetImportError.empty())
-            ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_assetImportError.c_str());
-        }
+        char scaleBuf[128] = {};
+        std::snprintf(scaleBuf, sizeof(scaleBuf), "%s", m_assetDraftRenderScale.c_str());
+        ImGui::TextDisabled("Render scale");
+        if (ImGui::InputText("##draft_scale", scaleBuf, sizeof(scaleBuf)))
+          m_assetDraftRenderScale = scaleBuf;
 
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        char meshEditBuf[512] = {};
-        std::snprintf(meshEditBuf, sizeof(meshEditBuf), "%s", assetIt->second.mesh.c_str());
-        if (ImGui::InputText("Mesh", meshEditBuf, sizeof(meshEditBuf))) {
-          assetIt->second.mesh = meshEditBuf;
-          m_document.dirty = true;
-        }
-
-        char displayEditBuf[256] = {};
-        std::snprintf(displayEditBuf, sizeof(displayEditBuf), "%s", assetIt->second.displayName.c_str());
-        if (ImGui::InputText("Display Name", displayEditBuf, sizeof(displayEditBuf))) {
-          assetIt->second.displayName = displayEditBuf;
-          m_document.dirty = true;
-        }
-
-        char scaleEditBuf[128] = {};
-        std::snprintf(scaleEditBuf, sizeof(scaleEditBuf), "%s", assetIt->second.renderScale.c_str());
-        if (ImGui::InputText("Render Scale", scaleEditBuf, sizeof(scaleEditBuf))) {
-          assetIt->second.renderScale = scaleEditBuf;
-          SyncAssetScaleMetadata(&m_document);
-          m_document.dirty = true;
-          TriggerReload();
-        }
-
+        char albDraftBuf[512] = {};
+        std::snprintf(albDraftBuf, sizeof(albDraftBuf), "%s", m_assetDraftAlbedoMap.c_str());
         ImGui::TextDisabled("Albedo map (optional)");
-        const ImVec2 selAlbLabelMin = ImGui::GetItemRectMin();
-        const ImVec2 selAlbLabelMax = ImGui::GetItemRectMax();
-        char albBuf[512] = {};
-        std::snprintf(albBuf, sizeof(albBuf), "%s", assetIt->second.albedoMap.c_str());
-        if (ImGui::InputText("##sel_alb", albBuf, sizeof(albBuf))) {
-          assetIt->second.albedoMap = albBuf;
-          m_document.dirty = true;
-        }
+        const ImVec2 draftAlbLabelMin = ImGui::GetItemRectMin();
+        const ImVec2 draftAlbLabelMax = ImGui::GetItemRectMax();
+        if (ImGui::InputText("##draft_albedo", albDraftBuf, sizeof(albDraftBuf)))
+          m_assetDraftAlbedoMap = albDraftBuf;
         {
           const ImVec2 fMin = ImGui::GetItemRectMin();
           const ImVec2 fMax = ImGui::GetItemRectMax();
-          m_albedoSelDrop.valid = true;
-          m_albedoSelDrop.minX = std::min(selAlbLabelMin.x, fMin.x);
-          m_albedoSelDrop.minY = selAlbLabelMin.y;
-          m_albedoSelDrop.maxX = std::max(selAlbLabelMax.x, fMax.x);
-          m_albedoSelDrop.maxY = fMax.y;
+          m_albedoDraftDrop.valid = true;
+          m_albedoDraftDrop.minX = std::min(draftAlbLabelMin.x, fMin.x);
+          m_albedoDraftDrop.minY = draftAlbLabelMin.y;
+          m_albedoDraftDrop.maxX = std::max(draftAlbLabelMax.x, fMax.x);
+          m_albedoDraftDrop.maxY = fMax.y;
         }
 
 #if defined(_WIN32) || defined(__APPLE__)
-        if (ImGui::Button("Browse texture...##alb_pick_asset", ImVec2(-1.0f, 0.0f)))
-          m_deferredFilePick = DeferredFilePick::SelectedAssetAlbedo;
+        if (ImGui::Button("Browse texture...##alb_pick_draft", ImVec2(blockW, 0.0f)))
+          m_deferredFilePick = DeferredFilePick::NewAssetAlbedo;
 #else
         ImGui::BeginDisabled();
-        ImGui::Button("Browse texture...##alb_pick_asset", ImVec2(-1.0f, 0.0f));
+        ImGui::Button("Browse texture...##alb_pick_draft", ImVec2(blockW, 0.0f));
         ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
           ImGui::SetTooltip("Texture file dialog is not available on this platform.");
 #endif
 
-        const float gap = ImGui::GetStyle().ItemSpacing.x;
-        const float fullW = ImGui::GetContentRegionAvail().x;
-        const float btnW = std::max(90.0f, (fullW - gap) * 0.5f);
-        if (ImGui::Button("Add Prop##sel_add", ImVec2(btnW, 0.0f))) {
-          SceneObject obj = MakeObjectFromAsset(m_document, m_selectedAssetId, m_schema);
-          m_document.objects.push_back(std::move(obj));
-          m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+        ImGui::Spacing();
+
+        const bool canCreate = !m_assetDraftId.empty() && !m_assetDraftMesh.empty();
+        if (!canCreate)
+          ImGui::BeginDisabled();
+        if (ImGui::Button("Create Asset", ImVec2(150.0f, 0.0f)))
+        {
+          AssetDef def;
+          def.mesh = m_assetDraftMesh;
+          def.renderScale = m_assetDraftRenderScale.empty() ? "1.0000,1.0000,1.0000" : m_assetDraftRenderScale;
+          def.albedoMap = m_assetDraftAlbedoMap;
+          def.guid = m_assetDraftGuid.empty() ? GenerateAssetGuid() : m_assetDraftGuid;
+          def.displayName = m_assetDraftDisplayName.empty() ? m_assetDraftId : m_assetDraftDisplayName;
+          m_document.assets[m_assetDraftId] = std::move(def);
+          std::string metadataError;
+          if (!m_assetImportService.SaveMetadataForAsset(m_assetDraftId, m_document.assets[m_assetDraftId], &metadataError) &&
+              !metadataError.empty())
+          {
+            LOG_WARN("Create Asset metadata sync: %s", metadataError.c_str());
+          }
+          m_selectedAssetId = m_assetDraftId;
+          m_assetDraftId.clear();
+          m_assetDraftGuid.clear();
+          m_assetDraftDisplayName.clear();
+          m_assetDraftMesh.clear();
+          m_assetDraftRenderScale = "1.0000,1.0000,1.0000";
+          m_assetDraftAlbedoMap.clear();
+          m_assetImportError.clear();
           m_document.dirty = true;
           TriggerReload();
+          ImGui::CloseCurrentPopup();
         }
-        ImGui::SameLine(0.0f, gap);
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.45f, 0.18f, 0.18f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.55f, 0.22f, 0.22f, 1.0f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.65f, 0.15f, 0.15f, 1.0f));
-        if (ImGui::Button("Delete Asset##sel_del", ImVec2(btnW, 0.0f)))
-          RequestDeleteAsset(m_selectedAssetId);
-        ImGui::PopStyleColor(3);
+        if (!canCreate)
+          ImGui::EndDisabled();
 
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(150.0f, 0.0f)))
+        {
+          m_assetImportError.clear();
+          m_assetDraftGuid.clear();
+          m_assetDraftDisplayName.clear();
+          ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::PopItemWidth();
+        ImGui::EndPopup();
+      }
+
+      ImGui::End();
+    }
+
+    void EditorLayer::DrawHelpPopup()
+    {
+      if (!m_helpOpen)
+        return;
+      const std::span<const ShortcutRow> shortcuts = GetEditorShortcuts();
+
+      ImGuiIO &io = ImGui::GetIO();
+      ImGui::SetNextWindowSize(ImVec2(620.0f, 420.0f), ImGuiCond_FirstUseEver);
+      ImGui::SetNextWindowPos(ImVec2((io.DisplaySize.x - 620.0f) * 0.5f, (io.DisplaySize.y - 420.0f) * 0.5f),
+                              ImGuiCond_FirstUseEver);
+
+      if (!ImGui::Begin("Help - Keyboard Shortcuts", &m_helpOpen, ImGuiWindowFlags_NoCollapse))
+      {
         ImGui::End();
         return;
       }
-    }
 
-    ImGui::TextDisabled("No selection");
-    ImGui::TextDisabled("Pick an object or asset to edit properties.");
-    ImGui::End();
-    return;
-  }
+      ImGui::TextDisabled("Search by category, command, or key");
+      char searchBuf[256] = {};
+      std::snprintf(searchBuf, sizeof(searchBuf), "%s", m_helpSearchQuery.c_str());
+      if (ImGui::InputTextWithHint("##shortcut_search", "Find shortcut...", searchBuf, sizeof(searchBuf)))
+        m_helpSearchQuery = searchBuf;
 
-  SceneObject& obj = m_document.objects[primaryIdx];
+      ImGui::Separator();
+      ImGui::Columns(3, "shortcut_columns", false);
+      ImGui::SetColumnWidth(0, 130.0f);
+      ImGui::SetColumnWidth(1, 300.0f);
+      ImGui::TextUnformatted("Category");
+      ImGui::NextColumn();
+      ImGui::TextUnformatted("Command");
+      ImGui::NextColumn();
+      ImGui::TextUnformatted("Shortcut");
+      ImGui::NextColumn();
+      ImGui::Separator();
 
-  // ---- Identity ----
-  ImGui::LabelText("ID", "%s", obj.id.c_str());
-  const char* typeName = (obj.type == SceneObjectType::Prop)    ? "Prop"
-                         : (obj.type == SceneObjectType::Light) ? "Light"
-                         : (obj.type == SceneObjectType::Camera) ? "Camera"
-                                                                 : "Panel";
-  ImGui::LabelText("Type", "%s", typeName);
-  if (obj.prefabInstance.has_value()) {
-    ImGui::LabelText("Prefab", "%s", obj.prefabInstance->prefabId.c_str());
-    ImGui::TextDisabled("%s", obj.prefabInstance->sourcePath.c_str());
-  }
-
-  {
-    std::string currentParent = GetParentId(obj);
-    std::vector<std::string> parentIds;
-    std::vector<const char*> parentItems;
-    parentItems.push_back("<root>");
-    int currentIdx = 0;
-    for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-      if (i == primaryIdx || IsDescendantOf(m_document, i, primaryIdx))
-        continue;
-      const std::string& id = m_document.objects[static_cast<size_t>(i)].id;
-      parentIds.push_back(id);
-      parentItems.push_back(parentIds.back().c_str());
-      if (id == currentParent)
-        currentIdx = static_cast<int>(parentItems.size()) - 1;
-    }
-    if (ImGui::Combo("Parent", &currentIdx, parentItems.data(), static_cast<int>(parentItems.size()))) {
-      if (currentIdx == 0)
-        obj.props.erase("parentId");
-      else
-        obj.props["parentId"] = parentIds[static_cast<size_t>(currentIdx - 1)];
-      m_document.dirty = true;
-    }
-  }
-  ImGui::Separator();
-
-  // ---- Camera-specific properties ----
-  if (obj.type == SceneObjectType::Camera) {
-    const Vec3 oldPos = obj.position;
-    const Quaternion oldRot =
-        Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
-    bool changedTransform = false;
-
-    float pos[3] = {obj.position.x, obj.position.y, obj.position.z};
-    if (ImGui::DragFloat3("Position", pos, 0.05f)) {
-      obj.position = {pos[0], pos[1], pos[2]};
-      changedTransform = true;
-      m_document.dirty = true;
-      if (m_transformCb)
-        m_transformCb(obj);
-    }
-
-    if (ImGui::DragFloat("Yaw", &obj.yaw, 1.0f, -360.0f, 360.0f)) {
-      changedTransform = true;
-      m_document.dirty = true;
-      if (m_transformCb)
-        m_transformCb(obj);
-    }
-
-    float pitch = obj.pitch;
-    if (ImGui::DragFloat("Pitch", &pitch, 1.0f, -89.0f, 89.0f)) {
-      obj.pitch = std::max(-89.0f, std::min(89.0f, pitch));
-      changedTransform = true;
-      m_document.dirty = true;
-      if (m_transformCb)
-        m_transformCb(obj);
-    }
-
-    if (changedTransform) {
-      const Quaternion newRot =
-          Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
-      PropagateHierarchyTransformDelta(
-          m_document, primaryIdx, oldPos, oldRot, obj.position, newRot, m_transformCb);
-    }
-
-    ImGui::Separator();
-
-    // FOV
-    {
-      auto& fovStr = obj.props["fov"];
-      if (fovStr.empty()) fovStr = "60";
-      float fov = std::stof(fovStr);
-      if (ImGui::SliderFloat("FOV", &fov, 1.0f, 179.0f)) {
-        char tmp[32];
-        std::snprintf(tmp, sizeof(tmp), "%.4f", fov);
-        fovStr = tmp;
-        m_document.dirty = true;
-      }
-    }
-
-    // Near Clip
-    {
-      auto& nearStr = obj.props["nearClip"];
-      if (nearStr.empty()) nearStr = "0.1";
-      float v = std::stof(nearStr);
-      if (ImGui::DragFloat("Near Clip", &v, 0.01f, 0.001f, 100.0f)) {
-        char tmp[32];
-        std::snprintf(tmp, sizeof(tmp), "%.4f", v);
-        nearStr = tmp;
-        m_document.dirty = true;
-      }
-    }
-
-    // Far Clip
-    {
-      auto& farStr = obj.props["farClip"];
-      if (farStr.empty()) farStr = "500";
-      float v = std::stof(farStr);
-      if (ImGui::DragFloat("Far Clip", &v, 1.0f, 1.0f, 100000.0f)) {
-        char tmp[32];
-        std::snprintf(tmp, sizeof(tmp), "%.4f", v);
-        farStr = tmp;
-        m_document.dirty = true;
-      }
-    }
-
-    ImGui::Separator();
-
-    // Follow Target dropdown
-    {
-      auto& followId = obj.props["followTargetId"];
-      std::vector<const char*> targetItems;
-      targetItems.push_back("<none>");
-      int curTarget = 0;
-      int ti = 1;
-      for (const auto& other : m_document.objects) {
-        if (other.id == obj.id)
+      int shownCount = 0;
+      for (const auto &row : shortcuts)
+      {
+        if (!MatchesShortcutQuery(row, m_helpSearchQuery))
           continue;
-        targetItems.push_back(other.id.c_str());
-        if (other.id == followId)
-          curTarget = ti;
-        ++ti;
+
+        ImGui::TextDisabled("%s", row.category);
+        ImGui::NextColumn();
+        ImGui::TextUnformatted(row.command);
+        ImGui::NextColumn();
+        ImGui::TextColored(ImVec4(0.65f, 0.85f, 1.0f, 1.0f), "%s", row.keys);
+        ImGui::NextColumn();
+        ++shownCount;
       }
-      if (ImGui::Combo("Follow Target", &curTarget, targetItems.data(),
-                       static_cast<int>(targetItems.size()))) {
-        followId = (curTarget == 0) ? "" : targetItems[static_cast<size_t>(curTarget)];
-        m_document.dirty = true;
-      }
+
+      ImGui::Columns(1);
+      if (shownCount == 0)
+        ImGui::TextDisabled("No shortcut matches '%s'", m_helpSearchQuery.c_str());
+
+      ImGui::Separator();
+      ImGui::TextDisabled("Tip: press ? or F1 to close this window quickly.");
+      ImGui::End();
     }
 
-    ImGui::Separator();
-    if (ImGui::Button("Delete"))
-      RequestDeleteSelectedObjects();
-    ImGui::End();
-    return;
-  }
-
-  // ---- Transform (non-camera objects) ----
-  const Vec3 oldPos = obj.position;
-  const Quaternion oldRot =
-      Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
-  bool changedTransform = false;
-
-  float pos[3] = {obj.position.x, obj.position.y, obj.position.z};
-  if (ImGui::DragFloat3("Position", pos, 0.05f)) {
-    obj.position = {pos[0], pos[1], pos[2]};
-    changedTransform = true;
-    m_document.dirty = true;
-    if (m_transformCb)
-      m_transformCb(obj);
-  }
-
-  float scl[3] = {obj.scale.x, obj.scale.y, obj.scale.z};
-  if (ImGui::DragFloat3("Scale", scl, 0.02f, 0.01f, 200.0f)) {
-    obj.scale = {scl[0], scl[1], scl[2]};
-    m_document.dirty = true;
-    if (m_transformCb)
-      m_transformCb(obj);
-  }
-
-  // ---- Rotation (Euler angles: Pitch / Yaw / Roll) ----
-  float rot[3] = {obj.pitch, obj.yaw, obj.roll};
-  if (ImGui::DragFloat3("Rotation (P/Y/R)", rot, 1.0f, -360.0f, 360.0f)) {
-    obj.pitch = rot[0];
-    obj.yaw = rot[1];
-    obj.roll = rot[2];
-    changedTransform = true;
-    m_document.dirty = true;
-    if (m_transformCb)
-      m_transformCb(obj);
-  }
-
-  if (changedTransform) {
-    const Quaternion newRot =
-        Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
-    PropagateHierarchyTransformDelta(
-        m_document, primaryIdx, oldPos, oldRot, obj.position, newRot, m_transformCb);
-  }
-
-  ImGui::Separator();
-  ImGui::Text("Asset");
-
-  std::vector<const char*> assetItems;
-  assetItems.reserve(m_document.assets.size() + 1);
-  assetItems.push_back("<none>");
-  int currentAssetIndex = 0;
-  int assetIndex = 1;
-  for (const auto& [assetId, _] : m_document.assets) {
-    assetItems.push_back(assetId.c_str());
-    if (obj.assetId == assetId)
-      currentAssetIndex = assetIndex;
-    ++assetIndex;
-  }
-
-  if (ImGui::Combo("Asset ID", &currentAssetIndex, assetItems.data(), static_cast<int>(assetItems.size()))) {
-    if (currentAssetIndex == 0)
-      obj.assetId.clear();
-    else
-      obj.assetId = assetItems[static_cast<size_t>(currentAssetIndex)];
-    SyncAssetScaleMetadata(&m_document);
-    m_document.dirty = true;
-    TriggerReload();
-  }
-
-  if (!obj.assetId.empty()) {
-    auto assetIt = m_document.assets.find(obj.assetId);
-    if (assetIt != m_document.assets.end()) {
-      ImGui::TextDisabled("mesh: %s", assetIt->second.mesh.c_str());
-      ImGui::TextDisabled("renderScale: %s", assetIt->second.renderScale.c_str());
-    } else {
-      ImGui::TextColored(ImVec4(1.0f, 0.55f, 0.35f, 1.0f), "Missing asset: %s", obj.assetId.c_str());
-    }
-  }
-
-  ImGui::Separator();
-  ImGui::Text("Props");
-
-  // ---- Schema-driven fields ----
-  const TypeSchema* schema = m_schema.GetSchema(obj.type);
-  if (schema) {
-    for (const auto& fd : schema->fields) {
-      std::string& val = obj.props[fd.key];
-      if (val.empty())
-        val = fd.defaultValue;
-
-      switch (fd.widget) {
-        case FieldDef::Widget::String: {
-          char buf[256] = {};
-          std::snprintf(buf, sizeof(buf), "%s", val.c_str());
-          if (ImGui::InputText(fd.label.c_str(), buf, sizeof(buf))) {
-            val = buf;
-            m_document.dirty = true;
-            if (obj.type == SceneObjectType::Light && m_transformCb)
-              m_transformCb(obj);
-          }
-          break;
-        }
-        case FieldDef::Widget::Float: {
-          float f = val.empty() ? fd.minVal : std::stof(val);
-          if (ImGui::SliderFloat(fd.label.c_str(), &f, fd.minVal, fd.maxVal)) {
-            char tmp[32];
-            std::snprintf(tmp, sizeof(tmp), "%.4f", f);
-            val = tmp;
-            m_document.dirty = true;
-            if (obj.type == SceneObjectType::Light && m_transformCb)
-              m_transformCb(obj);
-          }
-          break;
-        }
-        case FieldDef::Widget::Bool: {
-          bool b = (val == "true" || val == "1");
-          if (ImGui::Checkbox(fd.label.c_str(), &b)) {
-            val = b ? "true" : "false";
-            m_document.dirty = true;
-            if (obj.type == SceneObjectType::Light && m_transformCb)
-              m_transformCb(obj);
-          }
-          break;
-        }
-        case FieldDef::Widget::Enum: {
-          int cur = 0;
-          for (int i = 0; i < static_cast<int>(fd.options.size()); ++i)
-            if (fd.options[i] == val) {
-              cur = i;
-              break;
-            }
-
-          // Build null-separated list for ImGui::Combo
-          std::string items;
-          for (auto& opt : fd.options) {
-            items += opt;
-            items += '\0';
-          }
-          items += '\0';
-
-          if (ImGui::Combo(fd.label.c_str(), &cur, items.c_str())) {
-            val = fd.options[static_cast<size_t>(cur)];
-            m_document.dirty = true;
-            if (obj.type == SceneObjectType::Light && m_transformCb)
-              m_transformCb(obj);
-          }
-          break;
-        }
-        case FieldDef::Widget::Color3: {
-          float col[3] = {1.0f, 1.0f, 1.0f};
-          if (!val.empty()) {
-            // Parse "r,g,b" using strtof to avoid MSVC sscanf deprecation
-            char tmp[64] = {};
-            std::snprintf(tmp, sizeof(tmp), "%s", val.c_str());
-            char* p = tmp;
-            char* end = nullptr;
-            col[0] = std::strtof(p, &end);
-            if (end && *end)
-              p = end + 1;
-            col[1] = std::strtof(p, &end);
-            if (end && *end)
-              p = end + 1;
-            col[2] = std::strtof(p, nullptr);
-          }
-          if (ImGui::ColorEdit3(fd.label.c_str(), col)) {
-            char tmp[64];
-            std::snprintf(tmp, sizeof(tmp), "%.4f,%.4f,%.4f", col[0], col[1], col[2]);
-            val = tmp;
-            m_document.dirty = true;
-            if (obj.type == SceneObjectType::Light && m_transformCb)
-              m_transformCb(obj);
-          }
-          break;
-        }
+    void EditorLayer::DrawCommandPalettePopup()
+    {
+      if (m_commandPaletteOpen)
+      {
+        ImGui::SetNextWindowSize(ImVec2(520.0f, 0.0f), ImGuiCond_Appearing);
+        if (!ImGui::IsPopupOpen("Command Palette"))
+          ImGui::OpenPopup("Command Palette");
       }
-    }
-  }
 
-  // ---- Components ----
-  ImGui::Separator();
-  ImGui::Text("Components");
+      if (!ImGui::BeginPopupModal("Command Palette", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        return;
 
-  int removeIdx = -1;
-  for (int ci = 0; ci < static_cast<int>(obj.components.size()); ++ci) {
-    ComponentDesc& comp = obj.components[ci];
+      ImGui::TextDisabled("Search commands");
+      ImGui::SetNextItemWidth(480.0f);
+      char queryBuf[256] = {};
+      std::snprintf(queryBuf, sizeof(queryBuf), "%s", m_commandPaletteQuery.c_str());
+      if (ImGui::InputTextWithHint("##command_palette_input",
+                                   "Type a command...",
+                                   queryBuf,
+                                   sizeof(queryBuf)))
+      {
+        m_commandPaletteQuery = queryBuf;
+      }
 
-    // Collapsing header label + inline [x] button via ID stack trick
-    std::string headerLabel = (comp.type == "light")      ? "Light"
-                              : (comp.type == "rigidbody") ? "RigidBody"
-                              : (comp.type == "script")    ? "Script"
-                                                           : comp.type;
-    ImGui::PushID(ci);
-    bool open = ImGui::CollapsingHeader(headerLabel.c_str(), ImGuiTreeNodeFlags_DefaultOpen);
-    bool removeThisComponent = false;
+      ImGui::Separator();
+      bool executed = false;
+      int shownCount = 0;
+      for (const CommandPaletteRow &row : GetEditorCommands())
+      {
+        if (!MatchesCommandPaletteQuery(row, m_commandPaletteQuery))
+          continue;
 
-    if (ImGui::BeginPopupContextItem("comp_ctx")) {
-      if (ImGui::MenuItem("Remove Component"))
-        removeThisComponent = true;
+        const std::string label = std::string(row.command) + "##cmd_" + row.id;
+        if (ImGui::Selectable(label.c_str(), false))
+        {
+          ExecuteCommandPaletteAction(row.id);
+          executed = true;
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", row.keys);
+        ++shownCount;
+      }
+
+      if (shownCount == 0)
+        ImGui::TextDisabled("No command matches '%s'", m_commandPaletteQuery.c_str());
+
+      if (executed || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape))
+      {
+        m_commandPaletteOpen = false;
+        ImGui::CloseCurrentPopup();
+      }
+
       ImGui::EndPopup();
     }
 
-    // Remove button on the same line, right-aligned
-    float btnW = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
-    ImGui::SameLine(ImGui::GetContentRegionAvail().x - btnW);
-    if (ImGui::SmallButton("x"))
-      removeThisComponent = true;
-
-    if (removeThisComponent)
-      removeIdx = ci;
-
-    if (open) {
-      if (comp.type == "light") {
-        // Intensity
-        {
-          float v = comp.props.count("intensity") ? std::strtof(comp.props["intensity"].c_str(), nullptr) : 1.0f;
-          if (ImGui::SliderFloat("Intensity", &v, 0.0f, 10.0f)) {
-            char tmp[32];
-            std::snprintf(tmp, sizeof(tmp), "%.4f", v);
-            comp.props["intensity"] = tmp;
-            m_document.dirty = true;
-          }
-        }
-        // Color
-        {
-          float col[3] = {1.0f, 1.0f, 1.0f};
-          if (comp.props.count("color")) {
-            char tmp[64] = {};
-            std::snprintf(tmp, sizeof(tmp), "%s", comp.props["color"].c_str());
-            char* p = tmp;
-            char* end = nullptr;
-            col[0] = std::strtof(p, &end);
-            if (end && *end) p = end + 1;
-            col[1] = std::strtof(p, &end);
-            if (end && *end) p = end + 1;
-            col[2] = std::strtof(p, nullptr);
-          }
-          if (ImGui::ColorEdit3("Color", col)) {
-            char tmp[64];
-            std::snprintf(tmp, sizeof(tmp), "%.4f,%.4f,%.4f", col[0], col[1], col[2]);
-            comp.props["color"] = tmp;
-            m_document.dirty = true;
-          }
-        }
-        // Radius
-        {
-          float v = comp.props.count("radius") ? std::strtof(comp.props["radius"].c_str(), nullptr) : 5.0f;
-          if (ImGui::DragFloat("Radius", &v, 0.1f, 0.0f, 100.0f)) {
-            char tmp[32];
-            std::snprintf(tmp, sizeof(tmp), "%.4f", v);
-            comp.props["radius"] = tmp;
-            m_document.dirty = true;
-          }
-        }
-      } else if (comp.type == "rigidbody") {
-        // Mass
-        {
-          float v = comp.props.count("mass") ? std::strtof(comp.props["mass"].c_str(), nullptr) : 1.0f;
-          if (ImGui::DragFloat("Mass", &v, 0.1f, 0.0f, 10000.0f)) {
-            char tmp[32];
-            std::snprintf(tmp, sizeof(tmp), "%.4f", v);
-            comp.props["mass"] = tmp;
-            m_document.dirty = true;
-          }
-        }
-        // Is Kinematic
-        {
-          bool b = comp.props.count("isKinematic") && comp.props["isKinematic"] == "true";
-          if (ImGui::Checkbox("Is Kinematic", &b)) {
-            comp.props["isKinematic"] = b ? "true" : "false";
-            m_document.dirty = true;
-          }
-        }
-        // Use Gravity
-        {
-          bool b = !comp.props.count("useGravity") || comp.props["useGravity"] == "true";
-          if (ImGui::Checkbox("Use Gravity", &b)) {
-            comp.props["useGravity"] = b ? "true" : "false";
-            m_document.dirty = true;
-          }
-        }
-      } else if (comp.type == "script") {
-        std::vector<std::string> options;
-        if (m_scriptBehaviorOptionsCb)
-          options = m_scriptBehaviorOptionsCb();
-        options.erase(std::remove_if(options.begin(), options.end(), [](const std::string& s) {
-                        return s.empty();
-                      }),
-                      options.end());
-        std::sort(options.begin(), options.end());
-        options.erase(std::unique(options.begin(), options.end()), options.end());
-
-        std::string current = comp.props["behaviorTag"];
-        if (!current.empty() && std::find(options.begin(), options.end(), current) == options.end())
-          options.push_back(current);
-
-        std::vector<const char*> labels;
-        labels.reserve(options.size() + 1);
-        labels.push_back("<none>");
-        int currentIdx = 0;
-        for (int i = 0; i < static_cast<int>(options.size()); ++i) {
-          labels.push_back(options[static_cast<size_t>(i)].c_str());
-          if (options[static_cast<size_t>(i)] == current)
-            currentIdx = i + 1;
-        }
-
-        if (ImGui::Combo("Behavior", &currentIdx, labels.data(), static_cast<int>(labels.size()))) {
-          comp.props["behaviorTag"] = (currentIdx == 0) ? "" : options[static_cast<size_t>(currentIdx - 1)];
-          m_document.dirty = true;
-        }
+    void EditorLayer::DrawQuickOpenPopup()
+    {
+      if (m_quickOpenOpen)
+      {
+        ImGui::SetNextWindowSize(ImVec2(560.0f, 0.0f), ImGuiCond_Appearing);
+        if (!ImGui::IsPopupOpen("Quick Open"))
+          ImGui::OpenPopup("Quick Open");
       }
-    }
-    ImGui::PopID();
-  }
 
-  if (removeIdx >= 0) {
-    obj.components.erase(obj.components.begin() + removeIdx);
-    m_document.dirty = true;
-  }
+      if (!ImGui::BeginPopupModal("Quick Open", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        return;
 
-  // ---- Add Component button ----
-  ImGui::Spacing();
-  if (ImGui::Button("+ Add Component")) {
-    ImGui::OpenPopup("##add_component_popup");
-  }
-  if (ImGui::BeginPopup("##add_component_popup")) {
-    std::vector<const ComponentSchema*> componentSchemas;
-    componentSchemas.reserve(m_schema.ComponentSchemas().size());
-    for (const auto& entry : m_schema.ComponentSchemas()) {
-      if (SchemaAppliesToObjectType(entry.second.appliesTo, obj.type))
-        componentSchemas.push_back(&entry.second);
-    }
-    std::sort(componentSchemas.begin(), componentSchemas.end(),
-              [](const ComponentSchema* lhs, const ComponentSchema* rhs) {
-                const std::string lhsLabel = lhs ? lhs->label : std::string();
-                const std::string rhsLabel = rhs ? rhs->label : std::string();
-                if (lhsLabel != rhsLabel)
-                  return lhsLabel < rhsLabel;
-                return lhs && rhs ? lhs->name < rhs->name : lhs < rhs;
-              });
+      ImGui::TextDisabled("Open object or asset");
+      ImGui::SetNextItemWidth(520.0f);
+      char queryBuf[256] = {};
+      std::snprintf(queryBuf, sizeof(queryBuf), "%s", m_quickOpenQuery.c_str());
+      if (ImGui::InputTextWithHint("##quick_open_input", "Type id, type, asset, or mesh...", queryBuf, sizeof(queryBuf)))
+        m_quickOpenQuery = queryBuf;
 
-    if (!componentSchemas.empty()) {
-      for (const ComponentSchema* componentSchema : componentSchemas) {
-        if (!componentSchema)
+      ImGui::Separator();
+
+      bool picked = false;
+      int shownCount = 0;
+
+      ImGui::TextDisabled("Objects");
+      for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+      {
+        const auto &obj = m_document.objects[i];
+        const char *typeName = ObjectTypeLabel(obj.type);
+
+        if (!ObjectMatchesQuickOpenQuery(obj, m_quickOpenQuery))
           continue;
-        const std::string menuLabel =
-            componentSchema->label.empty() ? componentSchema->name : componentSchema->label;
-        if (ImGui::MenuItem(menuLabel.c_str())) {
-          ComponentDesc component;
-          component.type = componentSchema->name;
-          ApplyComponentSchemaDefaults(component);
-          obj.components.push_back(std::move(component));
+
+        const std::string label = "Object: " + obj.id + "##quick_open_obj_" + std::to_string(i);
+        if (ImGui::Selectable(label.c_str(), IsSelected(i)))
+        {
+          m_selectedIndices = {i};
+          picked = true;
+        }
+        ImGui::SameLine();
+        if (obj.assetId.empty())
+          ImGui::TextDisabled("type: %s", typeName);
+        else
+          ImGui::TextDisabled("type: %s  |  asset: %s", typeName, obj.assetId.c_str());
+        ++shownCount;
+      }
+
+      ImGui::Spacing();
+      ImGui::TextDisabled("Assets");
+      for (const auto &[assetId, asset] : m_document.assets)
+      {
+        if (!AssetMatchesQuickOpenQuery(assetId, asset, m_quickOpenQuery))
+          continue;
+
+        const std::string label = "Asset: " + assetId + "##quick_open_asset_" + assetId;
+        if (ImGui::Selectable(label.c_str(), m_selectedAssetId == assetId))
+        {
+          m_selectedAssetId = assetId;
+          picked = true;
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("mesh: %s", asset.mesh.c_str());
+        ++shownCount;
+      }
+
+      if (shownCount == 0)
+        ImGui::TextDisabled("No match for '%s'", m_quickOpenQuery.c_str());
+
+      if (picked || ImGui::Button("Close") || ImGui::IsKeyPressed(ImGuiKey_Escape))
+      {
+        m_quickOpenOpen = false;
+        ImGui::CloseCurrentPopup();
+      }
+
+      ImGui::EndPopup();
+    }
+
+    void EditorLayer::DrawDeleteConfirmModals()
+    {
+      if (m_confirmDeleteObjectsOpen)
+        ImGui::OpenPopup("Confirm Delete Objects");
+
+      if (ImGui::BeginPopupModal("Confirm Delete Objects", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+      {
+        int validCount = 0;
+        for (int idx : m_pendingDeleteObjectIndices)
+          if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+            ++validCount;
+
+        if (validCount <= 0)
+        {
+          m_confirmDeleteObjectsOpen = false;
+          m_pendingDeleteObjectIndices.clear();
+          ImGui::CloseCurrentPopup();
+          ImGui::EndPopup();
+          return;
+        }
+
+        ImGui::Text("Delete %d selected object(s)?", validCount);
+        ImGui::TextDisabled("This action cannot be undone.");
+        ImGui::Separator();
+
+        if (ImGui::Button("Cancel", ImVec2(110.0f, 0.0f)))
+        {
+          m_confirmDeleteObjectsOpen = false;
+          m_pendingDeleteObjectIndices.clear();
+          ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Delete", ImVec2(110.0f, 0.0f)))
+        {
+          std::vector<int> sorted = m_pendingDeleteObjectIndices;
+          std::sort(sorted.rbegin(), sorted.rend());
+          for (int idx : sorted)
+          {
+            if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+              m_document.objects.erase(m_document.objects.begin() + idx);
+          }
+          m_selectedIndices.clear();
           m_document.dirty = true;
+          TriggerReload();
+
+          m_confirmDeleteObjectsOpen = false;
+          m_pendingDeleteObjectIndices.clear();
+          ImGui::CloseCurrentPopup();
         }
+
+        ImGui::EndPopup();
       }
-    } else {
-      if (ImGui::MenuItem("Light")) {
-        ComponentDesc component;
-        component.type = "light";
-        ApplyComponentSchemaDefaults(component);
-        if (component.props.empty()) {
-          component.props["intensity"] = "1.0000";
-          component.props["color"] = "1.0000,1.0000,1.0000";
-          component.props["radius"] = "5.0000";
+
+      if (m_confirmDeleteAssetOpen)
+        ImGui::OpenPopup("Confirm Delete Asset");
+
+      if (ImGui::BeginPopupModal("Confirm Delete Asset", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+      {
+        if (m_pendingDeleteAssetId.empty() ||
+            m_document.assets.find(m_pendingDeleteAssetId) == m_document.assets.end())
+        {
+          m_confirmDeleteAssetOpen = false;
+          m_pendingDeleteAssetId.clear();
+          m_pendingDeleteAssetError.clear();
+          ImGui::CloseCurrentPopup();
+          ImGui::EndPopup();
+          return;
         }
-        obj.components.push_back(std::move(component));
-        m_document.dirty = true;
-      }
-      if (ImGui::MenuItem("RigidBody")) {
-        ComponentDesc component;
-        component.type = "rigidbody";
-        ApplyComponentSchemaDefaults(component);
-        if (component.props.empty()) {
-          component.props["mass"] = "1.0000";
-          component.props["isKinematic"] = "false";
-          component.props["useGravity"] = "true";
+
+        const std::filesystem::path managedDirectory =
+            GetManagedImportedAssetDirectory(m_document.assets.at(m_pendingDeleteAssetId));
+
+        ImGui::Text("Delete asset '%s'?", m_pendingDeleteAssetId.c_str());
+        ImGui::TextDisabled("All object bindings to this asset will be cleared.");
+        if (!managedDirectory.empty())
+        {
+          ImGui::TextDisabled("Imported project files will also be removed:");
+          ImGui::TextWrapped("%s", managedDirectory.generic_string().c_str());
         }
-        obj.components.push_back(std::move(component));
-        m_document.dirty = true;
+        else
+        {
+          ImGui::TextDisabled("No managed imported asset folder was detected; only the asset record will be removed.");
+        }
+        if (!m_pendingDeleteAssetError.empty())
+        {
+          ImGui::Spacing();
+          ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 360.0f);
+          ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_pendingDeleteAssetError.c_str());
+          ImGui::PopTextWrapPos();
+        }
+        ImGui::Separator();
+
+        if (ImGui::Button("Cancel", ImVec2(110.0f, 0.0f)))
+        {
+          m_confirmDeleteAssetOpen = false;
+          m_pendingDeleteAssetId.clear();
+          m_pendingDeleteAssetError.clear();
+          ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Delete", ImVec2(110.0f, 0.0f)))
+        {
+          const AssetDeleteResult deleteResult = DeleteAssetDefinition(m_pendingDeleteAssetId);
+          if (!deleteResult.ok)
+          {
+            m_pendingDeleteAssetError = deleteResult.error;
+          }
+          else
+          {
+            m_confirmDeleteAssetOpen = false;
+            m_pendingDeleteAssetId.clear();
+            m_pendingDeleteAssetError.clear();
+            ImGui::CloseCurrentPopup();
+          }
+        }
+
+        ImGui::EndPopup();
       }
-      if (ImGui::MenuItem("Script")) {
-        ComponentDesc component;
-        component.type = "script";
-        ApplyComponentSchemaDefaults(component);
-        if (component.props.empty())
-          component.props["behaviorTag"] = "";
-        obj.components.push_back(std::move(component));
-        m_document.dirty = true;
-      }
-    }
-    ImGui::EndPopup();
-  }
-
-  ImGui::Separator();
-  if (ImGui::Button("Delete")) {
-    RequestDeleteSelectedObjects();
-  }
-
-  ImGui::End();
-}
-
-// ---- Picking -----------------------------------------------------------------
-
-void EditorLayer::HandlePicking(const Camera& cam, int screenW, int screenH) {
-  bool currL = glfwGetMouseButton(m_window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS;
-  bool clicked = currL && !m_prevMouseL;
-  m_prevMouseL = currL;
-
-  if (!clicked)
-    return;
-
-  double mx, my;
-  glfwGetCursorPos(m_window, &mx, &my);
-  if (!m_viewportPanelRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
-    return;
-  if (ImGui::GetIO().WantCaptureMouse &&
-      !m_viewportPanelRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
-    return;
-  const ImGuiIO& io = ImGui::GetIO();
-  const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
-  const EditorViewGimbalLayout viewGimbalLayout =
-      BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
-  if (viewGimbalLayout.pickRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
-    return;
-  if (m_viewGizmoPickRect.valid &&
-      m_viewGizmoPickRect.Contains(static_cast<float>(mx), static_cast<float>(my), 2.0f))
-    return;
-
-  Ray ray = ScreenToRay(static_cast<float>(mx), static_cast<float>(my), screenW, screenH, cam);
-
-  float bestT = std::numeric_limits<float>::max();
-  int bestIdx = -1;
-
-  for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-    const auto& obj = m_document.objects[i];
-    Vec3 center = obj.position;
-    Vec3 half = {std::max(obj.scale.x, 0.25f), std::max(obj.scale.y, 0.25f),
-                 std::max(obj.scale.z, 0.25f)};
-    if (m_liveRegistry && TryPropWorldAabb(*m_liveRegistry, obj, center, half)) {
-      half.x = std::max(half.x, 0.25f);
-      half.y = std::max(half.y, 0.25f);
-      half.z = std::max(half.z, 0.25f);
-    }
-    float t = RayVsAABB(ray, center, half);
-    if (t >= 0.0f && t < bestT) {
-      bestT = t;
-      bestIdx = i;
-    }
-  }
-
-  bool shiftHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
-                   glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
-
-  if (bestIdx >= 0) {
-    if (shiftHeld)
-      ToggleSelect(bestIdx);
-    else
-      m_selectedIndices = {bestIdx};
-  } else if (!shiftHeld) {
-    m_selectedIndices.clear();
-  }
-}
-
-void EditorLayer::DrawSelectionHighlight() {
-  const int n = static_cast<int>(m_document.objects.size());
-  for (int i : m_selectedIndices) {
-    if (i < 0 || i >= n)
-      continue;
-    const auto& obj = m_document.objects[i];
-
-    if (obj.type == SceneObjectType::Camera) {
-      const Vec4 color = {0.2f, 0.7f, 1.0f, 1.0f};
-      const float yawRad = ToRadians(obj.yaw);
-      const float pitchRad = ToRadians(std::max(-89.0f, std::min(89.0f, obj.pitch)));
-      const Vec3 forward = {-std::sin(yawRad) * std::cos(pitchRad),
-                            std::sin(pitchRad),
-                            -std::cos(yawRad) * std::cos(pitchRad)};
-
-      Vec3 right = Vec3::Cross(forward, Vec3::Up());
-      if (right.LengthSq() < 1e-5f)
-        right = {1.0f, 0.0f, 0.0f};
-      else
-        right = right.Normalized();
-      Vec3 up = Vec3::Cross(right, forward).Normalized();
-
-      const Vec3 tip = obj.position;
-      const Vec3 baseCenter = tip + forward * 0.55f;
-      const float baseHalfW = 0.24f;
-      const float baseHalfH = 0.16f;
-
-      const Vec3 b0 = baseCenter + right * baseHalfW + up * baseHalfH;
-      const Vec3 b1 = baseCenter - right * baseHalfW + up * baseHalfH;
-      const Vec3 b2 = baseCenter - right * baseHalfW - up * baseHalfH;
-      const Vec3 b3 = baseCenter + right * baseHalfW - up * baseHalfH;
-
-      DebugDraw::Line(tip, b0, color);
-      DebugDraw::Line(tip, b1, color);
-      DebugDraw::Line(tip, b2, color);
-      DebugDraw::Line(tip, b3, color);
-      DebugDraw::Line(b0, b1, color);
-      DebugDraw::Line(b1, b2, color);
-      DebugDraw::Line(b2, b3, color);
-      DebugDraw::Line(b3, b0, color);
-
-      const Vec3 dirTip = tip + forward * 0.78f;
-      DebugDraw::Line(tip, dirTip, {1.0f, 0.55f, 0.1f, 1.0f});
-      continue;
     }
 
-    Vec3 center = obj.position;
-    Vec3 half = obj.scale;
-    if (!m_liveRegistry || !TryPropWorldAabb(*m_liveRegistry, obj, center, half))
-      half = {std::max(half.x, 0.25f), std::max(half.y, 0.25f), std::max(half.z, 0.25f)};
-    else {
-      half.x = std::max(half.x, 0.25f);
-      half.y = std::max(half.y, 0.25f);
-      half.z = std::max(half.z, 0.25f);
-    }
-    DebugDraw::Box(center, half, {0.2f, 0.7f, 1.0f, 1.0f});
-  }
-}
+    void EditorLayer::DrawExitConfirmModal()
+    {
+      if (m_confirmExitOpen)
+        ImGui::OpenPopup("Unsaved Changes");
 
-void EditorLayer::ApplyPendingViewSnap(Camera& cam) {
-  if (m_pendingViewSnap == ViewSnap::None)
-    return;
+      if (!ImGui::BeginPopupModal("Unsaved Changes", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        return;
 
-  Vec3 pivot = Vec3::Zero();
-  float extent = 1.0f;
-  const int idx = PrimaryIdx();
-  if (idx >= 0 && idx < static_cast<int>(m_document.objects.size())) {
-    const SceneObject& obj = m_document.objects[idx];
-    pivot = obj.position;
-    extent = std::max(obj.scale.x, std::max(obj.scale.y, obj.scale.z));
-  }
-
-  const float distance = std::max(2.0f, extent * 3.0f + 1.0f);
-
-  cam.target = pivot;
-  cam.up = {0.0f, 1.0f, 0.0f};
-
-  switch (m_pendingViewSnap) {
-    case ViewSnap::Top:
-      cam.position = pivot + Vec3{0.0f, distance, 0.0f};
-      cam.up = {0.0f, 0.0f, -1.0f};
-      break;
-    case ViewSnap::Bottom:
-      cam.position = pivot + Vec3{0.0f, -distance, 0.0f};
-      cam.up = {0.0f, 0.0f, 1.0f};
-      break;
-    case ViewSnap::Left:
-      cam.position = pivot + Vec3{-distance, 0.0f, 0.0f};
-      break;
-    case ViewSnap::Right:
-      cam.position = pivot + Vec3{distance, 0.0f, 0.0f};
-      break;
-    case ViewSnap::Front:
-      cam.position = pivot + Vec3{0.0f, 0.0f, distance};
-      break;
-    case ViewSnap::Back:
-      cam.position = pivot + Vec3{0.0f, 0.0f, -distance};
-      break;
-    case ViewSnap::None:
-      break;
-  }
-
-  m_flyCamInitialized = false;
-  m_pendingViewSnap = ViewSnap::None;
-}
-
-// ---- Helpers -----------------------------------------------------------------
-
-bool EditorLayer::IsSelected(int i) const {
-  return std::find(m_selectedIndices.begin(), m_selectedIndices.end(), i) !=
-         m_selectedIndices.end();
-}
-
-int EditorLayer::PrimaryIdx() const {
-  return m_selectedIndices.empty() ? -1 : m_selectedIndices.back();
-}
-
-void EditorLayer::ToggleSelect(int i) {
-  auto it = std::find(m_selectedIndices.begin(), m_selectedIndices.end(), i);
-  if (it != m_selectedIndices.end())
-    m_selectedIndices.erase(it);
-  else
-    m_selectedIndices.push_back(i);
-}
-
-void EditorLayer::TriggerReload() {
-  m_pendingDoc = m_document;
-  m_wantsReload = true;
-}
-
-std::vector<std::string> EditorLayer::GetSelectedObjectIds() const {
-  std::vector<std::string> ids;
-  ids.reserve(m_selectedIndices.size());
-  for (int idx : m_selectedIndices) {
-    if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-      ids.push_back(m_document.objects[static_cast<size_t>(idx)].id);
-  }
-  return ids;
-}
-
-void EditorLayer::SetSelectedObjectIds(const std::vector<std::string>& ids) {
-  m_selectedIndices.clear();
-  std::unordered_set<std::string> seen;
-  seen.reserve(ids.size());
-  for (const std::string& id : ids) {
-    if (id.empty() || !seen.insert(id).second)
-      continue;
-    for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-      if (m_document.objects[static_cast<size_t>(i)].id == id) {
-        m_selectedIndices.push_back(i);
+      const char *actionLabel = "continue";
+      switch (m_pendingSceneAction)
+      {
+      case PendingSceneAction::NewScene:
+        actionLabel = "create a new scene";
+        break;
+      case PendingSceneAction::OpenSceneFile:
+        actionLabel = "open another scene";
+        break;
+      case PendingSceneAction::LoadSceneFromDisk:
+        actionLabel = "load the scene from disk";
+        break;
+      case PendingSceneAction::ReloadSceneFromDisk:
+        actionLabel = "reload the scene";
+        break;
+      case PendingSceneAction::CloseEditor:
+        actionLabel = "exit editor mode";
+        break;
+      case PendingSceneAction::None:
         break;
       }
+
+      ImGui::TextUnformatted("You have unsaved changes.");
+      ImGui::TextDisabled("Save or discard them before you %s.", actionLabel);
+      ImGui::Separator();
+
+      if (!m_exitConfirmError.empty())
+        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", m_exitConfirmError.c_str());
+
+      if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f)))
+      {
+        m_confirmExitOpen = false;
+        m_exitConfirmError.clear();
+        m_pendingSceneAction = PendingSceneAction::None;
+        ImGui::CloseCurrentPopup();
+      }
+
+      ImGui::SameLine();
+      if (ImGui::Button("Discard", ImVec2(120.0f, 0.0f)))
+      {
+        if (m_pendingSceneAction == PendingSceneAction::CloseEditor)
+          DiscardUnsavedChanges();
+        m_confirmExitOpen = false;
+        m_exitConfirmError.clear();
+        ImGui::CloseCurrentPopup();
+        std::string actionError;
+        if (!ExecutePendingSceneAction(&actionError))
+          m_exitConfirmError = actionError;
+      }
+
+      ImGui::SameLine();
+      if (ImGui::Button("Save & Continue", ImVec2(120.0f, 0.0f)))
+      {
+        std::string saveError;
+        if (SaveDocument(&saveError))
+        {
+          m_confirmExitOpen = false;
+          m_exitConfirmError.clear();
+          ImGui::CloseCurrentPopup();
+          std::string actionError;
+          if (!ExecutePendingSceneAction(&actionError))
+            m_exitConfirmError = actionError;
+        }
+        else
+        {
+          m_exitConfirmError = saveError;
+        }
+      }
+
+      ImGui::EndPopup();
     }
-  }
-}
 
-bool EditorLayer::ReloadDocumentFromDisk(std::string* outError,
-                                         const std::vector<std::string>* preferredSelectionIds,
-                                         const std::string* preferredAssetId) {
-  if (outError)
-    outError->clear();
+    // ---- Properties panel --------------------------------------------------------
 
-  const std::string path = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
-  try {
-    SceneDocument reloaded = SceneSerializer::LoadFromFile(path);
-    reloaded.dirty = false;
-    ApplyLoadedDocument(std::move(reloaded), false);
-    m_document.filePath = path;
-    m_lastSavedDocument = m_document;
-    if (preferredSelectionIds)
-      SetSelectedObjectIds(*preferredSelectionIds);
-    if (preferredAssetId && m_document.assets.find(*preferredAssetId) != m_document.assets.end())
-      m_selectedAssetId = *preferredAssetId;
-    TriggerReload();
-    return true;
-  } catch (const std::exception& e) {
-    if (outError)
-      *outError = e.what();
-    return false;
-  }
-}
+    void EditorLayer::DrawPropertiesPanel()
+    {
+      ImGuiIO &io = ImGui::GetIO();
+      const float bottomDockH = ComputeEditorBottomDockHeight(io.DisplaySize.y);
+      const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+      const float workBottom = io.DisplaySize.y - kEditorStatusH - bottomDockH;
+      ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x - rightDockW, kEditorToolbarH), ImGuiCond_Always);
+      ImGui::SetNextWindowSize(ImVec2(rightDockW, std::max(260.0f, workBottom - kEditorToolbarH)),
+                               ImGuiCond_Always);
+      ImGui::Begin(kEditorPropertiesWindow, nullptr, kMainPanelWindowFlags);
 
-bool EditorLayer::HistorySnapshotsEqual(const EditorHistorySnapshot& lhs,
-                                        const EditorHistorySnapshot& rhs) {
-  return SceneDocumentsEqual(lhs.document, rhs.document) &&
-         SceneDocumentsEqual(lhs.savedDocument, rhs.savedDocument) &&
-         lhs.selectedObjectIds == rhs.selectedObjectIds &&
-         lhs.selectedAssetId == rhs.selectedAssetId;
-}
+      // ---- Multi-selection summary ----
+      if (m_selectedIndices.size() > 1)
+      {
+        ImGui::Text("%d objects selected", static_cast<int>(m_selectedIndices.size()));
+        ImGui::Separator();
 
-void EditorLayer::TrimHistory(std::vector<EditorHistorySnapshot>* history) {
-  if (!history)
-    return;
-  if (history->size() <= kMaxEditorHistorySnapshots)
-    return;
-  history->erase(history->begin(),
-                 history->begin() + static_cast<std::ptrdiff_t>(history->size() - kMaxEditorHistorySnapshots));
-}
+        std::string sharedAssetId;
+        bool hasSharedAssetId = true;
+        bool firstObject = true;
+        for (int idx : m_selectedIndices)
+        {
+          if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
+            continue;
+          const SceneObject &selected = m_document.objects[static_cast<size_t>(idx)];
+          if (firstObject)
+          {
+            sharedAssetId = selected.assetId;
+            firstObject = false;
+          }
+          else if (sharedAssetId != selected.assetId)
+          {
+            hasSharedAssetId = false;
+            break;
+          }
+        }
 
-EditorLayer::EditorHistorySnapshot EditorLayer::CaptureHistorySnapshot() const {
-  EditorHistorySnapshot snapshot;
-  snapshot.document = m_document;
-  snapshot.savedDocument = m_lastSavedDocument;
-  snapshot.selectedObjectIds = GetSelectedObjectIds();
-  snapshot.selectedAssetId = m_selectedAssetId;
-  return snapshot;
-}
+        ImGui::TextDisabled("Asset");
+        if (firstObject)
+        {
+          ImGui::TextDisabled("No valid selection");
+        }
+        else if (hasSharedAssetId && sharedAssetId.empty())
+        {
+          ImGui::TextUnformatted("<none>");
+        }
+        else if (hasSharedAssetId)
+        {
+          ImGui::TextUnformatted(sharedAssetId.c_str());
+        }
+        else
+        {
+          ImGui::TextDisabled("Mixed");
+        }
 
-void EditorLayer::RestoreHistorySnapshot(const EditorHistorySnapshot& snapshot) {
-  m_document = snapshot.document;
-  m_lastSavedDocument = snapshot.savedDocument;
-  SetSelectedObjectIds(snapshot.selectedObjectIds);
-  if (!snapshot.selectedAssetId.empty() &&
-      m_document.assets.find(snapshot.selectedAssetId) != m_document.assets.end()) {
-    m_selectedAssetId = snapshot.selectedAssetId;
-  } else {
-    m_selectedAssetId.clear();
-  }
-  TriggerReload();
-}
+        std::vector<const char *> assetItems;
+        assetItems.reserve(m_document.assets.size() + 2);
+        assetItems.push_back("<keep current>");
+        assetItems.push_back("<clear>");
+        std::vector<std::string> assetIds;
+        assetIds.reserve(m_document.assets.size());
+        for (const auto &[assetId, _] : m_document.assets)
+          assetIds.push_back(assetId);
+        std::sort(assetIds.begin(), assetIds.end());
+        for (const std::string &assetId : assetIds)
+          assetItems.push_back(assetId.c_str());
 
-void EditorLayer::CommitHistoryChange(const EditorHistorySnapshot& before) {
-  const EditorHistorySnapshot after = CaptureHistorySnapshot();
-  if (HistorySnapshotsEqual(before, after))
-    return;
+        ImGui::Combo("Batch Asset", &m_batchAssetChoice, assetItems.data(), static_cast<int>(assetItems.size()));
+        if (ImGui::Button("Apply Asset"))
+        {
+          if (m_batchAssetChoice == 1)
+          {
+            for (int idx : m_selectedIndices)
+            {
+              if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+                m_document.objects[static_cast<size_t>(idx)].assetId.clear();
+            }
+          }
+          else if (m_batchAssetChoice > 1)
+          {
+            const std::string selectedAssetId = assetIds[static_cast<size_t>(m_batchAssetChoice - 2)];
+            for (int idx : m_selectedIndices)
+            {
+              if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+                m_document.objects[static_cast<size_t>(idx)].assetId = selectedAssetId;
+            }
+          }
+          if (m_batchAssetChoice > 0)
+          {
+            SyncAssetScaleMetadata(&m_document);
+            m_document.dirty = true;
+            TriggerReload();
+          }
+        }
 
-  m_undoHistory.push_back(before);
-  TrimHistory(&m_undoHistory);
-  m_redoHistory.clear();
-}
+        ImGui::Separator();
+        float moveBy[3] = {m_batchTranslateDraft.x, m_batchTranslateDraft.y, m_batchTranslateDraft.z};
+        if (ImGui::DragFloat3("Move By", moveBy, 0.05f))
+          m_batchTranslateDraft = {moveBy[0], moveBy[1], moveBy[2]};
 
-void EditorLayer::BeginHistoryTransaction(const EditorHistorySnapshot& before) {
-  if (m_historyTransactionOpen)
-    return;
-  m_historyTransactionBefore = before;
-  m_historyTransactionOpen = true;
-}
+        float rotateBy[3] = {m_batchRotateDraft.x, m_batchRotateDraft.y, m_batchRotateDraft.z};
+        if (ImGui::DragFloat3("Rotate By (P/Y/R)", rotateBy, 1.0f))
+          m_batchRotateDraft = {rotateBy[0], rotateBy[1], rotateBy[2]};
 
-void EditorLayer::FinalizeHistoryTransaction() {
-  if (!m_historyTransactionOpen)
-    return;
-  CommitHistoryChange(m_historyTransactionBefore);
-  m_historyTransactionOpen = false;
-}
+        float scaleBy[3] = {m_batchScaleDraft.x, m_batchScaleDraft.y, m_batchScaleDraft.z};
+        if (ImGui::DragFloat3("Scale By", scaleBy, 0.02f, 0.01f, 20.0f))
+          m_batchScaleDraft = {scaleBy[0], scaleBy[1], scaleBy[2]};
 
-void EditorLayer::ClearHistory() {
-  m_undoHistory.clear();
-  m_redoHistory.clear();
-  m_historyTransactionOpen = false;
-}
+        if (ImGui::Button("Apply Batch Transform"))
+        {
+          for (int idx : m_selectedIndices)
+          {
+            if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
+              continue;
+            SceneObject &object = m_document.objects[static_cast<size_t>(idx)];
+            object.position = object.position + m_batchTranslateDraft;
+            object.pitch += m_batchRotateDraft.x;
+            object.yaw += m_batchRotateDraft.y;
+            object.roll += m_batchRotateDraft.z;
+            object.scale.x *= m_batchScaleDraft.x;
+            object.scale.y *= m_batchScaleDraft.y;
+            object.scale.z *= m_batchScaleDraft.z;
+            if (m_transformCb)
+              m_transformCb(object);
+          }
+          m_document.dirty = true;
+          TriggerReload();
+        }
 
-void EditorLayer::RefreshHistorySavedBaseline() {
-  auto refreshSnapshot = [this](EditorHistorySnapshot* snapshot) {
-    if (!snapshot)
-      return;
-    if (snapshot->document.filePath == m_document.filePath) {
-      snapshot->savedDocument = m_lastSavedDocument;
-      snapshot->document.dirty = !SceneDocumentsEqual(snapshot->document, snapshot->savedDocument);
+        ImGui::Separator();
+        if (ImGui::Button("Duplicate Selected"))
+        {
+          DuplicateSelectedObjects();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Delete Selected"))
+        {
+          RequestDeleteSelectedObjects();
+        }
+        ImGui::End();
+        return;
+      }
+
+      int primaryIdx = PrimaryIdx();
+      if (primaryIdx < 0 || primaryIdx >= static_cast<int>(m_document.objects.size()))
+      {
+        if (!m_selectedAssetId.empty())
+        {
+          auto assetIt = m_document.assets.find(m_selectedAssetId);
+          if (assetIt == m_document.assets.end())
+          {
+            m_selectedAssetId.clear();
+          }
+          else
+          {
+            ImGui::TextDisabled("Asset");
+            ImGui::TextUnformatted(m_selectedAssetId.c_str());
+            ImGui::TextDisabled("Display name");
+            ImGui::TextUnformatted(assetIt->second.displayName.c_str());
+            ImGui::TextDisabled("GUID");
+            ImGui::TextWrapped("%s", assetIt->second.guid.c_str());
+
+            AssetMetadata assetMetadata;
+            std::string metadataError;
+            const bool hasAssetMetadata = LoadAssetMetadata(assetIt->second.guid, &assetMetadata, &metadataError);
+            if (hasAssetMetadata)
+            {
+              if (!assetMetadata.importerId.empty())
+              {
+                ImGui::TextDisabled("Importer");
+                ImGui::TextWrapped("%s", assetMetadata.importerId.c_str());
+              }
+              if (!assetMetadata.sourcePath.empty())
+              {
+                ImGui::TextDisabled("Source");
+                ImGui::TextWrapped("%s", assetMetadata.sourcePath.c_str());
+              }
+              if (!assetMetadata.lastImportReason.empty())
+              {
+                ImGui::TextDisabled("Last rebuild reason");
+                ImGui::TextWrapped("%s", assetMetadata.lastImportReason.c_str());
+              }
+              if (!assetMetadata.diagnostics.empty())
+              {
+                ImGui::TextDisabled("Diagnostics");
+                for (const AssetImportDiagnostic &diagnostic : assetMetadata.diagnostics)
+                {
+                  const ImVec4 color =
+                      diagnostic.severity == AssetDiagnosticSeverity::Error
+                          ? ImVec4(1.f, 0.4f, 0.4f, 1.f)
+                      : diagnostic.severity == AssetDiagnosticSeverity::Warning
+                          ? ImVec4(1.f, 0.8f, 0.35f, 1.f)
+                          : ImVec4(0.6f, 0.85f, 1.f, 1.f);
+                  const std::string line = "[" + diagnostic.code + "] " + diagnostic.message;
+                  ImGui::TextWrapped("%s", line.c_str());
+                  const ImVec2 min = ImGui::GetItemRectMin();
+                  const ImVec2 max = ImGui::GetItemRectMax();
+                  ImGui::GetWindowDrawList()->AddRectFilled(
+                      ImVec2(min.x - 6.0f, min.y + 3.0f),
+                      ImVec2(min.x - 2.0f, max.y - 3.0f),
+                      ImGui::ColorConvertFloat4ToU32(color),
+                      1.0f);
+                }
+              }
+            }
+
+            if (ImGui::Button("Deselect Asset", ImVec2(-1.0f, 0.0f)))
+            {
+              m_selectedAssetId.clear();
+              ImGui::End();
+              return;
+            }
+
+            if (hasAssetMetadata)
+            {
+              if (ImGui::Button("Reimport Asset", ImVec2(-1.0f, 0.0f)))
+              {
+                const AssetReimportResult reimportResult =
+                    m_assetImportService.ReimportAssetWithDependents(&m_document,
+                                                                     assetIt->second.guid,
+                                                                     "Manual reimport from editor");
+                if (reimportResult.ok)
+                {
+                  m_document.dirty = true;
+                  m_assetImportError.clear();
+                  TriggerReload();
+                }
+                else
+                {
+                  m_assetImportError = reimportResult.error;
+                }
+              }
+              if (!m_assetImportError.empty())
+                ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s", m_assetImportError.c_str());
+            }
+
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            char meshEditBuf[512] = {};
+            std::snprintf(meshEditBuf, sizeof(meshEditBuf), "%s", assetIt->second.mesh.c_str());
+            if (ImGui::InputText("Mesh", meshEditBuf, sizeof(meshEditBuf)))
+            {
+              assetIt->second.mesh = meshEditBuf;
+              m_document.dirty = true;
+            }
+
+            char displayEditBuf[256] = {};
+            std::snprintf(displayEditBuf, sizeof(displayEditBuf), "%s", assetIt->second.displayName.c_str());
+            if (ImGui::InputText("Display Name", displayEditBuf, sizeof(displayEditBuf)))
+            {
+              assetIt->second.displayName = displayEditBuf;
+              m_document.dirty = true;
+            }
+
+            char scaleEditBuf[128] = {};
+            std::snprintf(scaleEditBuf, sizeof(scaleEditBuf), "%s", assetIt->second.renderScale.c_str());
+            if (ImGui::InputText("Render Scale", scaleEditBuf, sizeof(scaleEditBuf)))
+            {
+              assetIt->second.renderScale = scaleEditBuf;
+              SyncAssetScaleMetadata(&m_document);
+              m_document.dirty = true;
+              TriggerReload();
+            }
+
+            ImGui::TextDisabled("Albedo map (optional)");
+            const ImVec2 selAlbLabelMin = ImGui::GetItemRectMin();
+            const ImVec2 selAlbLabelMax = ImGui::GetItemRectMax();
+            char albBuf[512] = {};
+            std::snprintf(albBuf, sizeof(albBuf), "%s", assetIt->second.albedoMap.c_str());
+            if (ImGui::InputText("##sel_alb", albBuf, sizeof(albBuf)))
+            {
+              assetIt->second.albedoMap = albBuf;
+              m_document.dirty = true;
+            }
+            {
+              const ImVec2 fMin = ImGui::GetItemRectMin();
+              const ImVec2 fMax = ImGui::GetItemRectMax();
+              m_albedoSelDrop.valid = true;
+              m_albedoSelDrop.minX = std::min(selAlbLabelMin.x, fMin.x);
+              m_albedoSelDrop.minY = selAlbLabelMin.y;
+              m_albedoSelDrop.maxX = std::max(selAlbLabelMax.x, fMax.x);
+              m_albedoSelDrop.maxY = fMax.y;
+            }
+
+#if defined(_WIN32) || defined(__APPLE__)
+            if (ImGui::Button("Browse texture...##alb_pick_asset", ImVec2(-1.0f, 0.0f)))
+              m_deferredFilePick = DeferredFilePick::SelectedAssetAlbedo;
+#else
+            ImGui::BeginDisabled();
+            ImGui::Button("Browse texture...##alb_pick_asset", ImVec2(-1.0f, 0.0f));
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+              ImGui::SetTooltip("Texture file dialog is not available on this platform.");
+#endif
+
+            const float gap = ImGui::GetStyle().ItemSpacing.x;
+            const float fullW = ImGui::GetContentRegionAvail().x;
+            const float btnW = std::max(90.0f, (fullW - gap) * 0.5f);
+            if (ImGui::Button("Add Prop##sel_add", ImVec2(btnW, 0.0f)))
+            {
+              SceneObject obj = MakeObjectFromAsset(m_document, m_selectedAssetId, m_schema);
+              m_document.objects.push_back(std::move(obj));
+              m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+              m_document.dirty = true;
+              TriggerReload();
+            }
+            ImGui::SameLine(0.0f, gap);
+            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.45f, 0.18f, 0.18f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.55f, 0.22f, 0.22f, 1.0f));
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.65f, 0.15f, 0.15f, 1.0f));
+            if (ImGui::Button("Delete Asset##sel_del", ImVec2(btnW, 0.0f)))
+              RequestDeleteAsset(m_selectedAssetId);
+            ImGui::PopStyleColor(3);
+
+            ImGui::End();
+            return;
+          }
+        }
+
+        ImGui::TextDisabled("No selection");
+        ImGui::TextDisabled("Pick an object or asset to edit properties.");
+        ImGui::End();
+        return;
+      }
+
+      SceneObject &obj = m_document.objects[primaryIdx];
+
+      // ---- Identity ----
+      ImGui::LabelText("ID", "%s", obj.id.c_str());
+      const char *typeName = (obj.type == SceneObjectType::Prop)     ? "Prop"
+                             : (obj.type == SceneObjectType::Light)  ? "Light"
+                             : (obj.type == SceneObjectType::Camera) ? "Camera"
+                                                                     : "Panel";
+      ImGui::LabelText("Type", "%s", typeName);
+      if (obj.prefabInstance.has_value())
+      {
+        ImGui::LabelText("Prefab", "%s", obj.prefabInstance->prefabId.c_str());
+        ImGui::TextDisabled("%s", obj.prefabInstance->sourcePath.c_str());
+      }
+
+      {
+        std::string currentParent = GetParentId(obj);
+        std::vector<std::string> parentIds;
+        std::vector<const char *> parentItems;
+        parentItems.push_back("<root>");
+        int currentIdx = 0;
+        for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+        {
+          if (i == primaryIdx || IsDescendantOf(m_document, i, primaryIdx))
+            continue;
+          const std::string &id = m_document.objects[static_cast<size_t>(i)].id;
+          parentIds.push_back(id);
+          parentItems.push_back(parentIds.back().c_str());
+          if (id == currentParent)
+            currentIdx = static_cast<int>(parentItems.size()) - 1;
+        }
+        if (ImGui::Combo("Parent", &currentIdx, parentItems.data(), static_cast<int>(parentItems.size())))
+        {
+          if (currentIdx == 0)
+            obj.props.erase("parentId");
+          else
+            obj.props["parentId"] = parentIds[static_cast<size_t>(currentIdx - 1)];
+          m_document.dirty = true;
+        }
+      }
+      ImGui::Separator();
+
+      // ---- Camera-specific properties ----
+      if (obj.type == SceneObjectType::Camera)
+      {
+        const Vec3 oldPos = obj.position;
+        const Quaternion oldRot =
+            Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
+        bool changedTransform = false;
+
+        float pos[3] = {obj.position.x, obj.position.y, obj.position.z};
+        if (ImGui::DragFloat3("Position", pos, 0.05f))
+        {
+          obj.position = {pos[0], pos[1], pos[2]};
+          changedTransform = true;
+          m_document.dirty = true;
+          if (m_transformCb)
+            m_transformCb(obj);
+        }
+
+        if (ImGui::DragFloat("Yaw", &obj.yaw, 1.0f, -360.0f, 360.0f))
+        {
+          changedTransform = true;
+          m_document.dirty = true;
+          if (m_transformCb)
+            m_transformCb(obj);
+        }
+
+        float pitch = obj.pitch;
+        if (ImGui::DragFloat("Pitch", &pitch, 1.0f, -89.0f, 89.0f))
+        {
+          obj.pitch = std::max(-89.0f, std::min(89.0f, pitch));
+          changedTransform = true;
+          m_document.dirty = true;
+          if (m_transformCb)
+            m_transformCb(obj);
+        }
+
+        if (changedTransform)
+        {
+          const Quaternion newRot =
+              Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
+          PropagateHierarchyTransformDelta(
+              m_document, primaryIdx, oldPos, oldRot, obj.position, newRot, m_transformCb);
+        }
+
+        ImGui::Separator();
+
+        // FOV
+        {
+          auto &fovStr = obj.props["fov"];
+          if (fovStr.empty())
+            fovStr = "60";
+          float fov = std::stof(fovStr);
+          if (ImGui::SliderFloat("FOV", &fov, 1.0f, 179.0f))
+          {
+            char tmp[32];
+            std::snprintf(tmp, sizeof(tmp), "%.4f", fov);
+            fovStr = tmp;
+            m_document.dirty = true;
+          }
+        }
+
+        // Near Clip
+        {
+          auto &nearStr = obj.props["nearClip"];
+          if (nearStr.empty())
+            nearStr = "0.1";
+          float v = std::stof(nearStr);
+          if (ImGui::DragFloat("Near Clip", &v, 0.01f, 0.001f, 100.0f))
+          {
+            char tmp[32];
+            std::snprintf(tmp, sizeof(tmp), "%.4f", v);
+            nearStr = tmp;
+            m_document.dirty = true;
+          }
+        }
+
+        // Far Clip
+        {
+          auto &farStr = obj.props["farClip"];
+          if (farStr.empty())
+            farStr = "500";
+          float v = std::stof(farStr);
+          if (ImGui::DragFloat("Far Clip", &v, 1.0f, 1.0f, 100000.0f))
+          {
+            char tmp[32];
+            std::snprintf(tmp, sizeof(tmp), "%.4f", v);
+            farStr = tmp;
+            m_document.dirty = true;
+          }
+        }
+
+        ImGui::Separator();
+
+        // Follow Target dropdown
+        {
+          auto &followId = obj.props["followTargetId"];
+          std::vector<const char *> targetItems;
+          targetItems.push_back("<none>");
+          int curTarget = 0;
+          int ti = 1;
+          for (const auto &other : m_document.objects)
+          {
+            if (other.id == obj.id)
+              continue;
+            targetItems.push_back(other.id.c_str());
+            if (other.id == followId)
+              curTarget = ti;
+            ++ti;
+          }
+          if (ImGui::Combo("Follow Target", &curTarget, targetItems.data(),
+                           static_cast<int>(targetItems.size())))
+          {
+            followId = (curTarget == 0) ? "" : targetItems[static_cast<size_t>(curTarget)];
+            m_document.dirty = true;
+          }
+        }
+
+        ImGui::Separator();
+        if (ImGui::Button("Delete"))
+          RequestDeleteSelectedObjects();
+        ImGui::End();
+        return;
+      }
+
+      // ---- Transform (non-camera objects) ----
+      const Vec3 oldPos = obj.position;
+      const Quaternion oldRot =
+          Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
+      bool changedTransform = false;
+
+      float pos[3] = {obj.position.x, obj.position.y, obj.position.z};
+      if (ImGui::DragFloat3("Position", pos, 0.05f))
+      {
+        obj.position = {pos[0], pos[1], pos[2]};
+        changedTransform = true;
+        m_document.dirty = true;
+        if (m_transformCb)
+          m_transformCb(obj);
+      }
+
+      float scl[3] = {obj.scale.x, obj.scale.y, obj.scale.z};
+      if (ImGui::DragFloat3("Scale", scl, 0.02f, 0.01f, 200.0f))
+      {
+        obj.scale = {scl[0], scl[1], scl[2]};
+        m_document.dirty = true;
+        if (m_transformCb)
+          m_transformCb(obj);
+      }
+
+      // ---- Rotation (Euler angles: Pitch / Yaw / Roll) ----
+      float rot[3] = {obj.pitch, obj.yaw, obj.roll};
+      if (ImGui::DragFloat3("Rotation (P/Y/R)", rot, 1.0f, -360.0f, 360.0f))
+      {
+        obj.pitch = rot[0];
+        obj.yaw = rot[1];
+        obj.roll = rot[2];
+        changedTransform = true;
+        m_document.dirty = true;
+        if (m_transformCb)
+          m_transformCb(obj);
+      }
+
+      if (changedTransform)
+      {
+        const Quaternion newRot =
+            Quaternion::FromEuler(ToRadians(obj.pitch), ToRadians(obj.yaw), ToRadians(obj.roll));
+        PropagateHierarchyTransformDelta(
+            m_document, primaryIdx, oldPos, oldRot, obj.position, newRot, m_transformCb);
+      }
+
+      ImGui::Separator();
+      ImGui::Text("Asset");
+
+      std::vector<const char *> assetItems;
+      assetItems.reserve(m_document.assets.size() + 1);
+      assetItems.push_back("<none>");
+      int currentAssetIndex = 0;
+      int assetIndex = 1;
+      for (const auto &[assetId, _] : m_document.assets)
+      {
+        assetItems.push_back(assetId.c_str());
+        if (obj.assetId == assetId)
+          currentAssetIndex = assetIndex;
+        ++assetIndex;
+      }
+
+      if (ImGui::Combo("Asset ID", &currentAssetIndex, assetItems.data(), static_cast<int>(assetItems.size())))
+      {
+        if (currentAssetIndex == 0)
+          obj.assetId.clear();
+        else
+          obj.assetId = assetItems[static_cast<size_t>(currentAssetIndex)];
+        SyncAssetScaleMetadata(&m_document);
+        m_document.dirty = true;
+        TriggerReload();
+      }
+
+      if (!obj.assetId.empty())
+      {
+        auto assetIt = m_document.assets.find(obj.assetId);
+        if (assetIt != m_document.assets.end())
+        {
+          ImGui::TextDisabled("mesh: %s", assetIt->second.mesh.c_str());
+          ImGui::TextDisabled("renderScale: %s", assetIt->second.renderScale.c_str());
+        }
+        else
+        {
+          ImGui::TextColored(ImVec4(1.0f, 0.55f, 0.35f, 1.0f), "Missing asset: %s", obj.assetId.c_str());
+        }
+      }
+
+      ImGui::Separator();
+      ImGui::Text("Props");
+
+      // ---- Schema-driven fields ----
+      const TypeSchema *schema = m_schema.GetSchema(obj.type);
+      if (schema)
+      {
+        for (const auto &fd : schema->fields)
+        {
+          std::string &val = obj.props[fd.key];
+          if (val.empty())
+            val = fd.defaultValue;
+
+          switch (fd.widget)
+          {
+          case FieldDef::Widget::String:
+          {
+            char buf[256] = {};
+            std::snprintf(buf, sizeof(buf), "%s", val.c_str());
+            if (ImGui::InputText(fd.label.c_str(), buf, sizeof(buf)))
+            {
+              val = buf;
+              m_document.dirty = true;
+              if (obj.type == SceneObjectType::Light && m_transformCb)
+                m_transformCb(obj);
+            }
+            break;
+          }
+          case FieldDef::Widget::Float:
+          {
+            float f = val.empty() ? fd.minVal : std::stof(val);
+            if (ImGui::SliderFloat(fd.label.c_str(), &f, fd.minVal, fd.maxVal))
+            {
+              char tmp[32];
+              std::snprintf(tmp, sizeof(tmp), "%.4f", f);
+              val = tmp;
+              m_document.dirty = true;
+              if (obj.type == SceneObjectType::Light && m_transformCb)
+                m_transformCb(obj);
+            }
+            break;
+          }
+          case FieldDef::Widget::Bool:
+          {
+            bool b = (val == "true" || val == "1");
+            if (ImGui::Checkbox(fd.label.c_str(), &b))
+            {
+              val = b ? "true" : "false";
+              m_document.dirty = true;
+              if (obj.type == SceneObjectType::Light && m_transformCb)
+                m_transformCb(obj);
+            }
+            break;
+          }
+          case FieldDef::Widget::Enum:
+          {
+            int cur = 0;
+            for (int i = 0; i < static_cast<int>(fd.options.size()); ++i)
+              if (fd.options[i] == val)
+              {
+                cur = i;
+                break;
+              }
+
+            // Build null-separated list for ImGui::Combo
+            std::string items;
+            for (auto &opt : fd.options)
+            {
+              items += opt;
+              items += '\0';
+            }
+            items += '\0';
+
+            if (ImGui::Combo(fd.label.c_str(), &cur, items.c_str()))
+            {
+              val = fd.options[static_cast<size_t>(cur)];
+              m_document.dirty = true;
+              if (obj.type == SceneObjectType::Light && m_transformCb)
+                m_transformCb(obj);
+            }
+            break;
+          }
+          case FieldDef::Widget::Color3:
+          {
+            float col[3] = {1.0f, 1.0f, 1.0f};
+            if (!val.empty())
+            {
+              // Parse "r,g,b" using strtof to avoid MSVC sscanf deprecation
+              char tmp[64] = {};
+              std::snprintf(tmp, sizeof(tmp), "%s", val.c_str());
+              char *p = tmp;
+              char *end = nullptr;
+              col[0] = std::strtof(p, &end);
+              if (end && *end)
+                p = end + 1;
+              col[1] = std::strtof(p, &end);
+              if (end && *end)
+                p = end + 1;
+              col[2] = std::strtof(p, nullptr);
+            }
+            if (ImGui::ColorEdit3(fd.label.c_str(), col))
+            {
+              char tmp[64];
+              std::snprintf(tmp, sizeof(tmp), "%.4f,%.4f,%.4f", col[0], col[1], col[2]);
+              val = tmp;
+              m_document.dirty = true;
+              if (obj.type == SceneObjectType::Light && m_transformCb)
+                m_transformCb(obj);
+            }
+            break;
+          }
+          }
+        }
+      }
+
+      // ---- Components ----
+      ImGui::Separator();
+      ImGui::Text("Components");
+
+      int removeIdx = -1;
+      for (int ci = 0; ci < static_cast<int>(obj.components.size()); ++ci)
+      {
+        ComponentDesc &comp = obj.components[ci];
+
+        // Collapsing header label + inline [x] button via ID stack trick
+        std::string headerLabel = (comp.type == "light")       ? "Light"
+                                  : (comp.type == "rigidbody") ? "RigidBody"
+                                  : (comp.type == "script")    ? "Script"
+                                                               : comp.type;
+        ImGui::PushID(ci);
+        bool open = ImGui::CollapsingHeader(headerLabel.c_str(), ImGuiTreeNodeFlags_DefaultOpen);
+        bool removeThisComponent = false;
+
+        if (ImGui::BeginPopupContextItem("comp_ctx"))
+        {
+          if (ImGui::MenuItem("Remove Component"))
+            removeThisComponent = true;
+          ImGui::EndPopup();
+        }
+
+        // Remove button on the same line, right-aligned
+        float btnW = ImGui::CalcTextSize("x").x + ImGui::GetStyle().FramePadding.x * 2.0f;
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x - btnW);
+        if (ImGui::SmallButton("x"))
+          removeThisComponent = true;
+
+        if (removeThisComponent)
+          removeIdx = ci;
+
+        if (open)
+        {
+          if (comp.type == "light")
+          {
+            // Intensity
+            {
+              float v = comp.props.count("intensity") ? std::strtof(comp.props["intensity"].c_str(), nullptr) : 1.0f;
+              if (ImGui::SliderFloat("Intensity", &v, 0.0f, 10.0f))
+              {
+                char tmp[32];
+                std::snprintf(tmp, sizeof(tmp), "%.4f", v);
+                comp.props["intensity"] = tmp;
+                m_document.dirty = true;
+              }
+            }
+            // Color
+            {
+              float col[3] = {1.0f, 1.0f, 1.0f};
+              if (comp.props.count("color"))
+              {
+                char tmp[64] = {};
+                std::snprintf(tmp, sizeof(tmp), "%s", comp.props["color"].c_str());
+                char *p = tmp;
+                char *end = nullptr;
+                col[0] = std::strtof(p, &end);
+                if (end && *end)
+                  p = end + 1;
+                col[1] = std::strtof(p, &end);
+                if (end && *end)
+                  p = end + 1;
+                col[2] = std::strtof(p, nullptr);
+              }
+              if (ImGui::ColorEdit3("Color", col))
+              {
+                char tmp[64];
+                std::snprintf(tmp, sizeof(tmp), "%.4f,%.4f,%.4f", col[0], col[1], col[2]);
+                comp.props["color"] = tmp;
+                m_document.dirty = true;
+              }
+            }
+            // Radius
+            {
+              float v = comp.props.count("radius") ? std::strtof(comp.props["radius"].c_str(), nullptr) : 5.0f;
+              if (ImGui::DragFloat("Radius", &v, 0.1f, 0.0f, 100.0f))
+              {
+                char tmp[32];
+                std::snprintf(tmp, sizeof(tmp), "%.4f", v);
+                comp.props["radius"] = tmp;
+                m_document.dirty = true;
+              }
+            }
+          }
+          else if (comp.type == "rigidbody")
+          {
+            // Mass
+            {
+              float v = comp.props.count("mass") ? std::strtof(comp.props["mass"].c_str(), nullptr) : 1.0f;
+              if (ImGui::DragFloat("Mass", &v, 0.1f, 0.0f, 10000.0f))
+              {
+                char tmp[32];
+                std::snprintf(tmp, sizeof(tmp), "%.4f", v);
+                comp.props["mass"] = tmp;
+                m_document.dirty = true;
+              }
+            }
+            // Is Kinematic
+            {
+              bool b = comp.props.count("isKinematic") && comp.props["isKinematic"] == "true";
+              if (ImGui::Checkbox("Is Kinematic", &b))
+              {
+                comp.props["isKinematic"] = b ? "true" : "false";
+                m_document.dirty = true;
+              }
+            }
+            // Use Gravity
+            {
+              bool b = !comp.props.count("useGravity") || comp.props["useGravity"] == "true";
+              if (ImGui::Checkbox("Use Gravity", &b))
+              {
+                comp.props["useGravity"] = b ? "true" : "false";
+                m_document.dirty = true;
+              }
+            }
+          }
+          else if (comp.type == "script")
+          {
+            std::vector<std::string> options;
+            if (m_scriptBehaviorOptionsCb)
+              options = m_scriptBehaviorOptionsCb();
+            options.erase(std::remove_if(options.begin(), options.end(), [](const std::string &s)
+                                         { return s.empty(); }),
+                          options.end());
+            std::sort(options.begin(), options.end());
+            options.erase(std::unique(options.begin(), options.end()), options.end());
+
+            std::string current = comp.props["behaviorTag"];
+            if (!current.empty() && std::find(options.begin(), options.end(), current) == options.end())
+              options.push_back(current);
+
+            std::vector<const char *> labels;
+            labels.reserve(options.size() + 1);
+            labels.push_back("<none>");
+            int currentIdx = 0;
+            for (int i = 0; i < static_cast<int>(options.size()); ++i)
+            {
+              labels.push_back(options[static_cast<size_t>(i)].c_str());
+              if (options[static_cast<size_t>(i)] == current)
+                currentIdx = i + 1;
+            }
+
+            if (ImGui::Combo("Behavior", &currentIdx, labels.data(), static_cast<int>(labels.size())))
+            {
+              comp.props["behaviorTag"] = (currentIdx == 0) ? "" : options[static_cast<size_t>(currentIdx - 1)];
+              m_document.dirty = true;
+            }
+          }
+        }
+        ImGui::PopID();
+      }
+
+      if (removeIdx >= 0)
+      {
+        obj.components.erase(obj.components.begin() + removeIdx);
+        m_document.dirty = true;
+      }
+
+      // ---- Add Component button ----
+      ImGui::Spacing();
+      if (ImGui::Button("+ Add Component"))
+      {
+        ImGui::OpenPopup("##add_component_popup");
+      }
+      if (ImGui::BeginPopup("##add_component_popup"))
+      {
+        std::vector<const ComponentSchema *> componentSchemas;
+        componentSchemas.reserve(m_schema.ComponentSchemas().size());
+        for (const auto &entry : m_schema.ComponentSchemas())
+        {
+          if (SchemaAppliesToObjectType(entry.second.appliesTo, obj.type))
+            componentSchemas.push_back(&entry.second);
+        }
+        std::sort(componentSchemas.begin(), componentSchemas.end(),
+                  [](const ComponentSchema *lhs, const ComponentSchema *rhs)
+                  {
+                    const std::string lhsLabel = lhs ? lhs->label : std::string();
+                    const std::string rhsLabel = rhs ? rhs->label : std::string();
+                    if (lhsLabel != rhsLabel)
+                      return lhsLabel < rhsLabel;
+                    return lhs && rhs ? lhs->name < rhs->name : lhs < rhs;
+                  });
+
+        if (!componentSchemas.empty())
+        {
+          for (const ComponentSchema *componentSchema : componentSchemas)
+          {
+            if (!componentSchema)
+              continue;
+            const std::string menuLabel =
+                componentSchema->label.empty() ? componentSchema->name : componentSchema->label;
+            if (ImGui::MenuItem(menuLabel.c_str()))
+            {
+              ComponentDesc component;
+              component.type = componentSchema->name;
+              ApplyComponentSchemaDefaults(component);
+              obj.components.push_back(std::move(component));
+              m_document.dirty = true;
+            }
+          }
+        }
+        else
+        {
+          if (ImGui::MenuItem("Light"))
+          {
+            ComponentDesc component;
+            component.type = "light";
+            ApplyComponentSchemaDefaults(component);
+            if (component.props.empty())
+            {
+              component.props["intensity"] = "1.0000";
+              component.props["color"] = "1.0000,1.0000,1.0000";
+              component.props["radius"] = "5.0000";
+            }
+            obj.components.push_back(std::move(component));
+            m_document.dirty = true;
+          }
+          if (ImGui::MenuItem("RigidBody"))
+          {
+            ComponentDesc component;
+            component.type = "rigidbody";
+            ApplyComponentSchemaDefaults(component);
+            if (component.props.empty())
+            {
+              component.props["mass"] = "1.0000";
+              component.props["isKinematic"] = "false";
+              component.props["useGravity"] = "true";
+            }
+            obj.components.push_back(std::move(component));
+            m_document.dirty = true;
+          }
+          if (ImGui::MenuItem("Script"))
+          {
+            ComponentDesc component;
+            component.type = "script";
+            ApplyComponentSchemaDefaults(component);
+            if (component.props.empty())
+              component.props["behaviorTag"] = "";
+            obj.components.push_back(std::move(component));
+            m_document.dirty = true;
+          }
+        }
+        ImGui::EndPopup();
+      }
+
+      ImGui::Separator();
+      if (ImGui::Button("Delete"))
+      {
+        RequestDeleteSelectedObjects();
+      }
+
+      ImGui::End();
     }
-  };
 
-  for (EditorHistorySnapshot& snapshot : m_undoHistory)
-    refreshSnapshot(&snapshot);
-  for (EditorHistorySnapshot& snapshot : m_redoHistory)
-    refreshSnapshot(&snapshot);
-  if (m_historyTransactionOpen)
-    refreshSnapshot(&m_historyTransactionBefore);
-}
+    // ---- Picking -----------------------------------------------------------------
 
-bool EditorLayer::CanUndoHistory() const {
-  return !m_undoHistory.empty();
-}
+    void EditorLayer::HandlePicking(const Camera &cam, int screenW, int screenH)
+    {
+      bool currL = glfwGetMouseButton(m_window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS;
+      bool clicked = currL && !m_prevMouseL;
+      m_prevMouseL = currL;
 
-bool EditorLayer::CanRedoHistory() const {
-  return !m_redoHistory.empty();
-}
+      if (!clicked)
+        return;
 
-bool EditorLayer::UndoHistory() {
-  FinalizeHistoryTransaction();
-  if (m_undoHistory.empty())
-    return false;
+      double mx, my;
+      glfwGetCursorPos(m_window, &mx, &my);
+      if (!m_viewportPanelRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
+        return;
+      if (ImGui::GetIO().WantCaptureMouse &&
+          !m_viewportPanelRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
+        return;
+      const ImGuiIO &io = ImGui::GetIO();
+      const float rightDockW = ComputeEditorRightPanelWidth(io.DisplaySize.x);
+      const EditorViewGimbalLayout viewGimbalLayout =
+          BuildEditorViewGimbalLayout(m_viewportPanelRect, io.DisplaySize.x, rightDockW, kEditorToolbarH);
+      if (viewGimbalLayout.pickRect.Contains(static_cast<float>(mx), static_cast<float>(my)))
+        return;
+      if (m_viewGizmoPickRect.valid &&
+          m_viewGizmoPickRect.Contains(static_cast<float>(mx), static_cast<float>(my), 2.0f))
+        return;
 
-  const EditorHistorySnapshot current = CaptureHistorySnapshot();
-  const EditorHistorySnapshot target = m_undoHistory.back();
-  m_undoHistory.pop_back();
-  m_redoHistory.push_back(current);
-  TrimHistory(&m_redoHistory);
-  RestoreHistorySnapshot(target);
-  return true;
-}
+      Ray ray = ScreenToRay(static_cast<float>(mx), static_cast<float>(my), screenW, screenH, cam);
 
-bool EditorLayer::RedoHistory() {
-  FinalizeHistoryTransaction();
-  if (m_redoHistory.empty())
-    return false;
+      float bestT = std::numeric_limits<float>::max();
+      int bestIdx = -1;
 
-  const EditorHistorySnapshot current = CaptureHistorySnapshot();
-  const EditorHistorySnapshot target = m_redoHistory.back();
-  m_redoHistory.pop_back();
-  m_undoHistory.push_back(current);
-  TrimHistory(&m_undoHistory);
-  RestoreHistorySnapshot(target);
-  return true;
-}
+      for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+      {
+        const auto &obj = m_document.objects[i];
+        Vec3 center = obj.position;
+        Vec3 half = {std::max(obj.scale.x, 0.25f), std::max(obj.scale.y, 0.25f),
+                     std::max(obj.scale.z, 0.25f)};
+        if (m_liveRegistry && TryPropWorldAabb(*m_liveRegistry, obj, center, half))
+        {
+          half.x = std::max(half.x, 0.25f);
+          half.y = std::max(half.y, 0.25f);
+          half.z = std::max(half.z, 0.25f);
+        }
+        float t = RayVsAABB(ray, center, half);
+        if (t >= 0.0f && t < bestT)
+        {
+          bestT = t;
+          bestIdx = i;
+        }
+      }
 
-void EditorLayer::ProcessMcpCommands() {
-  m_mcpController.DrainCommands([this](const std::string& toolName, const nlohmann::json& arguments) {
-    return ExecuteMcpCommand(toolName, arguments);
-  });
-}
+      bool shiftHeld = glfwGetKey(m_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+                       glfwGetKey(m_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
 
-void EditorLayer::PublishMcpSnapshot() {
-  Mcp::McpEditorSnapshot snapshot;
-  snapshot.editorActive = m_active;
-  snapshot.playMode = m_playMode;
-  snapshot.dirty = m_document.dirty;
-  snapshot.reloadPending = m_wantsReload;
-  snapshot.sceneId = m_document.sceneId;
-  snapshot.sceneName = m_document.sceneName;
-  snapshot.sceneFilePath = m_document.filePath;
-  snapshot.selectedAssetId = m_selectedAssetId;
-
-  for (int idx : m_selectedIndices) {
-    if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-      snapshot.selectedObjectIds.push_back(m_document.objects[static_cast<size_t>(idx)].id);
-  }
-
-  snapshot.objects.reserve(m_document.objects.size());
-  for (const SceneObject& object : m_document.objects) {
-    Mcp::McpObjectSnapshot entry;
-    entry.id = object.id;
-    entry.type = SceneObjectTypeToString(object.type);
-    entry.position = object.position;
-    entry.scale = object.scale;
-    entry.yaw = object.yaw;
-    entry.pitch = object.pitch;
-    entry.roll = object.roll;
-    entry.assetId = object.assetId;
-    entry.props = object.props;
-    for (const ComponentDesc& component : object.components) {
-      Mcp::McpComponentSnapshot componentEntry;
-      componentEntry.type = component.type;
-      componentEntry.props = component.props;
-      entry.components.push_back(std::move(componentEntry));
+      if (bestIdx >= 0)
+      {
+        if (shiftHeld)
+          ToggleSelect(bestIdx);
+        else
+          m_selectedIndices = {bestIdx};
+      }
+      else if (!shiftHeld)
+      {
+        m_selectedIndices.clear();
+      }
     }
-    snapshot.objects.push_back(std::move(entry));
-  }
 
-  std::vector<std::string> assetIds;
-  assetIds.reserve(m_document.assets.size());
-  for (const auto& entry : m_document.assets)
-    assetIds.push_back(entry.first);
-  std::sort(assetIds.begin(), assetIds.end());
-  for (const std::string& assetId : assetIds) {
-    const AssetDef& asset = m_document.assets.at(assetId);
-    snapshot.assets.push_back(Mcp::McpAssetSnapshot{assetId, asset.mesh, asset.renderScale,
-                                                    asset.albedoMap});
-  }
+    void EditorLayer::DrawSelectionHighlight()
+    {
+      const int n = static_cast<int>(m_document.objects.size());
+      for (int i : m_selectedIndices)
+      {
+        if (i < 0 || i >= n)
+          continue;
+        const auto &obj = m_document.objects[i];
 
-  std::vector<LogLine> lines;
-  LogBuffer::Instance().CopyLinesTo(&lines);
-  const size_t start = lines.size() > 50 ? lines.size() - 50 : 0;
-  for (size_t i = start; i < lines.size(); ++i) {
-    char timeBuf[32];
-    FormatLogTime(lines[i], timeBuf, sizeof(timeBuf));
-    snapshot.consoleEntries.push_back(Mcp::McpConsoleEntry{
-        timeBuf,
-        lines[i].level == LogLevel::Info ? "INFO" : lines[i].level == LogLevel::Warn ? "WARN" : "ERR",
-        lines[i].message,
-    });
-  }
+        if (obj.type == SceneObjectType::Camera)
+        {
+          const Vec4 color = {0.2f, 0.7f, 1.0f, 1.0f};
+          const float yawRad = ToRadians(obj.yaw);
+          const float pitchRad = ToRadians(std::max(-89.0f, std::min(89.0f, obj.pitch)));
+          const Vec3 forward = {-std::sin(yawRad) * std::cos(pitchRad),
+                                std::sin(pitchRad),
+                                -std::cos(yawRad) * std::cos(pitchRad)};
 
-  snapshot.build = BuildMcpBuildSnapshot(m_document);
-  snapshot.schema = BuildMcpSchemaCatalogSnapshot(m_schema);
-  m_mcpController.PublishSnapshot(snapshot);
-}
+          Vec3 right = Vec3::Cross(forward, Vec3::Up());
+          if (right.LengthSq() < 1e-5f)
+            right = {1.0f, 0.0f, 0.0f};
+          else
+            right = right.Normalized();
+          Vec3 up = Vec3::Cross(right, forward).Normalized();
 
-Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string& toolName,
-                                                     const nlohmann::json& arguments) {
-  using json = nlohmann::json;
+          const Vec3 tip = obj.position;
+          const Vec3 baseCenter = tip + forward * 0.55f;
+          const float baseHalfW = 0.24f;
+          const float baseHalfH = 0.16f;
 
-  auto parseVec3 = [](const json& value, Vec3* out) -> bool {
-    if (!out || !value.is_array() || value.size() != 3)
-      return false;
-    if (!value[0].is_number() || !value[1].is_number() || !value[2].is_number())
-      return false;
-    out->x = value[0].get<float>();
-    out->y = value[1].get<float>();
-    out->z = value[2].get<float>();
-    return true;
-  };
+          const Vec3 b0 = baseCenter + right * baseHalfW + up * baseHalfH;
+          const Vec3 b1 = baseCenter - right * baseHalfW + up * baseHalfH;
+          const Vec3 b2 = baseCenter - right * baseHalfW - up * baseHalfH;
+          const Vec3 b3 = baseCenter + right * baseHalfW - up * baseHalfH;
 
-  auto parseProps = [](const json& value) {
-    std::unordered_map<std::string, std::string> props;
-    if (!value.is_object())
-      return props;
-    for (auto it = value.begin(); it != value.end(); ++it) {
-      props[it.key()] = it.value().is_string() ? it.value().get<std::string>() : it.value().dump();
+          DebugDraw::Line(tip, b0, color);
+          DebugDraw::Line(tip, b1, color);
+          DebugDraw::Line(tip, b2, color);
+          DebugDraw::Line(tip, b3, color);
+          DebugDraw::Line(b0, b1, color);
+          DebugDraw::Line(b1, b2, color);
+          DebugDraw::Line(b2, b3, color);
+          DebugDraw::Line(b3, b0, color);
+
+          const Vec3 dirTip = tip + forward * 0.78f;
+          DebugDraw::Line(tip, dirTip, {1.0f, 0.55f, 0.1f, 1.0f});
+          continue;
+        }
+
+        Vec3 center = obj.position;
+        Vec3 half = obj.scale;
+        if (!m_liveRegistry || !TryPropWorldAabb(*m_liveRegistry, obj, center, half))
+          half = {std::max(half.x, 0.25f), std::max(half.y, 0.25f), std::max(half.z, 0.25f)};
+        else
+        {
+          half.x = std::max(half.x, 0.25f);
+          half.y = std::max(half.y, 0.25f);
+          half.z = std::max(half.z, 0.25f);
+        }
+        DebugDraw::Box(center, half, {0.2f, 0.7f, 1.0f, 1.0f});
+      }
     }
-    return props;
-  };
 
-  auto parseComponents = [&](const json& value, std::vector<ComponentDesc>* out) -> bool {
-    if (!out)
-      return false;
-    if (!value.is_array())
-      return false;
-    std::vector<ComponentDesc> components;
-    for (const json& item : value) {
-      if (!item.is_object() || !item.contains("type") || !item["type"].is_string())
+    void EditorLayer::ApplyPendingViewSnap(Camera &cam)
+    {
+      if (m_pendingViewSnap == ViewSnap::None)
+        return;
+
+      Vec3 pivot = Vec3::Zero();
+      float extent = 1.0f;
+      const int idx = PrimaryIdx();
+      if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+      {
+        const SceneObject &obj = m_document.objects[idx];
+        pivot = obj.position;
+        extent = std::max(obj.scale.x, std::max(obj.scale.y, obj.scale.z));
+      }
+
+      const float distance = std::max(2.0f, extent * 3.0f + 1.0f);
+
+      cam.target = pivot;
+      cam.up = {0.0f, 1.0f, 0.0f};
+
+      switch (m_pendingViewSnap)
+      {
+      case ViewSnap::Top:
+        cam.position = pivot + Vec3{0.0f, distance, 0.0f};
+        cam.up = {0.0f, 0.0f, -1.0f};
+        break;
+      case ViewSnap::Bottom:
+        cam.position = pivot + Vec3{0.0f, -distance, 0.0f};
+        cam.up = {0.0f, 0.0f, 1.0f};
+        break;
+      case ViewSnap::Left:
+        cam.position = pivot + Vec3{-distance, 0.0f, 0.0f};
+        break;
+      case ViewSnap::Right:
+        cam.position = pivot + Vec3{distance, 0.0f, 0.0f};
+        break;
+      case ViewSnap::Front:
+        cam.position = pivot + Vec3{0.0f, 0.0f, distance};
+        break;
+      case ViewSnap::Back:
+        cam.position = pivot + Vec3{0.0f, 0.0f, -distance};
+        break;
+      case ViewSnap::None:
+        break;
+      }
+
+      m_flyCamInitialized = false;
+      m_pendingViewSnap = ViewSnap::None;
+    }
+
+    // ---- Helpers -----------------------------------------------------------------
+
+    bool EditorLayer::IsSelected(int i) const
+    {
+      return std::find(m_selectedIndices.begin(), m_selectedIndices.end(), i) !=
+             m_selectedIndices.end();
+    }
+
+    int EditorLayer::PrimaryIdx() const
+    {
+      return m_selectedIndices.empty() ? -1 : m_selectedIndices.back();
+    }
+
+    void EditorLayer::ToggleSelect(int i)
+    {
+      auto it = std::find(m_selectedIndices.begin(), m_selectedIndices.end(), i);
+      if (it != m_selectedIndices.end())
+        m_selectedIndices.erase(it);
+      else
+        m_selectedIndices.push_back(i);
+    }
+
+    void EditorLayer::TriggerReload()
+    {
+      m_pendingDoc = m_document;
+      m_wantsReload = true;
+    }
+
+    std::vector<std::string> EditorLayer::GetSelectedObjectIds() const
+    {
+      std::vector<std::string> ids;
+      ids.reserve(m_selectedIndices.size());
+      for (int idx : m_selectedIndices)
+      {
+        if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+          ids.push_back(m_document.objects[static_cast<size_t>(idx)].id);
+      }
+      return ids;
+    }
+
+    void EditorLayer::SetSelectedObjectIds(const std::vector<std::string> &ids)
+    {
+      m_selectedIndices.clear();
+      std::unordered_set<std::string> seen;
+      seen.reserve(ids.size());
+      for (const std::string &id : ids)
+      {
+        if (id.empty() || !seen.insert(id).second)
+          continue;
+        for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+        {
+          if (m_document.objects[static_cast<size_t>(i)].id == id)
+          {
+            m_selectedIndices.push_back(i);
+            break;
+          }
+        }
+      }
+    }
+
+    bool EditorLayer::ReloadDocumentFromDisk(std::string *outError,
+                                             const std::vector<std::string> *preferredSelectionIds,
+                                             const std::string *preferredAssetId)
+    {
+      if (outError)
+        outError->clear();
+
+      const std::string path = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
+      try
+      {
+        SceneDocument reloaded = SceneSerializer::LoadFromFile(path);
+        reloaded.dirty = false;
+        ApplyLoadedDocument(std::move(reloaded), false);
+        m_document.filePath = path;
+        m_lastSavedDocument = m_document;
+        if (preferredSelectionIds)
+          SetSelectedObjectIds(*preferredSelectionIds);
+        if (preferredAssetId && m_document.assets.find(*preferredAssetId) != m_document.assets.end())
+          m_selectedAssetId = *preferredAssetId;
+        TriggerReload();
+        return true;
+      }
+      catch (const std::exception &e)
+      {
+        if (outError)
+          *outError = e.what();
         return false;
-      ComponentDesc component;
-      component.type = item["type"].get<std::string>();
-      component.props = parseProps(item.value("props", json::object()));
-      components.push_back(std::move(component));
-    }
-    *out = std::move(components);
-    return true;
-  };
-
-  auto findIndexById = [&](const std::string& id) -> int {
-    for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i) {
-      if (m_document.objects[static_cast<size_t>(i)].id == id)
-        return i;
-    }
-    return -1;
-  };
-
-  auto summarizeObject = [&](const SceneObject& object) {
-    json out = json::object();
-    out["id"] = object.id;
-    out["type"] = SceneObjectTypeToString(object.type);
-    out["position"] = json::array({object.position.x, object.position.y, object.position.z});
-    out["scale"] = json::array({object.scale.x, object.scale.y, object.scale.z});
-    out["yaw"] = object.yaw;
-    out["pitch"] = object.pitch;
-    out["roll"] = object.roll;
-    out["assetId"] = object.assetId;
-    if (object.prefabInstance.has_value()) {
-      out["prefab"] = json{{"id", object.prefabInstance->prefabId},
-                           {"path", object.prefabInstance->sourcePath}};
-    }
-    const auto parentIt = object.props.find("parentId");
-    if (parentIt != object.props.end() && !parentIt->second.empty())
-      out["parentId"] = parentIt->second;
-    return out;
-  };
-
-  auto summarizeAsset = [&](const std::string& assetId, const AssetDef& asset) {
-    int referenceCount = 0;
-    for (const SceneObject& object : m_document.objects) {
-      if (object.assetId == assetId)
-        ++referenceCount;
-    }
-    return json{{"id", assetId},
-                {"guid", asset.guid},
-                {"displayName", asset.displayName},
-                {"mesh", asset.mesh},
-                {"renderScale", asset.renderScale},
-                {"albedoMap", asset.albedoMap},
-                {"objectReferenceCount", referenceCount}};
-  };
-
-  if (toolName == "editor.select") {
-    std::vector<std::string> ids;
-    if (arguments.contains("id") && arguments["id"].is_string())
-      ids.push_back(arguments["id"].get<std::string>());
-    if (arguments.contains("ids") && arguments["ids"].is_array()) {
-      for (const json& item : arguments["ids"]) {
-        if (item.is_string())
-          ids.push_back(item.get<std::string>());
       }
     }
-    m_selectedIndices.clear();
-    for (const std::string& id : ids) {
-      const int idx = findIndexById(id);
-      if (idx >= 0)
-        m_selectedIndices.push_back(idx);
-    }
-    m_selectedAssetId.clear();
-    return Mcp::McpCommandResult{true,
-                                 json{{"selectedObjectIds", GetSelectedObjectIds()}},
-                                 std::string()};
-  }
 
-  if (toolName == "editor.clear_selection") {
-    m_selectedIndices.clear();
-    m_selectedAssetId.clear();
-    return Mcp::McpCommandResult{true, json{{"cleared", true}}, std::string()};
-  }
-
-  if (toolName == "editor.undo") {
-    const bool undone = UndoHistory();
-    return Mcp::McpCommandResult{true,
-                                 json{{"undone", undone},
-                                      {"dirty", m_document.dirty},
-                                      {"selectedObjectIds", GetSelectedObjectIds()},
-                                      {"selectedAssetId", m_selectedAssetId}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.redo") {
-    const bool redone = RedoHistory();
-    return Mcp::McpCommandResult{true,
-                                 json{{"redone", redone},
-                                      {"dirty", m_document.dirty},
-                                      {"selectedObjectIds", GetSelectedObjectIds()},
-                                      {"selectedAssetId", m_selectedAssetId}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.create_object") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    SceneObjectType type = SceneObjectType::Panel;
-    if (!ParseSceneObjectType(arguments.value("type", std::string()), &type))
-      return Mcp::McpCommandResult{false, json::object(), "Invalid object type."};
-
-    SceneObject object;
-    object.type = type;
-    ApplySchemaDefaults(object);
-    object.id = arguments.value("id", std::string());
-    if (object.id.empty())
-      object.id = type == SceneObjectType::Camera ? GenerateCameraId(m_document) : GenerateId(m_document);
-    if (IsReservedObjectId(m_document, object.id))
-      return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
-
-    if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
-      return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
-    if (arguments.contains("scale") && !parseVec3(arguments["scale"], &object.scale))
-      return Mcp::McpCommandResult{false, json::object(), "scale must be [x,y,z]."};
-    object.yaw = arguments.value("yaw", object.yaw);
-    object.pitch = arguments.value("pitch", object.pitch);
-    object.roll = arguments.value("roll", object.roll);
-    object.assetId = arguments.value("assetId", std::string());
-    if (arguments.contains("props"))
-      object.props = parseProps(arguments["props"]);
-    if (arguments.contains("components") && !parseComponents(arguments["components"], &object.components))
-      return Mcp::McpCommandResult{false, json::object(), "components must be an array of objects."};
-    const std::string parentId = arguments.value("parentId", std::string());
-    if (!parentId.empty()) {
-      if (findIndexById(parentId) < 0)
-        return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
-      object.props["parentId"] = parentId;
+    bool EditorLayer::HistorySnapshotsEqual(const EditorHistorySnapshot &lhs,
+                                            const EditorHistorySnapshot &rhs)
+    {
+      return SceneDocumentsEqual(lhs.document, rhs.document) &&
+             SceneDocumentsEqual(lhs.savedDocument, rhs.savedDocument) &&
+             lhs.selectedObjectIds == rhs.selectedObjectIds &&
+             lhs.selectedAssetId == rhs.selectedAssetId;
     }
 
-    m_document.objects.push_back(std::move(object));
-    m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"created", summarizeObject(m_document.objects.back())}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.create_object_from_asset") {
-    const std::string assetId = arguments.value("assetId", std::string());
-    Vec3 position = Vec3::Zero();
-    const Vec3* positionPtr = nullptr;
-    if (arguments.contains("position") && !parseVec3(arguments["position"], &position))
-      return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
-    if (arguments.contains("position"))
-      positionPtr = &position;
-
-    const std::string requestedId = arguments.value("id", std::string());
-    const std::string parentId = arguments.value("parentId", std::string());
-    SceneObject createdObject;
-    std::string createError;
-    if (!CreateObjectFromAsset(assetId,
-                               parentId,
-                               positionPtr,
-                               requestedId.empty() ? nullptr : &requestedId,
-                               &createdObject,
-                               &createError)) {
-      return Mcp::McpCommandResult{false, json::object(), createError};
+    void EditorLayer::TrimHistory(std::vector<EditorHistorySnapshot> *history)
+    {
+      if (!history)
+        return;
+      if (history->size() <= kMaxEditorHistorySnapshots)
+        return;
+      history->erase(history->begin(),
+                     history->begin() + static_cast<std::ptrdiff_t>(history->size() - kMaxEditorHistorySnapshots));
     }
-    SceneObject& object = m_document.objects.back();
-    object.yaw = arguments.value("yaw", object.yaw);
-    object.pitch = arguments.value("pitch", object.pitch);
-    object.roll = arguments.value("roll", object.roll);
-    if (m_transformCb)
-      m_transformCb(object);
-    TriggerReload();
 
-    return Mcp::McpCommandResult{true,
-                                 json{{"created", summarizeObject(object)}},
-                                 std::string()};
-  }
+    EditorLayer::EditorHistorySnapshot EditorLayer::CaptureHistorySnapshot() const
+    {
+      EditorHistorySnapshot snapshot;
+      snapshot.document = m_document;
+      snapshot.savedDocument = m_lastSavedDocument;
+      snapshot.selectedObjectIds = GetSelectedObjectIds();
+      snapshot.selectedAssetId = m_selectedAssetId;
+      return snapshot;
+    }
 
-  if (toolName == "editor.create_prefab") {
-    const std::string id = arguments.value("id", std::string());
-    if (!id.empty())
-      SetSelectedObjectIds({id});
-
-    std::string prefabPath;
-    std::string prefabError;
-    if (!CreatePrefabFromSelection(&prefabError, &prefabPath))
-      return Mcp::McpCommandResult{false, json::object(), prefabError};
-
-    const int idx = PrimaryIdx();
-    const SceneObject* object =
-        (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
-            ? &m_document.objects[static_cast<size_t>(idx)]
-            : nullptr;
-    return Mcp::McpCommandResult{
-        true,
-        json{{"prefabPath", prefabPath},
-             {"prefabId", object && object->prefabInstance.has_value() ? object->prefabInstance->prefabId
-                                                                       : std::string()},
-             {"instance", object ? summarizeObject(*object) : json::object()}},
-        std::string()};
-  }
-
-  if (toolName == "editor.update_object" || toolName == "editor.transform") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    const std::string id = arguments.value("id", std::string());
-    const int idx = findIndexById(id);
-    if (idx < 0)
-      return Mcp::McpCommandResult{false, json::object(), "Object not found."};
-
-    SceneObject& object = m_document.objects[static_cast<size_t>(idx)];
-    if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
-      return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
-    if (arguments.contains("scale") && !parseVec3(arguments["scale"], &object.scale))
-      return Mcp::McpCommandResult{false, json::object(), "scale must be [x,y,z]."};
-    if (arguments.contains("yaw"))
-      object.yaw = arguments["yaw"].get<float>();
-    if (arguments.contains("pitch"))
-      object.pitch = arguments["pitch"].get<float>();
-    if (arguments.contains("roll"))
-      object.roll = arguments["roll"].get<float>();
-    if (toolName == "editor.update_object") {
-      if (arguments.contains("assetId"))
-        object.assetId = arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
-      if (arguments.contains("props")) {
-        const auto props = parseProps(arguments["props"]);
-        for (const auto& entry : props)
-          object.props[entry.first] = entry.second;
+    void EditorLayer::RestoreHistorySnapshot(const EditorHistorySnapshot &snapshot)
+    {
+      m_document = snapshot.document;
+      m_lastSavedDocument = snapshot.savedDocument;
+      SetSelectedObjectIds(snapshot.selectedObjectIds);
+      if (!snapshot.selectedAssetId.empty() &&
+          m_document.assets.find(snapshot.selectedAssetId) != m_document.assets.end())
+      {
+        m_selectedAssetId = snapshot.selectedAssetId;
       }
-      if (arguments.contains("components") &&
-          !parseComponents(arguments["components"], &object.components)) {
-        return Mcp::McpCommandResult{false, json::object(), "components must be an array of objects."};
+      else
+      {
+        m_selectedAssetId.clear();
+      }
+      TriggerReload();
+    }
+
+    void EditorLayer::CommitHistoryChange(const EditorHistorySnapshot &before)
+    {
+      const EditorHistorySnapshot after = CaptureHistorySnapshot();
+      if (HistorySnapshotsEqual(before, after))
+        return;
+
+      m_undoHistory.push_back(before);
+      TrimHistory(&m_undoHistory);
+      m_redoHistory.clear();
+    }
+
+    void EditorLayer::BeginHistoryTransaction(const EditorHistorySnapshot &before)
+    {
+      if (m_historyTransactionOpen)
+        return;
+      m_historyTransactionBefore = before;
+      m_historyTransactionOpen = true;
+    }
+
+    void EditorLayer::FinalizeHistoryTransaction()
+    {
+      if (!m_historyTransactionOpen)
+        return;
+      CommitHistoryChange(m_historyTransactionBefore);
+      m_historyTransactionOpen = false;
+    }
+
+    void EditorLayer::ClearHistory()
+    {
+      m_undoHistory.clear();
+      m_redoHistory.clear();
+      m_historyTransactionOpen = false;
+    }
+
+    void EditorLayer::RefreshHistorySavedBaseline()
+    {
+      auto refreshSnapshot = [this](EditorHistorySnapshot *snapshot)
+      {
+        if (!snapshot)
+          return;
+        if (snapshot->document.filePath == m_document.filePath)
+        {
+          snapshot->savedDocument = m_lastSavedDocument;
+          snapshot->document.dirty = !SceneDocumentsEqual(snapshot->document, snapshot->savedDocument);
+        }
+      };
+
+      for (EditorHistorySnapshot &snapshot : m_undoHistory)
+        refreshSnapshot(&snapshot);
+      for (EditorHistorySnapshot &snapshot : m_redoHistory)
+        refreshSnapshot(&snapshot);
+      if (m_historyTransactionOpen)
+        refreshSnapshot(&m_historyTransactionBefore);
+    }
+
+    bool EditorLayer::CanUndoHistory() const
+    {
+      return !m_undoHistory.empty();
+    }
+
+    bool EditorLayer::CanRedoHistory() const
+    {
+      return !m_redoHistory.empty();
+    }
+
+    bool EditorLayer::UndoHistory()
+    {
+      FinalizeHistoryTransaction();
+      if (m_undoHistory.empty())
+        return false;
+
+      const EditorHistorySnapshot current = CaptureHistorySnapshot();
+      const EditorHistorySnapshot target = m_undoHistory.back();
+      m_undoHistory.pop_back();
+      m_redoHistory.push_back(current);
+      TrimHistory(&m_redoHistory);
+      RestoreHistorySnapshot(target);
+      return true;
+    }
+
+    bool EditorLayer::RedoHistory()
+    {
+      FinalizeHistoryTransaction();
+      if (m_redoHistory.empty())
+        return false;
+
+      const EditorHistorySnapshot current = CaptureHistorySnapshot();
+      const EditorHistorySnapshot target = m_redoHistory.back();
+      m_redoHistory.pop_back();
+      m_undoHistory.push_back(current);
+      TrimHistory(&m_undoHistory);
+      RestoreHistorySnapshot(target);
+      return true;
+    }
+
+    void EditorLayer::ProcessMcpCommands()
+    {
+      m_mcpController.DrainCommands([this](const std::string &toolName, const nlohmann::json &arguments)
+                                    { return ExecuteMcpCommand(toolName, arguments); });
+    }
+
+    void EditorLayer::PublishMcpSnapshot()
+    {
+      Mcp::McpEditorSnapshot snapshot;
+      snapshot.editorActive = m_active;
+      snapshot.playMode = m_playMode;
+      snapshot.dirty = m_document.dirty;
+      snapshot.reloadPending = m_wantsReload;
+      snapshot.sceneId = m_document.sceneId;
+      snapshot.sceneName = m_document.sceneName;
+      snapshot.sceneFilePath = m_document.filePath;
+      snapshot.selectedAssetId = m_selectedAssetId;
+
+      for (int idx : m_selectedIndices)
+      {
+        if (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+          snapshot.selectedObjectIds.push_back(m_document.objects[static_cast<size_t>(idx)].id);
+      }
+
+      snapshot.objects.reserve(m_document.objects.size());
+      for (const SceneObject &object : m_document.objects)
+      {
+        Mcp::McpObjectSnapshot entry;
+        entry.id = object.id;
+        entry.type = SceneObjectTypeToString(object.type);
+        entry.position = object.position;
+        entry.scale = object.scale;
+        entry.yaw = object.yaw;
+        entry.pitch = object.pitch;
+        entry.roll = object.roll;
+        entry.assetId = object.assetId;
+        entry.props = object.props;
+        for (const ComponentDesc &component : object.components)
+        {
+          Mcp::McpComponentSnapshot componentEntry;
+          componentEntry.type = component.type;
+          componentEntry.props = component.props;
+          entry.components.push_back(std::move(componentEntry));
+        }
+        snapshot.objects.push_back(std::move(entry));
+      }
+
+      std::vector<std::string> assetIds;
+      assetIds.reserve(m_document.assets.size());
+      for (const auto &entry : m_document.assets)
+        assetIds.push_back(entry.first);
+      std::sort(assetIds.begin(), assetIds.end());
+      for (const std::string &assetId : assetIds)
+      {
+        const AssetDef &asset = m_document.assets.at(assetId);
+        snapshot.assets.push_back(Mcp::McpAssetSnapshot{assetId, asset.mesh, asset.renderScale,
+                                                        asset.albedoMap});
+      }
+
+      std::vector<LogLine> lines;
+      LogBuffer::Instance().CopyLinesTo(&lines);
+      const size_t start = lines.size() > 50 ? lines.size() - 50 : 0;
+      for (size_t i = start; i < lines.size(); ++i)
+      {
+        char timeBuf[32];
+        FormatLogTime(lines[i], timeBuf, sizeof(timeBuf));
+        snapshot.consoleEntries.push_back(Mcp::McpConsoleEntry{
+            timeBuf,
+            lines[i].level == LogLevel::Info ? "INFO" : lines[i].level == LogLevel::Warn ? "WARN"
+                                                                                         : "ERR",
+            lines[i].message,
+        });
+      }
+
+      snapshot.build = BuildMcpBuildSnapshot(m_document);
+      snapshot.schema = BuildMcpSchemaCatalogSnapshot(m_schema);
+      m_mcpController.PublishSnapshot(snapshot);
+    }
+
+    Mcp::McpCommandResult EditorLayer::ExecuteMcpCommand(const std::string &toolName,
+                                                         const nlohmann::json &arguments)
+    {
+      using json = nlohmann::json;
+
+      auto parseVec3 = [](const json &value, Vec3 *out) -> bool
+      {
+        if (!out || !value.is_array() || value.size() != 3)
+          return false;
+        if (!value[0].is_number() || !value[1].is_number() || !value[2].is_number())
+          return false;
+        out->x = value[0].get<float>();
+        out->y = value[1].get<float>();
+        out->z = value[2].get<float>();
+        return true;
+      };
+
+      auto parseProps = [](const json &value)
+      {
+        std::unordered_map<std::string, std::string> props;
+        if (!value.is_object())
+          return props;
+        for (auto it = value.begin(); it != value.end(); ++it)
+        {
+          props[it.key()] = it.value().is_string() ? it.value().get<std::string>() : it.value().dump();
+        }
+        return props;
+      };
+
+      auto parseComponents = [&](const json &value, std::vector<ComponentDesc> *out) -> bool
+      {
+        if (!out)
+          return false;
+        if (!value.is_array())
+          return false;
+        std::vector<ComponentDesc> components;
+        for (const json &item : value)
+        {
+          if (!item.is_object() || !item.contains("type") || !item["type"].is_string())
+            return false;
+          ComponentDesc component;
+          component.type = item["type"].get<std::string>();
+          component.props = parseProps(item.value("props", json::object()));
+          components.push_back(std::move(component));
+        }
+        *out = std::move(components);
+        return true;
+      };
+
+      auto findIndexById = [&](const std::string &id) -> int
+      {
+        for (int i = 0; i < static_cast<int>(m_document.objects.size()); ++i)
+        {
+          if (m_document.objects[static_cast<size_t>(i)].id == id)
+            return i;
+        }
+        return -1;
+      };
+
+      auto summarizeObject = [&](const SceneObject &object)
+      {
+        json out = json::object();
+        out["id"] = object.id;
+        out["type"] = SceneObjectTypeToString(object.type);
+        out["position"] = json::array({object.position.x, object.position.y, object.position.z});
+        out["scale"] = json::array({object.scale.x, object.scale.y, object.scale.z});
+        out["yaw"] = object.yaw;
+        out["pitch"] = object.pitch;
+        out["roll"] = object.roll;
+        out["assetId"] = object.assetId;
+        if (object.prefabInstance.has_value())
+        {
+          out["prefab"] = json{{"id", object.prefabInstance->prefabId},
+                               {"path", object.prefabInstance->sourcePath}};
+        }
+        const auto parentIt = object.props.find("parentId");
+        if (parentIt != object.props.end() && !parentIt->second.empty())
+          out["parentId"] = parentIt->second;
+        return out;
+      };
+
+      auto summarizeAsset = [&](const std::string &assetId, const AssetDef &asset)
+      {
+        int referenceCount = 0;
+        for (const SceneObject &object : m_document.objects)
+        {
+          if (object.assetId == assetId)
+            ++referenceCount;
+        }
+        return json{{"id", assetId},
+                    {"guid", asset.guid},
+                    {"displayName", asset.displayName},
+                    {"mesh", asset.mesh},
+                    {"renderScale", asset.renderScale},
+                    {"albedoMap", asset.albedoMap},
+                    {"objectReferenceCount", referenceCount}};
+      };
+
+      if (toolName == "editor.select")
+      {
+        std::vector<std::string> ids;
+        if (arguments.contains("id") && arguments["id"].is_string())
+          ids.push_back(arguments["id"].get<std::string>());
+        if (arguments.contains("ids") && arguments["ids"].is_array())
+        {
+          for (const json &item : arguments["ids"])
+          {
+            if (item.is_string())
+              ids.push_back(item.get<std::string>());
+          }
+        }
+        m_selectedIndices.clear();
+        for (const std::string &id : ids)
+        {
+          const int idx = findIndexById(id);
+          if (idx >= 0)
+            m_selectedIndices.push_back(idx);
+        }
+        m_selectedAssetId.clear();
+        return Mcp::McpCommandResult{true,
+                                     json{{"selectedObjectIds", GetSelectedObjectIds()}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.clear_selection")
+      {
+        m_selectedIndices.clear();
+        m_selectedAssetId.clear();
+        return Mcp::McpCommandResult{true, json{{"cleared", true}}, std::string()};
+      }
+
+      if (toolName == "editor.undo")
+      {
+        const bool undone = UndoHistory();
+        return Mcp::McpCommandResult{true,
+                                     json{{"undone", undone},
+                                          {"dirty", m_document.dirty},
+                                          {"selectedObjectIds", GetSelectedObjectIds()},
+                                          {"selectedAssetId", m_selectedAssetId}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.redo")
+      {
+        const bool redone = RedoHistory();
+        return Mcp::McpCommandResult{true,
+                                     json{{"redone", redone},
+                                          {"dirty", m_document.dirty},
+                                          {"selectedObjectIds", GetSelectedObjectIds()},
+                                          {"selectedAssetId", m_selectedAssetId}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.create_object")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        SceneObjectType type = SceneObjectType::Panel;
+        if (!ParseSceneObjectType(arguments.value("type", std::string()), &type))
+          return Mcp::McpCommandResult{false, json::object(), "Invalid object type."};
+
+        SceneObject object;
+        object.type = type;
+        ApplySchemaDefaults(object);
+        object.id = arguments.value("id", std::string());
+        if (object.id.empty())
+          object.id = type == SceneObjectType::Camera ? GenerateCameraId(m_document) : GenerateId(m_document);
+        if (IsReservedObjectId(m_document, object.id))
+          return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
+
+        if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
+          return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
+        if (arguments.contains("scale") && !parseVec3(arguments["scale"], &object.scale))
+          return Mcp::McpCommandResult{false, json::object(), "scale must be [x,y,z]."};
+        object.yaw = arguments.value("yaw", object.yaw);
+        object.pitch = arguments.value("pitch", object.pitch);
+        object.roll = arguments.value("roll", object.roll);
+        object.assetId = arguments.value("assetId", std::string());
+        if (arguments.contains("props"))
+          object.props = parseProps(arguments["props"]);
+        if (arguments.contains("components") && !parseComponents(arguments["components"], &object.components))
+          return Mcp::McpCommandResult{false, json::object(), "components must be an array of objects."};
+        const std::string parentId = arguments.value("parentId", std::string());
+        if (!parentId.empty())
+        {
+          if (findIndexById(parentId) < 0)
+            return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
+          object.props["parentId"] = parentId;
+        }
+
+        m_document.objects.push_back(std::move(object));
+        m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"created", summarizeObject(m_document.objects.back())}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.create_object_from_asset")
+      {
+        const std::string assetId = arguments.value("assetId", std::string());
+        Vec3 position = Vec3::Zero();
+        const Vec3 *positionPtr = nullptr;
+        if (arguments.contains("position") && !parseVec3(arguments["position"], &position))
+          return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
+        if (arguments.contains("position"))
+          positionPtr = &position;
+
+        const std::string requestedId = arguments.value("id", std::string());
+        const std::string parentId = arguments.value("parentId", std::string());
+        SceneObject createdObject;
+        std::string createError;
+        if (!CreateObjectFromAsset(assetId,
+                                   parentId,
+                                   positionPtr,
+                                   requestedId.empty() ? nullptr : &requestedId,
+                                   &createdObject,
+                                   &createError))
+        {
+          return Mcp::McpCommandResult{false, json::object(), createError};
+        }
+        SceneObject &object = m_document.objects.back();
+        object.yaw = arguments.value("yaw", object.yaw);
+        object.pitch = arguments.value("pitch", object.pitch);
+        object.roll = arguments.value("roll", object.roll);
+        if (m_transformCb)
+          m_transformCb(object);
+        TriggerReload();
+
+        return Mcp::McpCommandResult{true,
+                                     json{{"created", summarizeObject(object)}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.create_prefab")
+      {
+        const std::string id = arguments.value("id", std::string());
+        if (!id.empty())
+          SetSelectedObjectIds({id});
+
+        std::string prefabPath;
+        std::string prefabError;
+        if (!CreatePrefabFromSelection(&prefabError, &prefabPath))
+          return Mcp::McpCommandResult{false, json::object(), prefabError};
+
+        const int idx = PrimaryIdx();
+        const SceneObject *object =
+            (idx >= 0 && idx < static_cast<int>(m_document.objects.size()))
+                ? &m_document.objects[static_cast<size_t>(idx)]
+                : nullptr;
+        return Mcp::McpCommandResult{
+            true,
+            json{{"prefabPath", prefabPath},
+                 {"prefabId", object && object->prefabInstance.has_value() ? object->prefabInstance->prefabId
+                                                                           : std::string()},
+                 {"instance", object ? summarizeObject(*object) : json::object()}},
+            std::string()};
+      }
+
+      if (toolName == "editor.update_object" || toolName == "editor.transform")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::string id = arguments.value("id", std::string());
+        const int idx = findIndexById(id);
+        if (idx < 0)
+          return Mcp::McpCommandResult{false, json::object(), "Object not found."};
+
+        SceneObject &object = m_document.objects[static_cast<size_t>(idx)];
+        if (arguments.contains("position") && !parseVec3(arguments["position"], &object.position))
+          return Mcp::McpCommandResult{false, json::object(), "position must be [x,y,z]."};
+        if (arguments.contains("scale") && !parseVec3(arguments["scale"], &object.scale))
+          return Mcp::McpCommandResult{false, json::object(), "scale must be [x,y,z]."};
+        if (arguments.contains("yaw"))
+          object.yaw = arguments["yaw"].get<float>();
+        if (arguments.contains("pitch"))
+          object.pitch = arguments["pitch"].get<float>();
+        if (arguments.contains("roll"))
+          object.roll = arguments["roll"].get<float>();
+        if (toolName == "editor.update_object")
+        {
+          if (arguments.contains("assetId"))
+            object.assetId = arguments["assetId"].is_null() ? std::string() : arguments["assetId"].get<std::string>();
+          if (arguments.contains("props"))
+          {
+            const auto props = parseProps(arguments["props"]);
+            for (const auto &entry : props)
+              object.props[entry.first] = entry.second;
+          }
+          if (arguments.contains("components") &&
+              !parseComponents(arguments["components"], &object.components))
+          {
+            return Mcp::McpCommandResult{false, json::object(), "components must be an array of objects."};
+          }
+        }
+        m_document.dirty = true;
+        if (m_transformCb)
+          m_transformCb(object);
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true, json{{"updated", summarizeObject(object)}}, std::string()};
+      }
+
+      if (toolName == "editor.rename_object")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::string id = arguments.value("id", std::string());
+        const std::string newId = arguments.value("newId", std::string());
+        const int idx = findIndexById(id);
+        if (idx < 0)
+          return Mcp::McpCommandResult{false, json::object(), "Object not found."};
+        if (newId.empty())
+          return Mcp::McpCommandResult{false, json::object(), "newId is required."};
+        if (id != newId && IsReservedObjectId(m_document, newId, &id))
+          return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
+
+        SceneObject &object = m_document.objects[static_cast<size_t>(idx)];
+        const std::string oldId = object.id;
+        object.id = newId;
+        RewriteObjectIdReferences(&m_document, oldId, newId);
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"renamed", true}, {"oldId", oldId}, {"newId", newId}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.reparent_object")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::string id = arguments.value("id", std::string());
+        const int idx = findIndexById(id);
+        if (idx < 0)
+          return Mcp::McpCommandResult{false, json::object(), "Object not found."};
+
+        const std::string parentId = arguments.value("parentId", std::string());
+        if (!parentId.empty())
+        {
+          const int parentIdx = findIndexById(parentId);
+          if (parentIdx < 0)
+            return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
+          if (parentIdx == idx)
+            return Mcp::McpCommandResult{false, json::object(), "Object cannot parent itself."};
+          if (IsDescendantOf(m_document, parentIdx, idx))
+            return Mcp::McpCommandResult{false, json::object(), "Parent would create a cycle."};
+          m_document.objects[static_cast<size_t>(idx)].props["parentId"] = parentId;
+        }
+        else
+        {
+          m_document.objects[static_cast<size_t>(idx)].props.erase("parentId");
+        }
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"id", id}, {"parentId", parentId}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.duplicate")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        std::vector<int> sourceIndices;
+        if (arguments.contains("id") && arguments["id"].is_string())
+        {
+          const int idx = findIndexById(arguments["id"].get<std::string>());
+          if (idx >= 0)
+            sourceIndices.push_back(idx);
+        }
+        if (arguments.contains("ids") && arguments["ids"].is_array())
+        {
+          for (const json &item : arguments["ids"])
+          {
+            if (!item.is_string())
+              continue;
+            const int idx = findIndexById(item.get<std::string>());
+            if (idx >= 0)
+              sourceIndices.push_back(idx);
+          }
+        }
+        if (sourceIndices.empty())
+          return Mcp::McpCommandResult{false, json::object(), "Object not found."};
+
+        std::sort(sourceIndices.begin(), sourceIndices.end());
+        sourceIndices.erase(std::unique(sourceIndices.begin(), sourceIndices.end()), sourceIndices.end());
+
+        const int count =
+            (sourceIndices.size() == 1) ? std::max(1, std::min(8, arguments.value("count", 1))) : 1;
+        json created = json::array();
+        std::vector<int> duplicatedIndices;
+        for (int idx : sourceIndices)
+        {
+          for (int i = 0; i < count; ++i)
+          {
+            SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(idx)]);
+            clone.position.x += static_cast<float>(i + 1);
+            clone.position.z += static_cast<float>(i + 1);
+            m_document.objects.push_back(std::move(clone));
+            duplicatedIndices.push_back(static_cast<int>(m_document.objects.size()) - 1);
+            created.push_back(summarizeObject(m_document.objects.back()));
+          }
+        }
+        m_selectedIndices = std::move(duplicatedIndices);
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true, json{{"duplicates", std::move(created)}}, std::string()};
+      }
+
+      if (toolName == "editor.delete")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        std::vector<int> indices;
+        if (arguments.contains("id") && arguments["id"].is_string())
+        {
+          const int idx = findIndexById(arguments["id"].get<std::string>());
+          if (idx >= 0)
+            indices.push_back(idx);
+        }
+        if (arguments.contains("ids") && arguments["ids"].is_array())
+        {
+          for (const json &item : arguments["ids"])
+          {
+            if (!item.is_string())
+              continue;
+            const int idx = findIndexById(item.get<std::string>());
+            if (idx >= 0)
+              indices.push_back(idx);
+          }
+        }
+        if (indices.empty())
+          return Mcp::McpCommandResult{false, json::object(), "No matching objects to delete."};
+
+        std::sort(indices.begin(), indices.end());
+        indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
+        std::sort(indices.rbegin(), indices.rend());
+        for (int idx : indices)
+          m_document.objects.erase(m_document.objects.begin() + idx);
+        m_selectedIndices.clear();
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"deletedCount", static_cast<int>(indices.size())}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.select_asset")
+      {
+        const std::string assetId = arguments.value("id", std::string());
+        if (!assetId.empty() && m_document.assets.find(assetId) == m_document.assets.end())
+          return Mcp::McpCommandResult{false, json::object(), "Asset not found."};
+        m_selectedAssetId = assetId;
+        return Mcp::McpCommandResult{true, json{{"selectedAssetId", m_selectedAssetId}}, std::string()};
+      }
+
+      if (toolName == "editor.update_asset")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::string assetId = arguments.value("id", std::string());
+        auto it = m_document.assets.find(assetId);
+        if (it == m_document.assets.end())
+          return Mcp::McpCommandResult{false, json::object(), "Asset not found."};
+        if (arguments.contains("mesh"))
+          it->second.mesh = arguments["mesh"].is_null() ? std::string() : arguments["mesh"].get<std::string>();
+        if (arguments.contains("renderScale"))
+          it->second.renderScale =
+              arguments["renderScale"].is_null() ? std::string() : arguments["renderScale"].get<std::string>();
+        if (arguments.contains("albedoMap"))
+          it->second.albedoMap =
+              arguments["albedoMap"].is_null() ? std::string() : arguments["albedoMap"].get<std::string>();
+        if (arguments.contains("displayName"))
+          it->second.displayName =
+              arguments["displayName"].is_null() ? std::string() : arguments["displayName"].get<std::string>();
+        EnsureAssetIdentity(assetId, &it->second);
+        m_document.dirty = true;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"asset", summarizeAsset(assetId, it->second)}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.delete_asset")
+      {
+        const std::string assetId = arguments.value("id", std::string());
+        const AssetDeleteResult deleteResult = DeleteAssetDefinition(assetId);
+        if (!deleteResult.ok)
+          return Mcp::McpCommandResult{false, json::object(), deleteResult.error};
+
+        json payload{{"deletedAssetId", assetId},
+                     {"clearedObjectReferences", deleteResult.clearedReferences},
+                     {"deletedManagedFiles", deleteResult.deletedManagedFiles}};
+        if (!deleteResult.deletedAssetDirectory.empty())
+          payload["deletedAssetDirectory"] = deleteResult.deletedAssetDirectory;
+        return Mcp::McpCommandResult{true,
+                                     std::move(payload),
+                                     std::string()};
+      }
+
+      if (toolName == "editor.new_scene")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        AddNewScene();
+        if (arguments.contains("sceneId") && arguments["sceneId"].is_string() &&
+            !arguments["sceneId"].get<std::string>().empty())
+        {
+          m_document.sceneId = arguments["sceneId"].get<std::string>();
+        }
+        if (arguments.contains("sceneName") && arguments["sceneName"].is_string() &&
+            !arguments["sceneName"].get<std::string>().empty())
+        {
+          m_document.sceneName = arguments["sceneName"].get<std::string>();
+        }
+        m_lastSavedDocument = m_document;
+        TriggerReload();
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"sceneId", m_document.sceneId},
+                                          {"sceneName", m_document.sceneName},
+                                          {"dirty", m_document.dirty}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.save_scene")
+      {
+        std::string saveError;
+        if (!SaveDocument(&saveError))
+          return Mcp::McpCommandResult{false, json::object(), saveError};
+        return Mcp::McpCommandResult{true, json{{"saved", true}, {"filePath", m_document.filePath}},
+                                     std::string()};
+      }
+
+      if (toolName == "editor.reload_scene")
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::vector<std::string> previousSelectionIds = GetSelectedObjectIds();
+        const std::string previousAssetId = m_selectedAssetId;
+        std::string reloadError;
+        if (!ReloadDocumentFromDisk(&reloadError, &previousSelectionIds, &previousAssetId))
+          return Mcp::McpCommandResult{false, json::object(), reloadError};
+        CommitHistoryChange(before);
+        return Mcp::McpCommandResult{true,
+                                     json{{"reloadPending", true},
+                                          {"filePath", m_document.filePath},
+                                          {"dirty", m_document.dirty}},
+                                     std::string()};
+      }
+
+      return Mcp::McpCommandResult{false, json::object(), "Unsupported MCP command."};
+    }
+
+    bool EditorLayer::SaveDocument(std::string *outError)
+    {
+      if (outError)
+        outError->clear();
+
+      FinalizeHistoryTransaction();
+
+      std::string path = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
+      m_document.filePath = path;
+      EnsureAssetIdentity(&m_document);
+
+      LOG_INFO("[Editor] Saving scene to: %s", path.c_str());
+
+      try
+      {
+        if (!EnsureAssetMetadataForDocument(&m_document, outError))
+        {
+          LOG_ERROR("[Editor] Asset metadata save failed: %s", outError ? outError->c_str() : "");
+          return false;
+        }
+        SceneSerializer::SaveToFile(m_document, path);
+        m_document.dirty = false;
+        m_lastSavedDocument = m_document;
+        RefreshHistorySavedBaseline();
+        LOG_INFO("[Editor] Scene saved OK");
+        TriggerReload(); // rebuild scene so changes are immediately visible
+        return true;
+      }
+      catch (const std::exception &e)
+      {
+        LOG_ERROR("[Editor] Save failed: %s", e.what());
+        if (outError)
+          *outError = e.what();
+        return false;
       }
     }
-    m_document.dirty = true;
-    if (m_transformCb)
-      m_transformCb(object);
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true, json{{"updated", summarizeObject(object)}}, std::string()};
-  }
 
-  if (toolName == "editor.rename_object") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    const std::string id = arguments.value("id", std::string());
-    const std::string newId = arguments.value("newId", std::string());
-    const int idx = findIndexById(id);
-    if (idx < 0)
-      return Mcp::McpCommandResult{false, json::object(), "Object not found."};
-    if (newId.empty())
-      return Mcp::McpCommandResult{false, json::object(), "newId is required."};
-    if (id != newId && IsReservedObjectId(m_document, newId, &id))
-      return Mcp::McpCommandResult{false, json::object(), "Object id already exists."};
-
-    SceneObject& object = m_document.objects[static_cast<size_t>(idx)];
-    const std::string oldId = object.id;
-    object.id = newId;
-    RewriteObjectIdReferences(&m_document, oldId, newId);
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"renamed", true}, {"oldId", oldId}, {"newId", newId}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.reparent_object") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    const std::string id = arguments.value("id", std::string());
-    const int idx = findIndexById(id);
-    if (idx < 0)
-      return Mcp::McpCommandResult{false, json::object(), "Object not found."};
-
-    const std::string parentId = arguments.value("parentId", std::string());
-    if (!parentId.empty()) {
-      const int parentIdx = findIndexById(parentId);
-      if (parentIdx < 0)
-        return Mcp::McpCommandResult{false, json::object(), "Parent object not found."};
-      if (parentIdx == idx)
-        return Mcp::McpCommandResult{false, json::object(), "Object cannot parent itself."};
-      if (IsDescendantOf(m_document, parentIdx, idx))
-        return Mcp::McpCommandResult{false, json::object(), "Parent would create a cycle."};
-      m_document.objects[static_cast<size_t>(idx)].props["parentId"] = parentId;
-    } else {
-      m_document.objects[static_cast<size_t>(idx)].props.erase("parentId");
-    }
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"id", id}, {"parentId", parentId}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.duplicate") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    std::vector<int> sourceIndices;
-    if (arguments.contains("id") && arguments["id"].is_string()) {
-      const int idx = findIndexById(arguments["id"].get<std::string>());
-      if (idx >= 0)
-        sourceIndices.push_back(idx);
-    }
-    if (arguments.contains("ids") && arguments["ids"].is_array()) {
-      for (const json& item : arguments["ids"]) {
-        if (!item.is_string())
-          continue;
-        const int idx = findIndexById(item.get<std::string>());
-        if (idx >= 0)
-          sourceIndices.push_back(idx);
+    EditorLayer::AssetDeleteResult EditorLayer::DeleteAssetDefinition(const std::string &assetId)
+    {
+      AssetDeleteResult result;
+      auto it = m_document.assets.find(assetId);
+      if (it == m_document.assets.end())
+      {
+        result.error = "Asset not found.";
+        return result;
       }
-    }
-    if (sourceIndices.empty())
-      return Mcp::McpCommandResult{false, json::object(), "Object not found."};
 
-    std::sort(sourceIndices.begin(), sourceIndices.end());
-    sourceIndices.erase(std::unique(sourceIndices.begin(), sourceIndices.end()), sourceIndices.end());
+      const EditorHistorySnapshot before = CaptureHistorySnapshot();
 
-    const int count =
-        (sourceIndices.size() == 1) ? std::max(1, std::min(8, arguments.value("count", 1))) : 1;
-    json created = json::array();
-    std::vector<int> duplicatedIndices;
-    for (int idx : sourceIndices) {
-      for (int i = 0; i < count; ++i) {
-        SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(idx)]);
-        clone.position.x += static_cast<float>(i + 1);
-        clone.position.z += static_cast<float>(i + 1);
-        m_document.objects.push_back(std::move(clone));
-        duplicatedIndices.push_back(static_cast<int>(m_document.objects.size()) - 1);
-        created.push_back(summarizeObject(m_document.objects.back()));
+      const std::filesystem::path managedDirectory = GetManagedImportedAssetDirectory(it->second);
+      if (!managedDirectory.empty())
+      {
+        std::error_code ec;
+        const bool existedBeforeDelete = std::filesystem::exists(managedDirectory, ec) && !ec;
+        ec.clear();
+        std::filesystem::remove_all(managedDirectory, ec);
+        if (ec)
+        {
+          result.error = "Failed to delete imported asset files: " + ec.message();
+          return result;
+        }
+        result.deletedManagedFiles = existedBeforeDelete;
+        result.deletedAssetDirectory = managedDirectory.generic_string();
       }
-    }
-    m_selectedIndices = std::move(duplicatedIndices);
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true, json{{"duplicates", std::move(created)}}, std::string()};
-  }
 
-  if (toolName == "editor.delete") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    std::vector<int> indices;
-    if (arguments.contains("id") && arguments["id"].is_string()) {
-      const int idx = findIndexById(arguments["id"].get<std::string>());
-      if (idx >= 0)
-        indices.push_back(idx);
-    }
-    if (arguments.contains("ids") && arguments["ids"].is_array()) {
-      for (const json& item : arguments["ids"]) {
-        if (!item.is_string())
-          continue;
-        const int idx = findIndexById(item.get<std::string>());
-        if (idx >= 0)
-          indices.push_back(idx);
+      for (SceneObject &object : m_document.objects)
+      {
+        if (object.assetId == assetId)
+        {
+          object.assetId.clear();
+          ++result.clearedReferences;
+        }
       }
-    }
-    if (indices.empty())
-      return Mcp::McpCommandResult{false, json::object(), "No matching objects to delete."};
+      if (m_selectedAssetId == assetId)
+        m_selectedAssetId.clear();
 
-    std::sort(indices.begin(), indices.end());
-    indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
-    std::sort(indices.rbegin(), indices.rend());
-    for (int idx : indices)
-      m_document.objects.erase(m_document.objects.begin() + idx);
-    m_selectedIndices.clear();
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"deletedCount", static_cast<int>(indices.size())}},
-                                 std::string()};
-  }
+      m_document.assets.erase(it);
+      m_document.dirty = true;
+      TriggerReload();
+      CommitHistoryChange(before);
 
-  if (toolName == "editor.select_asset") {
-    const std::string assetId = arguments.value("id", std::string());
-    if (!assetId.empty() && m_document.assets.find(assetId) == m_document.assets.end())
-      return Mcp::McpCommandResult{false, json::object(), "Asset not found."};
-    m_selectedAssetId = assetId;
-    return Mcp::McpCommandResult{true, json{{"selectedAssetId", m_selectedAssetId}}, std::string()};
-  }
-
-  if (toolName == "editor.update_asset") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    const std::string assetId = arguments.value("id", std::string());
-    auto it = m_document.assets.find(assetId);
-    if (it == m_document.assets.end())
-      return Mcp::McpCommandResult{false, json::object(), "Asset not found."};
-    if (arguments.contains("mesh"))
-      it->second.mesh = arguments["mesh"].is_null() ? std::string() : arguments["mesh"].get<std::string>();
-    if (arguments.contains("renderScale"))
-      it->second.renderScale =
-          arguments["renderScale"].is_null() ? std::string() : arguments["renderScale"].get<std::string>();
-    if (arguments.contains("albedoMap"))
-      it->second.albedoMap =
-          arguments["albedoMap"].is_null() ? std::string() : arguments["albedoMap"].get<std::string>();
-    if (arguments.contains("displayName"))
-      it->second.displayName =
-          arguments["displayName"].is_null() ? std::string() : arguments["displayName"].get<std::string>();
-    EnsureAssetIdentity(assetId, &it->second);
-    m_document.dirty = true;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"asset", summarizeAsset(assetId, it->second)}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.delete_asset") {
-    const std::string assetId = arguments.value("id", std::string());
-    const AssetDeleteResult deleteResult = DeleteAssetDefinition(assetId);
-    if (!deleteResult.ok)
-      return Mcp::McpCommandResult{false, json::object(), deleteResult.error};
-
-    json payload{{"deletedAssetId", assetId},
-                 {"clearedObjectReferences", deleteResult.clearedReferences},
-                 {"deletedManagedFiles", deleteResult.deletedManagedFiles}};
-    if (!deleteResult.deletedAssetDirectory.empty())
-      payload["deletedAssetDirectory"] = deleteResult.deletedAssetDirectory;
-    return Mcp::McpCommandResult{true,
-                                 std::move(payload),
-                                 std::string()};
-  }
-
-  if (toolName == "editor.new_scene") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    AddNewScene();
-    if (arguments.contains("sceneId") && arguments["sceneId"].is_string() &&
-        !arguments["sceneId"].get<std::string>().empty()) {
-      m_document.sceneId = arguments["sceneId"].get<std::string>();
-    }
-    if (arguments.contains("sceneName") && arguments["sceneName"].is_string() &&
-        !arguments["sceneName"].get<std::string>().empty()) {
-      m_document.sceneName = arguments["sceneName"].get<std::string>();
-    }
-    m_lastSavedDocument = m_document;
-    TriggerReload();
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"sceneId", m_document.sceneId},
-                                      {"sceneName", m_document.sceneName},
-                                      {"dirty", m_document.dirty}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.save_scene") {
-    std::string saveError;
-    if (!SaveDocument(&saveError))
-      return Mcp::McpCommandResult{false, json::object(), saveError};
-    return Mcp::McpCommandResult{true, json{{"saved", true}, {"filePath", m_document.filePath}},
-                                 std::string()};
-  }
-
-  if (toolName == "editor.reload_scene") {
-    const EditorHistorySnapshot before = CaptureHistorySnapshot();
-    const std::vector<std::string> previousSelectionIds = GetSelectedObjectIds();
-    const std::string previousAssetId = m_selectedAssetId;
-    std::string reloadError;
-    if (!ReloadDocumentFromDisk(&reloadError, &previousSelectionIds, &previousAssetId))
-      return Mcp::McpCommandResult{false, json::object(), reloadError};
-    CommitHistoryChange(before);
-    return Mcp::McpCommandResult{true,
-                                 json{{"reloadPending", true},
-                                      {"filePath", m_document.filePath},
-                                      {"dirty", m_document.dirty}},
-                                 std::string()};
-  }
-
-  return Mcp::McpCommandResult{false, json::object(), "Unsupported MCP command."};
-}
-
-bool EditorLayer::SaveDocument(std::string* outError) {
-  if (outError)
-    outError->clear();
-
-  FinalizeHistoryTransaction();
-
-  std::string path = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
-  m_document.filePath = path;
-  EnsureAssetIdentity(&m_document);
-
-  LOG_INFO("[Editor] Saving scene to: %s", path.c_str());
-
-  try {
-    if (!EnsureAssetMetadataForDocument(&m_document, outError)) {
-      LOG_ERROR("[Editor] Asset metadata save failed: %s", outError ? outError->c_str() : "");
-      return false;
-    }
-    SceneSerializer::SaveToFile(m_document, path);
-    m_document.dirty = false;
-    m_lastSavedDocument = m_document;
-    RefreshHistorySavedBaseline();
-    LOG_INFO("[Editor] Scene saved OK");
-    TriggerReload();  // rebuild scene so changes are immediately visible
-    return true;
-  } catch (const std::exception& e) {
-    LOG_ERROR("[Editor] Save failed: %s", e.what());
-    if (outError)
-      *outError = e.what();
-    return false;
-  }
-}
-
-EditorLayer::AssetDeleteResult EditorLayer::DeleteAssetDefinition(const std::string& assetId) {
-  AssetDeleteResult result;
-  auto it = m_document.assets.find(assetId);
-  if (it == m_document.assets.end()) {
-    result.error = "Asset not found.";
-    return result;
-  }
-
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-
-  const std::filesystem::path managedDirectory = GetManagedImportedAssetDirectory(it->second);
-  if (!managedDirectory.empty()) {
-    std::error_code ec;
-    const bool existedBeforeDelete = std::filesystem::exists(managedDirectory, ec) && !ec;
-    ec.clear();
-    std::filesystem::remove_all(managedDirectory, ec);
-    if (ec) {
-      result.error = "Failed to delete imported asset files: " + ec.message();
+      result.ok = true;
       return result;
     }
-    result.deletedManagedFiles = existedBeforeDelete;
-    result.deletedAssetDirectory = managedDirectory.generic_string();
-  }
 
-  for (SceneObject& object : m_document.objects) {
-    if (object.assetId == assetId) {
-      object.assetId.clear();
-      ++result.clearedReferences;
+    void EditorLayer::DiscardUnsavedChanges()
+    {
+      if (!m_document.dirty)
+        return;
+
+      m_document = m_lastSavedDocument;
+      m_selectedIndices.clear();
+      m_selectedAssetId.clear();
+      TriggerReload();
     }
-  }
-  if (m_selectedAssetId == assetId)
-    m_selectedAssetId.clear();
 
-  m_document.assets.erase(it);
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
+    void EditorLayer::RequestSceneAction(PendingSceneAction action)
+    {
+      if (action == PendingSceneAction::None)
+        return;
 
-  result.ok = true;
-  return result;
-}
+      m_pendingSceneAction = action;
+      m_exitConfirmError.clear();
+      if (m_document.dirty)
+      {
+        m_confirmExitOpen = true;
+        return;
+      }
 
-void EditorLayer::DiscardUnsavedChanges() {
-  if (!m_document.dirty)
-    return;
+      std::string actionError;
+      if (!ExecutePendingSceneAction(&actionError))
+        LOG_ERROR("[Editor] Scene action failed: %s", actionError.c_str());
+    }
 
-  m_document = m_lastSavedDocument;
-  m_selectedIndices.clear();
-  m_selectedAssetId.clear();
-  TriggerReload();
-}
+    bool EditorLayer::ExecutePendingSceneAction(std::string *outError)
+    {
+      if (outError)
+        outError->clear();
 
-void EditorLayer::RequestSceneAction(PendingSceneAction action) {
-  if (action == PendingSceneAction::None)
-    return;
+      const PendingSceneAction action = m_pendingSceneAction;
+      m_pendingSceneAction = PendingSceneAction::None;
 
-  m_pendingSceneAction = action;
-  m_exitConfirmError.clear();
-  if (m_document.dirty) {
-    m_confirmExitOpen = true;
-    return;
-  }
+      switch (action)
+      {
+      case PendingSceneAction::None:
+        return true;
+      case PendingSceneAction::NewScene:
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        AddNewScene();
+        m_lastSavedDocument = m_document;
+        CommitHistoryChange(before);
+        return true;
+      }
+      case PendingSceneAction::OpenSceneFile:
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        OpenAdditionalSceneFile();
+        CommitHistoryChange(before);
+        return true;
+      }
+      case PendingSceneAction::LoadSceneFromDisk:
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::vector<std::string> selectionIds = GetSelectedObjectIds();
+        const std::string selectedAssetId = m_selectedAssetId;
+        const bool ok = ReloadDocumentFromDisk(outError, &selectionIds, &selectedAssetId);
+        if (ok)
+          CommitHistoryChange(before);
+        return ok;
+      }
+      case PendingSceneAction::ReloadSceneFromDisk:
+      {
+        const EditorHistorySnapshot before = CaptureHistorySnapshot();
+        const std::vector<std::string> selectionIds = GetSelectedObjectIds();
+        const std::string selectedAssetId = m_selectedAssetId;
+        const bool ok = ReloadDocumentFromDisk(outError, &selectionIds, &selectedAssetId);
+        if (ok)
+          CommitHistoryChange(before);
+        return ok;
+      }
+      case PendingSceneAction::CloseEditor:
+        m_closeRequested = true;
+        return true;
+      }
 
-  std::string actionError;
-  if (!ExecutePendingSceneAction(&actionError))
-    LOG_ERROR("[Editor] Scene action failed: %s", actionError.c_str());
-}
-
-bool EditorLayer::ExecutePendingSceneAction(std::string* outError) {
-  if (outError)
-    outError->clear();
-
-  const PendingSceneAction action = m_pendingSceneAction;
-  m_pendingSceneAction = PendingSceneAction::None;
-
-  switch (action) {
-    case PendingSceneAction::None:
       return true;
-    case PendingSceneAction::NewScene: {
+    }
+
+    void EditorLayer::ExecuteCommandPaletteAction(const std::string &commandId)
+    {
+      if (commandId == "undo")
+        UndoHistory();
+      else if (commandId == "redo")
+        RedoHistory();
+      else if (commandId == "new_scene")
+        RequestSceneAction(PendingSceneAction::NewScene);
+      else if (commandId == "open_scene")
+        RequestSceneAction(PendingSceneAction::OpenSceneFile);
+      else if (commandId == "load_scene")
+        RequestSceneAction(PendingSceneAction::LoadSceneFromDisk);
+      else if (commandId == "reload_scene")
+        RequestSceneAction(PendingSceneAction::ReloadSceneFromDisk);
+      else if (commandId == "save_scene")
+      {
+        std::string saveError;
+        if (!SaveDocument(&saveError))
+          LOG_ERROR("[Editor] Save failed: %s", saveError.c_str());
+      }
+      else if (commandId == "reset_layout")
+      {
+        m_resetDockLayoutRequested = true;
+      }
+      else if (commandId == "quick_open")
+      {
+        m_quickOpenOpen = true;
+        m_quickOpenQuery.clear();
+      }
+      else if (commandId == "close_editor")
+      {
+        RequestSceneAction(PendingSceneAction::CloseEditor);
+      }
+    }
+
+    bool EditorLayer::CreatePrefabFromSelection(std::string *outError, std::string *outPrefabPath)
+    {
+      if (outError)
+        outError->clear();
+      if (outPrefabPath)
+        outPrefabPath->clear();
+
+      const int primaryIdx = PrimaryIdx();
+      if (m_selectedIndices.size() != 1 ||
+          primaryIdx < 0 ||
+          primaryIdx >= static_cast<int>(m_document.objects.size()))
+      {
+        if (outError)
+          *outError = "Select exactly one object to create a prefab.";
+        return false;
+      }
+
       const EditorHistorySnapshot before = CaptureHistorySnapshot();
-      AddNewScene();
-      m_lastSavedDocument = m_document;
+      const SceneObject &sourceObject = m_document.objects[static_cast<size_t>(primaryIdx)];
+      const std::filesystem::path prefabAbsPath = BuildUniquePrefabPath(m_document, sourceObject);
+      std::error_code ec;
+      std::filesystem::create_directories(prefabAbsPath.parent_path(), ec);
+      if (ec)
+      {
+        if (outError)
+          *outError = "Failed to create prefab directory: " + ec.message();
+        return false;
+      }
+
+      SceneDocument prefabDoc;
+      prefabDoc.version = m_document.version;
+      prefabDoc.sceneId = prefabAbsPath.stem().string();
+      prefabDoc.sceneName = sourceObject.id.empty() ? prefabDoc.sceneId : sourceObject.id;
+      prefabDoc.filePath = prefabAbsPath.generic_string();
+
+      SceneObject prefabObject = sourceObject;
+      prefabObject.prefabInstance.reset();
+      prefabObject.props.erase("parentId");
+      prefabDoc.objects.push_back(std::move(prefabObject));
+      if (!sourceObject.assetId.empty())
+      {
+        const auto assetIt = m_document.assets.find(sourceObject.assetId);
+        if (assetIt != m_document.assets.end())
+          prefabDoc.assets[sourceObject.assetId] = assetIt->second;
+      }
+
+      try
+      {
+        SceneSerializer::SaveToFile(prefabDoc, prefabAbsPath.generic_string());
+      }
+      catch (const std::exception &e)
+      {
+        if (outError)
+          *outError = e.what();
+        return false;
+      }
+
+      const std::filesystem::path relativePath =
+          prefabAbsPath.lexically_relative(ProjectPath::Root()).lexically_normal();
+      SceneObject &object = m_document.objects[static_cast<size_t>(primaryIdx)];
+      object.prefabInstance = ScenePrefabInstance{prefabDoc.sceneId, relativePath.generic_string()};
+      m_document.dirty = true;
+      TriggerReload();
       CommitHistoryChange(before);
+
+      if (outPrefabPath)
+        *outPrefabPath = relativePath.generic_string();
       return true;
     }
-    case PendingSceneAction::OpenSceneFile:
+
+    void EditorLayer::RequestDeleteSelectedObjects()
+    {
+      if (m_selectedIndices.empty())
+        return;
+
+      m_pendingDeleteObjectIndices = m_selectedIndices;
+      m_confirmDeleteObjectsOpen = true;
+    }
+
+    void EditorLayer::RequestDeleteAsset(const std::string &assetId)
+    {
+      if (assetId.empty())
+        return;
+      if (m_document.assets.find(assetId) == m_document.assets.end())
+        return;
+
+      m_pendingDeleteAssetId = assetId;
+      m_pendingDeleteAssetError.clear();
+      m_confirmDeleteAssetOpen = true;
+    }
+
+    void EditorLayer::OpenRenameObjectModal(int index)
+    {
+      if (index < 0 || index >= static_cast<int>(m_document.objects.size()))
+        return;
+      m_renameObjectIndex = index;
+      m_renameObjectDraft = m_document.objects[static_cast<size_t>(index)].id;
+      m_renameObjectError.clear();
+      m_renameObjectOpen = true;
+    }
+
+    void EditorLayer::AddObject(SceneObjectType type, const std::string &parentId)
     {
       const EditorHistorySnapshot before = CaptureHistorySnapshot();
-      OpenAdditionalSceneFile();
+      SceneObject obj;
+      obj.id = (type == SceneObjectType::Camera) ? GenerateCameraId(m_document) : GenerateId(m_document);
+      obj.type = type;
+      ApplySchemaDefaults(obj);
+      if (type == SceneObjectType::Camera)
+      {
+        obj.props["fov"] = "60";
+        obj.props["nearClip"] = "0.1";
+        obj.props["farClip"] = "500";
+        obj.props["followTargetId"] = "";
+      }
+      if (!parentId.empty())
+        obj.props["parentId"] = parentId;
+
+      m_document.objects.push_back(std::move(obj));
+      m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+      m_document.dirty = true;
+      TriggerReload();
       CommitHistoryChange(before);
-      return true;
     }
-    case PendingSceneAction::LoadSceneFromDisk: {
-      const EditorHistorySnapshot before = CaptureHistorySnapshot();
-      const std::vector<std::string> selectionIds = GetSelectedObjectIds();
-      const std::string selectedAssetId = m_selectedAssetId;
-      const bool ok = ReloadDocumentFromDisk(outError, &selectionIds, &selectedAssetId);
-      if (ok)
-        CommitHistoryChange(before);
-      return ok;
+
+    void EditorLayer::AddObjectFromSelectedAsset(const std::string &parentId)
+    {
+      CreateObjectFromAsset(m_selectedAssetId, parentId);
     }
-    case PendingSceneAction::ReloadSceneFromDisk: {
-      const EditorHistorySnapshot before = CaptureHistorySnapshot();
-      const std::vector<std::string> selectionIds = GetSelectedObjectIds();
-      const std::string selectedAssetId = m_selectedAssetId;
-      const bool ok = ReloadDocumentFromDisk(outError, &selectionIds, &selectedAssetId);
-      if (ok)
-        CommitHistoryChange(before);
-      return ok;
-    }
-    case PendingSceneAction::CloseEditor:
-      m_closeRequested = true;
-      return true;
-  }
 
-  return true;
-}
-
-void EditorLayer::ExecuteCommandPaletteAction(const std::string& commandId) {
-  if (commandId == "undo")
-    UndoHistory();
-  else if (commandId == "redo")
-    RedoHistory();
-  else if (commandId == "new_scene")
-    RequestSceneAction(PendingSceneAction::NewScene);
-  else if (commandId == "open_scene")
-    RequestSceneAction(PendingSceneAction::OpenSceneFile);
-  else if (commandId == "load_scene")
-    RequestSceneAction(PendingSceneAction::LoadSceneFromDisk);
-  else if (commandId == "reload_scene")
-    RequestSceneAction(PendingSceneAction::ReloadSceneFromDisk);
-  else if (commandId == "save_scene") {
-    std::string saveError;
-    if (!SaveDocument(&saveError))
-      LOG_ERROR("[Editor] Save failed: %s", saveError.c_str());
-  } else if (commandId == "reset_layout") {
-    m_resetDockLayoutRequested = true;
-  } else if (commandId == "quick_open") {
-    m_quickOpenOpen = true;
-    m_quickOpenQuery.clear();
-  } else if (commandId == "close_editor") {
-    RequestSceneAction(PendingSceneAction::CloseEditor);
-  }
-}
-
-bool EditorLayer::CreatePrefabFromSelection(std::string* outError, std::string* outPrefabPath) {
-  if (outError)
-    outError->clear();
-  if (outPrefabPath)
-    outPrefabPath->clear();
-
-  const int primaryIdx = PrimaryIdx();
-  if (m_selectedIndices.size() != 1 ||
-      primaryIdx < 0 ||
-      primaryIdx >= static_cast<int>(m_document.objects.size())) {
-    if (outError)
-      *outError = "Select exactly one object to create a prefab.";
-    return false;
-  }
-
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-  const SceneObject& sourceObject = m_document.objects[static_cast<size_t>(primaryIdx)];
-  const std::filesystem::path prefabAbsPath = BuildUniquePrefabPath(m_document, sourceObject);
-  std::error_code ec;
-  std::filesystem::create_directories(prefabAbsPath.parent_path(), ec);
-  if (ec) {
-    if (outError)
-      *outError = "Failed to create prefab directory: " + ec.message();
-    return false;
-  }
-
-  SceneDocument prefabDoc;
-  prefabDoc.version = m_document.version;
-  prefabDoc.sceneId = prefabAbsPath.stem().string();
-  prefabDoc.sceneName = sourceObject.id.empty() ? prefabDoc.sceneId : sourceObject.id;
-  prefabDoc.filePath = prefabAbsPath.generic_string();
-
-  SceneObject prefabObject = sourceObject;
-  prefabObject.prefabInstance.reset();
-  prefabObject.props.erase("parentId");
-  prefabDoc.objects.push_back(std::move(prefabObject));
-  if (!sourceObject.assetId.empty()) {
-    const auto assetIt = m_document.assets.find(sourceObject.assetId);
-    if (assetIt != m_document.assets.end())
-      prefabDoc.assets[sourceObject.assetId] = assetIt->second;
-  }
-
-  try {
-    SceneSerializer::SaveToFile(prefabDoc, prefabAbsPath.generic_string());
-  } catch (const std::exception& e) {
-    if (outError)
-      *outError = e.what();
-    return false;
-  }
-
-  const std::filesystem::path relativePath =
-      prefabAbsPath.lexically_relative(ProjectPath::Root()).lexically_normal();
-  SceneObject& object = m_document.objects[static_cast<size_t>(primaryIdx)];
-  object.prefabInstance = ScenePrefabInstance{prefabDoc.sceneId, relativePath.generic_string()};
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
-
-  if (outPrefabPath)
-    *outPrefabPath = relativePath.generic_string();
-  return true;
-}
-
-void EditorLayer::RequestDeleteSelectedObjects() {
-  if (m_selectedIndices.empty())
-    return;
-
-  m_pendingDeleteObjectIndices = m_selectedIndices;
-  m_confirmDeleteObjectsOpen = true;
-}
-
-void EditorLayer::RequestDeleteAsset(const std::string& assetId) {
-  if (assetId.empty())
-    return;
-  if (m_document.assets.find(assetId) == m_document.assets.end())
-    return;
-
-  m_pendingDeleteAssetId = assetId;
-  m_pendingDeleteAssetError.clear();
-  m_confirmDeleteAssetOpen = true;
-}
-
-void EditorLayer::OpenRenameObjectModal(int index) {
-  if (index < 0 || index >= static_cast<int>(m_document.objects.size()))
-    return;
-  m_renameObjectIndex = index;
-  m_renameObjectDraft = m_document.objects[static_cast<size_t>(index)].id;
-  m_renameObjectError.clear();
-  m_renameObjectOpen = true;
-}
-
-void EditorLayer::AddObject(SceneObjectType type, const std::string& parentId) {
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-  SceneObject obj;
-  obj.id = (type == SceneObjectType::Camera) ? GenerateCameraId(m_document) : GenerateId(m_document);
-  obj.type = type;
-  ApplySchemaDefaults(obj);
-  if (type == SceneObjectType::Camera) {
-    obj.props["fov"] = "60";
-    obj.props["nearClip"] = "0.1";
-    obj.props["farClip"] = "500";
-    obj.props["followTargetId"] = "";
-  }
-  if (!parentId.empty())
-    obj.props["parentId"] = parentId;
-
-  m_document.objects.push_back(std::move(obj));
-  m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
-}
-
-void EditorLayer::AddObjectFromSelectedAsset(const std::string& parentId) {
-  CreateObjectFromAsset(m_selectedAssetId, parentId);
-}
-
-bool EditorLayer::CreateObjectFromAsset(const std::string& assetId,
-                                        const std::string& parentId,
-                                        const Vec3* worldPosition,
-                                        const std::string* preferredId,
-                                        SceneObject* outCreated,
-                                        std::string* outError) {
-  if (outError)
-    outError->clear();
-
-  if (assetId.empty() || m_document.assets.find(assetId) == m_document.assets.end()) {
-    if (outError)
-      *outError = "Asset not found.";
-    return false;
-  }
-  if (!parentId.empty() && FindObjectIndexById(m_document, parentId) < 0) {
-    if (outError)
-      *outError = "Parent object not found.";
-    return false;
-  }
-
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-
-  SceneObject object = MakeObjectFromAsset(m_document, assetId, m_schema);
-  if (preferredId && !preferredId->empty()) {
-    if (IsReservedObjectId(m_document, *preferredId)) {
+    bool EditorLayer::CreateObjectFromAsset(const std::string &assetId,
+                                            const std::string &parentId,
+                                            const Vec3 *worldPosition,
+                                            const std::string *preferredId,
+                                            SceneObject *outCreated,
+                                            std::string *outError)
+    {
       if (outError)
-        *outError = "Object id already exists.";
-      return false;
+        outError->clear();
+
+      if (assetId.empty() || m_document.assets.find(assetId) == m_document.assets.end())
+      {
+        if (outError)
+          *outError = "Asset not found.";
+        return false;
+      }
+      if (!parentId.empty() && FindObjectIndexById(m_document, parentId) < 0)
+      {
+        if (outError)
+          *outError = "Parent object not found.";
+        return false;
+      }
+
+      const EditorHistorySnapshot before = CaptureHistorySnapshot();
+
+      SceneObject object = MakeObjectFromAsset(m_document, assetId, m_schema);
+      if (preferredId && !preferredId->empty())
+      {
+        if (IsReservedObjectId(m_document, *preferredId))
+        {
+          if (outError)
+            *outError = "Object id already exists.";
+          return false;
+        }
+        object.id = *preferredId;
+      }
+      if (!parentId.empty())
+        object.props["parentId"] = parentId;
+      if (worldPosition)
+        object.position = *worldPosition;
+
+      m_document.objects.push_back(object);
+      m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+      m_selectedAssetId = assetId;
+      m_document.dirty = true;
+      TriggerReload();
+      CommitHistoryChange(before);
+
+      if (outCreated)
+        *outCreated = m_document.objects.back();
+      return true;
     }
-    object.id = *preferredId;
-  }
-  if (!parentId.empty())
-    object.props["parentId"] = parentId;
-  if (worldPosition)
-    object.position = *worldPosition;
 
-  m_document.objects.push_back(object);
-  m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
-  m_selectedAssetId = assetId;
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
+    bool EditorLayer::TryBuildViewportDropPosition(const Camera &cam,
+                                                   int screenW,
+                                                   int screenH,
+                                                   const std::string &assetId,
+                                                   Vec3 *outPosition) const
+    {
+      if (!outPosition)
+        return false;
 
-  if (outCreated)
-    *outCreated = m_document.objects.back();
-  return true;
-}
+      double mx = 0.0;
+      double my = 0.0;
+      glfwGetCursorPos(m_window, &mx, &my);
+      const Ray ray = ScreenToRay(static_cast<float>(mx), static_cast<float>(my), screenW, screenH, cam);
 
-bool EditorLayer::TryBuildViewportDropPosition(const Camera& cam,
-                                               int screenW,
-                                               int screenH,
-                                               const std::string& assetId,
-                                               Vec3* outPosition) const {
-  if (!outPosition)
-    return false;
+      const SceneObject droppedObject = MakeObjectFromAsset(m_document, assetId, m_schema);
+      const Vec3 droppedHalf = ResolveObjectPlacementHalfExtents(droppedObject);
 
-  double mx = 0.0;
-  double my = 0.0;
-  glfwGetCursorPos(m_window, &mx, &my);
-  const Ray ray = ScreenToRay(static_cast<float>(mx), static_cast<float>(my), screenW, screenH, cam);
+      RayAabbHit bestHit;
+      bool hasSurfaceHit = false;
+      for (const SceneObject &object : m_document.objects)
+      {
+        Vec3 center = Vec3::Zero();
+        Vec3 half = Vec3::Zero();
+        if (!TryGetPlacementSurfaceBounds(m_liveRegistry, object, &center, &half))
+          continue;
 
-  const SceneObject droppedObject = MakeObjectFromAsset(m_document, assetId, m_schema);
-  const Vec3 droppedHalf = ResolveObjectPlacementHalfExtents(droppedObject);
+        RayAabbHit hit;
+        if (!RayVsAABBHit(ray, center, half, &hit))
+          continue;
+        if (!hasSurfaceHit || hit.distance < bestHit.distance)
+        {
+          bestHit = hit;
+          hasSurfaceHit = true;
+        }
+      }
 
-  RayAabbHit bestHit;
-  bool hasSurfaceHit = false;
-  for (const SceneObject& object : m_document.objects) {
-    Vec3 center = Vec3::Zero();
-    Vec3 half = Vec3::Zero();
-    if (!TryGetPlacementSurfaceBounds(m_liveRegistry, object, &center, &half))
-      continue;
+      if (hasSurfaceHit)
+      {
+        *outPosition =
+            bestHit.point + bestHit.normal * ProjectHalfExtentOntoNormal(droppedHalf, bestHit.normal);
+        return true;
+      }
 
-    RayAabbHit hit;
-    if (!RayVsAABBHit(ray, center, half, &hit))
-      continue;
-    if (!hasSurfaceHit || hit.distance < bestHit.distance) {
-      bestHit = hit;
-      hasSurfaceHit = true;
+      Vec3 groundHit = Vec3::Zero();
+      if (!TryIntersectGroundPlane(ray, &groundHit))
+        return false;
+
+      *outPosition =
+          groundHit + Vec3::Up() * ProjectHalfExtentOntoNormal(droppedHalf, Vec3::Up());
+      return true;
     }
-  }
 
-  if (hasSurfaceHit) {
-    *outPosition =
-        bestHit.point + bestHit.normal * ProjectHalfExtentOntoNormal(droppedHalf, bestHit.normal);
-    return true;
-  }
-
-  Vec3 groundHit = Vec3::Zero();
-  if (!TryIntersectGroundPlane(ray, &groundHit))
-    return false;
-
-  *outPosition =
-      groundHit + Vec3::Up() * ProjectHalfExtentOntoNormal(droppedHalf, Vec3::Up());
-  return true;
-}
-
-void EditorLayer::DuplicatePrimarySelection() {
-  const int primaryIdx = PrimaryIdx();
-  if (primaryIdx < 0 || primaryIdx >= static_cast<int>(m_document.objects.size()))
-    return;
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-  SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(primaryIdx)]);
-  clone.position.x += 1.0f;
-  clone.position.z += 1.0f;
-  m_document.objects.push_back(std::move(clone));
-  m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
-}
-
-void EditorLayer::DuplicateSelectedObjects() {
-  if (m_selectedIndices.empty())
-    return;
-  if (m_selectedIndices.size() == 1) {
-    DuplicatePrimarySelection();
-    return;
-  }
-
-  const EditorHistorySnapshot before = CaptureHistorySnapshot();
-
-  std::vector<int> sourceIndices = m_selectedIndices;
-  std::sort(sourceIndices.begin(), sourceIndices.end());
-  sourceIndices.erase(std::unique(sourceIndices.begin(), sourceIndices.end()), sourceIndices.end());
-
-  std::vector<int> duplicatedIndices;
-  duplicatedIndices.reserve(sourceIndices.size());
-  for (int idx : sourceIndices) {
-    if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
-      continue;
-    SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(idx)]);
-    clone.position.x += 1.0f;
-    clone.position.z += 1.0f;
-    m_document.objects.push_back(std::move(clone));
-    duplicatedIndices.push_back(static_cast<int>(m_document.objects.size()) - 1);
-  }
-
-  if (!duplicatedIndices.empty())
-    m_selectedIndices = std::move(duplicatedIndices);
-  m_document.dirty = true;
-  TriggerReload();
-  CommitHistoryChange(before);
-}
-
-SceneObject EditorLayer::MakeObjectFromAsset(const SceneDocument& doc,
-                                             const std::string& assetId,
-                                             const EditorSchema& schema) {
-  SceneObject obj;
-  obj.id = GenerateId(doc);
-  obj.type = SceneObjectType::Prop;
-  obj.assetId = assetId;
-  const auto assetIt = doc.assets.find(assetId);
-  if (assetIt != doc.assets.end())
-    obj.props["_assetRenderScale"] = assetIt->second.renderScale.empty() ? "1.0000,1.0000,1.0000"
-                                                                         : assetIt->second.renderScale;
-
-  const TypeSchema* typeSchema = schema.GetSchema(obj.type);
-  if (typeSchema) {
-    for (const auto& fd : typeSchema->fields)
-      obj.props[fd.key] = fd.defaultValue;
-  }
-
-  return obj;
-}
-
-SceneObject EditorLayer::DuplicateObject(const SceneDocument& doc, const SceneObject& src) {
-  SceneObject clone = src;
-  clone.id = GenerateId(doc);
-  clone.props.erase("_eid");
-  return clone;
-}
-
-std::string EditorLayer::BuildSelectionRefCode(const SceneObject& obj, int idx) const {
-  auto typeToStr = [](SceneObjectType t) {
-    switch (t) {
-      case SceneObjectType::Panel:
-        return "Panel";
-      case SceneObjectType::Prop:
-        return "Prop";
-      case SceneObjectType::Light:
-        return "Light";
-      case SceneObjectType::Camera:
-        return "Camera";
+    void EditorLayer::DuplicatePrimarySelection()
+    {
+      const int primaryIdx = PrimaryIdx();
+      if (primaryIdx < 0 || primaryIdx >= static_cast<int>(m_document.objects.size()))
+        return;
+      const EditorHistorySnapshot before = CaptureHistorySnapshot();
+      SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(primaryIdx)]);
+      clone.position.x += 1.0f;
+      clone.position.z += 1.0f;
+      m_document.objects.push_back(std::move(clone));
+      m_selectedIndices = {static_cast<int>(m_document.objects.size()) - 1};
+      m_document.dirty = true;
+      TriggerReload();
+      CommitHistoryChange(before);
     }
-    return "Unknown";
-  };
 
-  auto getProp = [&](const char* key) -> std::string {
-    auto it = obj.props.find(key);
-    return (it != obj.props.end()) ? it->second : "";
-  };
+    void EditorLayer::DuplicateSelectedObjects()
+    {
+      if (m_selectedIndices.empty())
+        return;
+      if (m_selectedIndices.size() == 1)
+      {
+        DuplicatePrimarySelection();
+        return;
+      }
 
-  std::ostringstream ss;
-  ss.setf(std::ios::fixed);
-  ss.precision(4);
-  const std::string scenePath = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
-  ss << "EDITOR_REF"
-     << " scene=\"" << scenePath << "\""
-     << " id=" << obj.id
-     << " idx=" << idx
-     << " type=" << typeToStr(obj.type)
-     << " pos=(" << obj.position.x << "," << obj.position.y << "," << obj.position.z << ")"
-     << " scale=(" << obj.scale.x << "," << obj.scale.y << "," << obj.scale.z << ")"
-     << " yaw=" << obj.yaw;
+      const EditorHistorySnapshot before = CaptureHistorySnapshot();
 
-  const std::string mesh = getProp("mesh");
-  if (!mesh.empty())
-    ss << " mesh=\"" << mesh << "\"";
+      std::vector<int> sourceIndices = m_selectedIndices;
+      std::sort(sourceIndices.begin(), sourceIndices.end());
+      sourceIndices.erase(std::unique(sourceIndices.begin(), sourceIndices.end()), sourceIndices.end());
 
-  const std::string eid = getProp("_eid");
-  if (!eid.empty())
-    ss << " _eid=" << eid;
+      std::vector<int> duplicatedIndices;
+      duplicatedIndices.reserve(sourceIndices.size());
+      for (int idx : sourceIndices)
+      {
+        if (idx < 0 || idx >= static_cast<int>(m_document.objects.size()))
+          continue;
+        SceneObject clone = DuplicateObject(m_document, m_document.objects[static_cast<size_t>(idx)]);
+        clone.position.x += 1.0f;
+        clone.position.z += 1.0f;
+        m_document.objects.push_back(std::move(clone));
+        duplicatedIndices.push_back(static_cast<int>(m_document.objects.size()) - 1);
+      }
 
-  return ss.str();
-}
-
-std::string EditorLayer::GenerateId(const SceneDocument& doc) {
-  const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
-
-  for (int i = 0; i < 1000000; ++i) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "obj_%03d", i);
-    if (existingIds.find(buf) == existingIds.end())
-      return buf;
-  }
-  return "obj_new";
-}
-
-std::string EditorLayer::GenerateCameraId(const SceneDocument& doc) {
-  const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
-
-  for (int i = 0; i < 1000000; ++i) {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "cam_%03d", i);
-    if (existingIds.find(buf) == existingIds.end())
-      return buf;
-  }
-  return "cam_new";
-}
-
-// ---- Fly camera --------------------------------------------------------------
-
-void EditorLayer::ToggleFlyMode(Camera& cam) {
-  m_flyMode = !m_flyMode;
-  m_flyCamInitialized = false;
-  m_prevCursorInit = false;
-  glfwSetInputMode(m_window, GLFW_CURSOR,
-                   m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
-  (void)cam;  // camera sync happens lazily in UpdateFlyCamera
-}
-
-void EditorLayer::UpdateFlyCamera(float dt, Camera& cam) {
-  // Fly mode always uses world-up to avoid inverted controls after view snaps.
-  cam.up = Vec3::Up();
-
-  // --- Sync yaw/pitch from live camera on first frame ---
-  if (!m_flyCamInitialized) {
-    Vec3 dir = cam.target - cam.position;
-    float len = std::sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-    if (len > 0.001f) {
-      dir.x /= len;
-      dir.y /= len;
-      dir.z /= len;
+      if (!duplicatedIndices.empty())
+        m_selectedIndices = std::move(duplicatedIndices);
+      m_document.dirty = true;
+      TriggerReload();
+      CommitHistoryChange(before);
     }
-    m_flyPitch = std::asin(std::max(-1.0f, std::min(1.0f, dir.y))) * (180.0f / PI);
 
-    // If the camera is nearly vertical (Top/Bottom snap), yaw is ill-defined.
-    // Keep previous yaw to avoid sudden axis flips when entering fly mode.
-    const float horizLen = std::sqrt(dir.x * dir.x + dir.z * dir.z);
-    if (horizLen > 0.0001f)
-      m_flyYaw = -std::atan2(dir.x, -dir.z) * (180.0f / PI);
+    SceneObject EditorLayer::MakeObjectFromAsset(const SceneDocument &doc,
+                                                 const std::string &assetId,
+                                                 const EditorSchema &schema)
+    {
+      SceneObject obj;
+      obj.id = GenerateId(doc);
+      obj.type = SceneObjectType::Prop;
+      obj.assetId = assetId;
+      const auto assetIt = doc.assets.find(assetId);
+      if (assetIt != doc.assets.end())
+        obj.props["_assetRenderScale"] = assetIt->second.renderScale.empty() ? "1.0000,1.0000,1.0000"
+                                                                             : assetIt->second.renderScale;
 
-    m_flyCamInitialized = true;
-  }
+      const TypeSchema *typeSchema = schema.GetSchema(obj.type);
+      if (typeSchema)
+      {
+        for (const auto &fd : typeSchema->fields)
+          obj.props[fd.key] = fd.defaultValue;
+      }
 
-  // --- Mouse look ---
-  double cx, cy;
-  glfwGetCursorPos(m_window, &cx, &cy);
-  if (!m_prevCursorInit) {
-    m_prevCursorX = cx;
-    m_prevCursorY = cy;
-    m_prevCursorInit = true;
-  }
-  const float MOUSE_SENS = 0.15f;
-  m_flyYaw -= static_cast<float>(cx - m_prevCursorX) * MOUSE_SENS;
-  m_flyPitch -= static_cast<float>(cy - m_prevCursorY) * MOUSE_SENS;
-  m_flyPitch = std::max(-89.0f, std::min(89.0f, m_flyPitch));
-  m_prevCursorX = cx;
-  m_prevCursorY = cy;
+      return obj;
+    }
 
-  // --- Compute forward/right from yaw/pitch ---
-  const float yawRad = m_flyYaw * (PI / 180.0f);
-  const float pitchRad = m_flyPitch * (PI / 180.0f);
-  Vec3 forward = {-std::sin(yawRad) * std::cos(pitchRad), std::sin(pitchRad),
-                  -std::cos(yawRad) * std::cos(pitchRad)};
-  Vec3 right = Vec3::Cross(forward, {0.0f, 1.0f, 0.0f});
-  float rLen = std::sqrt(right.x * right.x + right.y * right.y + right.z * right.z);
-  if (rLen > 0.001f) {
-    right.x /= rLen;
-    right.y /= rLen;
-    right.z /= rLen;
-  }
+    SceneObject EditorLayer::DuplicateObject(const SceneDocument &doc, const SceneObject &src)
+    {
+      SceneObject clone = src;
+      clone.id = GenerateId(doc);
+      clone.props.erase("_eid");
+      return clone;
+    }
 
-  // --- WASD movement ---
-  const float FLY_SPEED = 8.0f;
-  Vec3 move = {0.0f, 0.0f, 0.0f};
-  if (glfwGetKey(m_window, GLFW_KEY_W) == GLFW_PRESS)
-    move = {move.x + forward.x, move.y + forward.y, move.z + forward.z};
-  if (glfwGetKey(m_window, GLFW_KEY_S) == GLFW_PRESS)
-    move = {move.x - forward.x, move.y - forward.y, move.z - forward.z};
-  if (glfwGetKey(m_window, GLFW_KEY_A) == GLFW_PRESS)
-    move = {move.x - right.x, move.y - right.y, move.z - right.z};
-  if (glfwGetKey(m_window, GLFW_KEY_D) == GLFW_PRESS)
-    move = {move.x + right.x, move.y + right.y, move.z + right.z};
+    std::string EditorLayer::BuildSelectionRefCode(const SceneObject &obj, int idx) const
+    {
+      auto typeToStr = [](SceneObjectType t)
+      {
+        switch (t)
+        {
+        case SceneObjectType::Panel:
+          return "Panel";
+        case SceneObjectType::Prop:
+          return "Prop";
+        case SceneObjectType::Light:
+          return "Light";
+        case SceneObjectType::Camera:
+          return "Camera";
+        }
+        return "Unknown";
+      };
 
-  float mLen = std::sqrt(move.x * move.x + move.y * move.y + move.z * move.z);
-  if (mLen > 0.001f) {
-    cam.position.x += (move.x / mLen) * FLY_SPEED * dt;
-    cam.position.y += (move.y / mLen) * FLY_SPEED * dt;
-    cam.position.z += (move.z / mLen) * FLY_SPEED * dt;
-  }
-  cam.target = {cam.position.x + forward.x, cam.position.y + forward.y,
-                cam.position.z + forward.z};
-}
+      auto getProp = [&](const char *key) -> std::string
+      {
+        auto it = obj.props.find(key);
+        return (it != obj.props.end()) ? it->second : "";
+      };
 
-void EditorLayer::ApplySchemaDefaults(SceneObject& obj) const {
-  const TypeSchema* schema = m_schema.GetSchema(obj.type);
-  if (!schema)
-    return;
-  for (const auto& fd : schema->fields)
-    if (fd.hasDefault && obj.props.find(fd.key) == obj.props.end())
-      obj.props[fd.key] = fd.defaultValue;
-}
+      std::ostringstream ss;
+      ss.setf(std::ios::fixed);
+      ss.precision(4);
+      const std::string scenePath = m_document.filePath.empty() ? "assets/scenes/scene.json" : m_document.filePath;
+      ss << "EDITOR_REF"
+         << " scene=\"" << scenePath << "\""
+         << " id=" << obj.id
+         << " idx=" << idx
+         << " type=" << typeToStr(obj.type)
+         << " pos=(" << obj.position.x << "," << obj.position.y << "," << obj.position.z << ")"
+         << " scale=(" << obj.scale.x << "," << obj.scale.y << "," << obj.scale.z << ")"
+         << " yaw=" << obj.yaw;
 
-void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc& component) const {
-  const ComponentSchema* schema = m_schema.GetComponentSchema(component.type);
-  if (!schema)
-    return;
-  for (const FieldDef& field : schema->fields) {
-    if (field.hasDefault && component.props.find(field.key) == component.props.end())
-      component.props[field.key] = field.defaultValue;
-  }
-}
+      const std::string mesh = getProp("mesh");
+      if (!mesh.empty())
+        ss << " mesh=\"" << mesh << "\"";
 
-// ---- Wireframe overlay -------------------------------------------------------
+      const std::string eid = getProp("_eid");
+      if (!eid.empty())
+        ss << " _eid=" << eid;
 
-void EditorLayer::DrawWireframeOverlay(const Camera& cam) {
-  if (!Renderer::GetBackendCapabilities().supportsWireframeOverlay) {
-    m_wireframeMode = false;
-    return;
-  }
+      return ss.str();
+    }
 
-  if (!m_wireframeMode || !m_wireframeShader.IsValid())
-    return;
+    std::string EditorLayer::GenerateId(const SceneDocument &doc)
+    {
+      const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
 
-  const bool ownsFrame = !Renderer::IsFrameActive();
-  if (ownsFrame) {
-    RenderFrameConfig overlayFrame{{}, "editor-wireframe-overlay"};
-    overlayFrame.clearColorBuffer = false;
-    overlayFrame.clearDepthBuffer = false;
-    Renderer::BeginFrame(overlayFrame);
-  }
-  Renderer::BeginPass(
-      RenderPassConfig{RenderPassId::WireframeOverlay, BuildRenderView(cam), "editor-wireframe-overlay"});
-  for (const auto& obj : m_document.objects) {
-    std::string meshPath;
-    if (!TryResolveObjectMeshPath(m_document, obj, &meshPath, nullptr))
-      continue;
+      for (int i = 0; i < 1000000; ++i)
+      {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "obj_%03d", i);
+        if (existingIds.find(buf) == existingIds.end())
+          return buf;
+      }
+      return "obj_new";
+    }
 
-    // Reuse the thumbnail mesh cache (already loaded for previews)
-    auto* meshEntry = TryLoadAssetMesh(meshPath);
-    if (!meshEntry || !meshEntry->mesh)
-      continue;
+    std::string EditorLayer::GenerateCameraId(const SceneDocument &doc)
+    {
+      const std::unordered_set<std::string> existingIds = CollectReservedObjectIds(doc);
 
-    const Mat4 model = BuildObjectModelMatrix(m_document, obj);
-    Renderer::SubmitWireframe(*meshEntry->mesh, model, m_wireframeShader, 0.3f, 0.85f, 0.3f);
-  }
-  Renderer::EndPass();
-  if (ownsFrame)
-    Renderer::EndFrame();
-}
+      for (int i = 0; i < 1000000; ++i)
+      {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "cam_%03d", i);
+        if (existingIds.find(buf) == existingIds.end())
+          return buf;
+      }
+      return "cam_new";
+    }
 
-}  // namespace Editor
-}  // namespace Monolith
+    // ---- Fly camera --------------------------------------------------------------
+
+    void EditorLayer::ToggleFlyMode(Camera &cam)
+    {
+      m_flyMode = !m_flyMode;
+      m_flyCamInitialized = false;
+      m_prevCursorInit = false;
+      glfwSetInputMode(m_window, GLFW_CURSOR,
+                       m_flyMode ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
+      (void)cam; // camera sync happens lazily in UpdateFlyCamera
+    }
+
+    void EditorLayer::UpdateFlyCamera(float dt, Camera &cam)
+    {
+      // Fly mode always uses world-up to avoid inverted controls after view snaps.
+      cam.up = Vec3::Up();
+
+      // --- Sync yaw/pitch from live camera on first frame ---
+      if (!m_flyCamInitialized)
+      {
+        Vec3 dir = cam.target - cam.position;
+        float len = std::sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+        if (len > 0.001f)
+        {
+          dir.x /= len;
+          dir.y /= len;
+          dir.z /= len;
+        }
+        m_flyPitch = std::asin(std::max(-1.0f, std::min(1.0f, dir.y))) * (180.0f / PI);
+
+        // If the camera is nearly vertical (Top/Bottom snap), yaw is ill-defined.
+        // Keep previous yaw to avoid sudden axis flips when entering fly mode.
+        const float horizLen = std::sqrt(dir.x * dir.x + dir.z * dir.z);
+        if (horizLen > 0.0001f)
+          m_flyYaw = -std::atan2(dir.x, -dir.z) * (180.0f / PI);
+
+        m_flyCamInitialized = true;
+      }
+
+      // --- Mouse look ---
+      double cx, cy;
+      glfwGetCursorPos(m_window, &cx, &cy);
+      if (!m_prevCursorInit)
+      {
+        m_prevCursorX = cx;
+        m_prevCursorY = cy;
+        m_prevCursorInit = true;
+      }
+      const float MOUSE_SENS = 0.15f;
+      m_flyYaw -= static_cast<float>(cx - m_prevCursorX) * MOUSE_SENS;
+      m_flyPitch -= static_cast<float>(cy - m_prevCursorY) * MOUSE_SENS;
+      m_flyPitch = std::max(-89.0f, std::min(89.0f, m_flyPitch));
+      m_prevCursorX = cx;
+      m_prevCursorY = cy;
+
+      // --- Compute forward/right from yaw/pitch ---
+      const float yawRad = m_flyYaw * (PI / 180.0f);
+      const float pitchRad = m_flyPitch * (PI / 180.0f);
+      Vec3 forward = {-std::sin(yawRad) * std::cos(pitchRad), std::sin(pitchRad),
+                      -std::cos(yawRad) * std::cos(pitchRad)};
+      Vec3 right = Vec3::Cross(forward, {0.0f, 1.0f, 0.0f});
+      float rLen = std::sqrt(right.x * right.x + right.y * right.y + right.z * right.z);
+      if (rLen > 0.001f)
+      {
+        right.x /= rLen;
+        right.y /= rLen;
+        right.z /= rLen;
+      }
+
+      // --- WASD movement ---
+      const float FLY_SPEED = 8.0f;
+      Vec3 move = {0.0f, 0.0f, 0.0f};
+      if (glfwGetKey(m_window, GLFW_KEY_W) == GLFW_PRESS)
+        move = {move.x + forward.x, move.y + forward.y, move.z + forward.z};
+      if (glfwGetKey(m_window, GLFW_KEY_S) == GLFW_PRESS)
+        move = {move.x - forward.x, move.y - forward.y, move.z - forward.z};
+      if (glfwGetKey(m_window, GLFW_KEY_A) == GLFW_PRESS)
+        move = {move.x - right.x, move.y - right.y, move.z - right.z};
+      if (glfwGetKey(m_window, GLFW_KEY_D) == GLFW_PRESS)
+        move = {move.x + right.x, move.y + right.y, move.z + right.z};
+
+      float mLen = std::sqrt(move.x * move.x + move.y * move.y + move.z * move.z);
+      if (mLen > 0.001f)
+      {
+        cam.position.x += (move.x / mLen) * FLY_SPEED * dt;
+        cam.position.y += (move.y / mLen) * FLY_SPEED * dt;
+        cam.position.z += (move.z / mLen) * FLY_SPEED * dt;
+      }
+      cam.target = {cam.position.x + forward.x, cam.position.y + forward.y,
+                    cam.position.z + forward.z};
+    }
+
+    void EditorLayer::ApplySchemaDefaults(SceneObject &obj) const
+    {
+      const TypeSchema *schema = m_schema.GetSchema(obj.type);
+      if (!schema)
+        return;
+      for (const auto &fd : schema->fields)
+        if (fd.hasDefault && obj.props.find(fd.key) == obj.props.end())
+          obj.props[fd.key] = fd.defaultValue;
+    }
+
+    void EditorLayer::ApplyComponentSchemaDefaults(ComponentDesc &component) const
+    {
+      const ComponentSchema *schema = m_schema.GetComponentSchema(component.type);
+      if (!schema)
+        return;
+      for (const FieldDef &field : schema->fields)
+      {
+        if (field.hasDefault && component.props.find(field.key) == component.props.end())
+          component.props[field.key] = field.defaultValue;
+      }
+    }
+
+    // ---- Wireframe overlay -------------------------------------------------------
+
+    void EditorLayer::DrawWireframeOverlay(const Camera &cam)
+    {
+      if (!Renderer::GetBackendCapabilities().supportsWireframeOverlay)
+      {
+        m_wireframeMode = false;
+        return;
+      }
+
+      if (!m_wireframeMode || !m_wireframeShader.IsValid())
+        return;
+
+      const bool ownsFrame = !Renderer::IsFrameActive();
+      if (ownsFrame)
+      {
+        RenderFrameConfig overlayFrame{{}, "editor-wireframe-overlay"};
+        overlayFrame.clearColorBuffer = false;
+        overlayFrame.clearDepthBuffer = false;
+        Renderer::BeginFrame(overlayFrame);
+      }
+      Renderer::BeginPass(
+          RenderPassConfig{RenderPassId::WireframeOverlay, BuildRenderView(cam), "editor-wireframe-overlay"});
+      for (const auto &obj : m_document.objects)
+      {
+        std::string meshPath;
+        if (!TryResolveObjectMeshPath(m_document, obj, &meshPath, nullptr))
+          continue;
+
+        // Reuse the thumbnail mesh cache (already loaded for previews)
+        auto *meshEntry = TryLoadAssetMesh(meshPath);
+        if (!meshEntry || !meshEntry->mesh)
+          continue;
+
+        const Mat4 model = BuildObjectModelMatrix(m_document, obj);
+        Renderer::SubmitWireframe(*meshEntry->mesh, model, m_wireframeShader, 0.3f, 0.85f, 0.3f);
+      }
+      Renderer::EndPass();
+      if (ownsFrame)
+        Renderer::EndFrame();
+    }
+
+  } // namespace Editor
+} // namespace Monolith

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -59,7 +59,6 @@
 #include "renderer/GltfLoader.h"
 #include "renderer/Mesh.h"
 #include "renderer/ObjLoader.h"
-#include "renderer/RenderContext.h"
 #include "renderer/Renderer.h"
 #include "renderer/RenderViewUtils.h"
 #include "renderer/Shader.h"
@@ -6874,8 +6873,12 @@ void EditorLayer::DrawWireframeOverlay(const Camera& cam) {
     return;
 
   const bool ownsFrame = !Renderer::IsFrameActive();
-  if (ownsFrame)
-    Renderer::BeginFrame(RenderFrameConfig{{}, "editor-wireframe-overlay"});
+  if (ownsFrame) {
+    RenderFrameConfig overlayFrame{{}, "editor-wireframe-overlay"};
+    overlayFrame.clearColorBuffer = false;
+    overlayFrame.clearDepthBuffer = false;
+    Renderer::BeginFrame(overlayFrame);
+  }
   Renderer::BeginPass(
       RenderPassConfig{RenderPassId::WireframeOverlay, BuildRenderView(cam), "editor-wireframe-overlay"});
   for (const auto& obj : m_document.objects) {

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -16,8 +16,6 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <imgui.h>
-#include <imgui_impl_glfw.h>
-#include <imgui_impl_opengl3.h>
 
 #include <algorithm>
 #include <array>
@@ -43,6 +41,7 @@
 #include "editor/AssetIdentity.h"
 #include "editor/AssetMetadata.h"
 #include "editor/ProjectEntryFilter.h"
+#include "editor/EditorImGuiBackend.h"
 #include "editor/EditorDebugTrace.h"
 #include "editor/EditorAssetImport.h"
 #include "editor/EditorSearch.h"
@@ -1310,8 +1309,11 @@ void EditorLayer::Init(GLFWwindow* window) {
   }
   LoadWorkspaceState();
 
-  ImGui_ImplGlfw_InitForOpenGL(window, true);
-  ImGui_ImplOpenGL3_Init("#version 410");
+  const RenderBackendId backendId = Renderer::GetBackendId();
+  m_imguiBackendInitialized = InitEditorImGuiBackend(window, backendId);
+  if (!m_imguiBackendInitialized) {
+    LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'", ToString(backendId));
+  }
 
   m_schema.LoadFromFile("assets/editor_schema.json");
 
@@ -1336,8 +1338,9 @@ void EditorLayer::Shutdown() {
   if (!m_imguiIniPath.empty())
     ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
   m_mcpController.Shutdown();
-  ImGui_ImplOpenGL3_Shutdown();
-  ImGui_ImplGlfw_Shutdown();
+  if (m_imguiBackendInitialized)
+    ShutdownEditorImGuiBackend(Renderer::GetBackendId());
+  m_imguiBackendInitialized = false;
   ImGui::DestroyContext();
 }
 
@@ -2061,8 +2064,8 @@ void EditorLayer::Render(const Camera& cam, int screenW, int screenH) {
   m_viewGizmoPickRect.Clear();
   ProcessPendingPathDrops();
 
-  ImGui_ImplOpenGL3_NewFrame();
-  ImGui_ImplGlfw_NewFrame();
+  if (m_imguiBackendInitialized)
+    BeginEditorImGuiFrame(Renderer::GetBackendId());
   ImGui::NewFrame();
 
   const EditorHistorySnapshot frameHistoryBefore = m_active ? CaptureHistorySnapshot()
@@ -2111,7 +2114,8 @@ void EditorLayer::Render(const Camera& cam, int screenW, int screenH) {
   DebugDraw::Flush(cam);
 
   ImGui::Render();
-  ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+  if (m_imguiBackendInitialized)
+    RenderEditorImGuiDrawData(Renderer::GetBackendId(), ImGui::GetDrawData());
 }
 
 void EditorLayer::DrawDockspace() {

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -991,21 +991,21 @@ static void FitCameraToMesh(const AssetThumbnailRenderer::CachedMesh& mesh,
 
 // Render a mesh to the thumbnail framebuffer and return a per-mesh cached texture ID.
 // meshKey must be the resolved mesh path (same key used in meshCache).
-static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
-                                          const std::string& meshKey) {
+static RenderTargetHandle RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh& mesh,
+                                                const std::string& meshKey) {
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   if (!caps.supportsOffscreenTargets || !caps.supportsNativeTextureHandles)
-    return 0;
+    return {};
 
   auto& renderer = AssetThumbnailRenderer::Instance();
 
   // Return existing per-mesh texture if already rendered this session.
   auto cacheIt = renderer.renderedTextureCache.find(meshKey);
   if (cacheIt != renderer.renderedTextureCache.end())
-    return cacheIt->second;
+    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
 
   if (!renderer.IsValid())
-    return 0;
+    return {};
 
   // Save GL state (viewport)
   GLint prevViewport[4] = {0, 0, 1, 1};
@@ -1072,18 +1072,15 @@ static unsigned int RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMe
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
 
-  return destTex;
+  return RenderTargetHandle::OpenGLTexture(destTex, true);
 }
 
-static bool TryGetAssetPreviewTextureId(const std::string& assetId,
-                                        const AssetDef& asset,
-                                        unsigned int* outTextureId,
-                                        bool* outNeedsYFlip = nullptr) {
-  if (!outTextureId)
+static bool TryGetAssetPreviewHandle(const std::string& assetId,
+                                     const AssetDef& asset,
+                                     RenderTargetHandle* outHandle) {
+  if (!outHandle)
     return false;
-  *outTextureId = 0;
-  if (outNeedsYFlip)
-    *outNeedsYFlip = false;
+  *outHandle = {};
 
   static std::unordered_map<std::string, Texture> s_textureByPath;
   static std::unordered_map<std::string, std::shared_ptr<Texture>> s_gltfTextureByMesh;
@@ -1093,14 +1090,14 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   if (s_noPreviewCache.find(key) != s_noPreviewCache.end())
     return false;
 
-  auto loadTextureByPath = [&](const std::filesystem::path& path) -> unsigned int {
+  auto loadTextureByPath = [&](const std::filesystem::path& path) -> RenderTargetHandle {
     if (!Renderer::GetBackendCapabilities().supportsNativeTextureHandles)
-      return 0;
+      return {};
     if (path.empty())
-      return 0;
+      return {};
     std::error_code ec;
     if (!std::filesystem::is_regular_file(path, ec) || ec)
-      return 0;
+      return {};
     const std::string abs = path.generic_string();
     auto it = s_textureByPath.find(abs);
     if (it == s_textureByPath.end()) {
@@ -1108,8 +1105,8 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       it = s_textureByPath.emplace(abs, std::move(tex)).first;
     }
     if (!it->second.IsValid())
-      return 0;
-    return it->second.GetNativeId();
+      return {};
+    return it->second.GetRenderTargetHandle();
   };
 
   // Priority 1: Try to render the 3D mesh as a thumbnail (offscreen FBO render)
@@ -1119,13 +1116,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
       if (auto* meshEntry = TryLoadAssetMesh(asset.mesh)) {
         const std::string meshKey =
             ResolveProjectRelativeOrAbsolutePath(asset.mesh).generic_string();
-        const unsigned int texId = RenderMeshToThumbnail(*meshEntry, meshKey);
-        if (texId != 0) {
-          *outTextureId = texId;
-          // OpenGL FBO textures have origin at bottom-left; ImGui expects top-left.
-          // Caller must flip Y UVs when displaying this texture.
-          if (outNeedsYFlip)
-            *outNeedsYFlip = true;
+        const RenderTargetHandle handle = RenderMeshToThumbnail(*meshEntry, meshKey);
+        if (handle.IsValid()) {
+          *outHandle = handle;
           return true;
         }
       }
@@ -1135,9 +1128,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   // Priority 2: Fallback to texture-based thumbnails
   if (!asset.albedoMap.empty()) {
     const std::filesystem::path albedo = ResolveProjectRelativeOrAbsolutePath(asset.albedoMap);
-    const unsigned int texId = loadTextureByPath(albedo);
-    if (texId != 0) {
-      *outTextureId = texId;
+    const RenderTargetHandle handle = loadTextureByPath(albedo);
+    if (handle.IsValid()) {
+      *outHandle = handle;
       return true;
     }
   }
@@ -1148,9 +1141,9 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
 
     if (ext == ".obj") {
       const std::string diffusePath = ObjLoader::FindDiffuseTexture(meshPath.generic_string());
-      const unsigned int texId = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
-      if (texId != 0) {
-        *outTextureId = texId;
+      const RenderTargetHandle handle = loadTextureByPath(ResolveProjectRelativeOrAbsolutePath(diffusePath));
+      if (handle.IsValid()) {
+        *outHandle = handle;
         return true;
       }
     }
@@ -1164,7 +1157,7 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
           it = s_gltfTextureByMesh.emplace(absMesh, std::move(result.albedoTexture)).first;
       }
       if (it != s_gltfTextureByMesh.end() && it->second && it->second->IsValid()) {
-        *outTextureId = it->second->GetNativeId();
+        *outHandle = it->second->GetRenderTargetHandle();
         return true;
       }
     }
@@ -1174,8 +1167,10 @@ static bool TryGetAssetPreviewTextureId(const std::string& assetId,
   return false;
 }
 
-static ImTextureID ToImTextureId(unsigned int textureId) {
-  return (ImTextureID)(intptr_t)textureId;
+static ImTextureID ToImTextureId(const RenderTargetHandle& handle) {
+  if (!handle.IsValid() || handle.nativeType != RenderNativeHandleType::OpenGLTexture2D)
+    return (ImTextureID)0;
+  return (ImTextureID)(intptr_t)handle.nativeHandle;
 }
 
 std::string PickTextureFilePath() {
@@ -3932,12 +3927,11 @@ void EditorLayer::DrawAssetsPanel() {
                       6.0f);
     dl->AddRect(thumbMin, thumbMax, ImGui::ColorConvertFloat4ToU32(ImVec4(0.26f, 0.34f, 0.46f, 1.0f)), 6.0f);
 
-    unsigned int previewTexId = 0;
-    bool previewNeedsYFlip = false;
-    if (TryGetAssetPreviewTextureId(assetId, asset, &previewTexId, &previewNeedsYFlip) && previewTexId != 0) {
-      const ImVec2 uv0 = previewNeedsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
-      const ImVec2 uv1 = previewNeedsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
-      dl->AddImage(ToImTextureId(previewTexId), thumbMin, thumbMax, uv0, uv1);
+    RenderTargetHandle previewHandle;
+    if (TryGetAssetPreviewHandle(assetId, asset, &previewHandle) && previewHandle.IsValid()) {
+      const ImVec2 uv0 = previewHandle.needsYFlip ? ImVec2(0.0f, 1.0f) : ImVec2(0.0f, 0.0f);
+      const ImVec2 uv1 = previewHandle.needsYFlip ? ImVec2(1.0f, 0.0f) : ImVec2(1.0f, 1.0f);
+      dl->AddImage(ToImTextureId(previewHandle), thumbMin, thumbMax, uv0, uv1);
     } else {
       const ImU32 labelCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.67f, 0.74f, 0.84f, 0.95f));
       const ImU32 meshCol = ImGui::ColorConvertFloat4ToU32(ImVec4(0.55f, 0.64f, 0.75f, 0.95f));

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -75,7 +75,7 @@ class EditorLayer {
   bool OnUpdate(float dt, Camera& cam, int screenW, int screenH);
 
   // Render ImGui panels, selection highlight, and transform gizmo.
-  // Must be called after the game 3D render and before RenderContext::EndFrame.
+  // Must be called after the game 3D render and before the backend presents the frame.
   void Render(const Camera& cam, int screenW, int screenH);
 
   // Replace the current document with a live-scene snapshot (called on editor open).

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -147,6 +147,7 @@ class EditorLayer {
 
   GLFWwindow* m_window = nullptr;
   bool m_active = false;
+  bool m_imguiBackendInitialized = false;
   bool m_playMode = false;
   bool m_wantsReload = false;
   bool m_prevMouseL = false;

--- a/renderer/DebugDraw.cpp
+++ b/renderer/DebugDraw.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "math/MathUtils.h"
+#include "renderer/Renderer.h"
 
 namespace Monolith {
 
@@ -36,6 +37,11 @@ void main() { FragColor = v_color; }
 )glsl";
 
 void DebugDraw::Init() {
+  if (!Renderer::GetBackendCapabilities().supportsDebugDraw) {
+    s_initialized = false;
+    return;
+  }
+
   s_shader = std::make_unique<Shader>(Shader::FromSource(DEBUG_VERT, DEBUG_FRAG));
 
   glGenVertexArrays(1, &s_vao);
@@ -77,6 +83,8 @@ void DebugDraw::Shutdown() {
 }
 
 void DebugDraw::Line(const Vec3& from, const Vec3& to, const Vec4& color) {
+  if (!Renderer::GetBackendCapabilities().supportsDebugDraw)
+    return;
   s_lines.push_back({from, color});
   s_lines.push_back({to, color});
 }
@@ -138,6 +146,11 @@ void DebugDraw::Box(const Vec3& center, const Vec3& h, const Vec4& color) {
 }
 
 void DebugDraw::Flush(const Camera& camera) {
+  if (!Renderer::GetBackendCapabilities().supportsDebugDraw) {
+    s_lines.clear();
+    return;
+  }
+
   if (!s_initialized || s_lines.empty())
     return;
 

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "input/Input.h"
+#include "renderer/Renderer.h"
 #include "input/KeyCodes.h"
 
 // Windows headers (pulled in by glad) define DrawText as DrawTextA — undefine to avoid collision
@@ -1237,6 +1238,12 @@ void DebugHUD::Init(int screenW, int screenH) {
   s_screenW = screenW;
   s_screenH = screenH;
 
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud) {
+    s_initialized = false;
+    s_visible = false;
+    return;
+  }
+
   s_shader = std::make_unique<Shader>(Shader::FromSource(HUD_VERT, HUD_FRAG));
 
   BuildFontAtlas();
@@ -1343,6 +1350,9 @@ void DebugHUD::SubmitWorldLabel(const Vec3& worldPos, const Mat4& vp, const char
 // ---- Update ----
 
 void DebugHUD::Update(float dt, const HUDStats& stats) {
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud)
+    return;
+
   if (Input::IsKeyPressed(Key::F3))
     s_visible = !s_visible;
   if (Input::IsKeyPressed(Key::F4))
@@ -1377,6 +1387,8 @@ void DebugHUD::Update(float dt, const HUDStats& stats) {
 // ---- Render ----
 
 void DebugHUD::Render() {
+  if (!Renderer::GetBackendCapabilities().supportsDebugHud)
+    return;
   if (!s_initialized)
     return;
   const bool forceNoCameraOverlay = s_stats.showNoCameraOverlay;

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <vector>
 
+#include "core/Logger.h"
 #include "input/Input.h"
 #include "renderer/Renderer.h"
 #include "input/KeyCodes.h"
@@ -1536,19 +1537,27 @@ void DebugHUD::Render() {
   // --- World-space object labels (independent of s_visible / s_settingsOpen) ---
   if (s_labelsVisible && s_labelCount > 0) {
     if (s_occlusionCulling && Renderer::GetBackendCapabilities().supportsDepthReadback) {
-      int total = s_screenW * s_screenH;
-      s_depthBuf.resize(static_cast<std::vector<float>::size_type>(total));
-      glReadPixels(0, 0, s_screenW, s_screenH, GL_DEPTH_COMPONENT, GL_FLOAT, s_depthBuf.data());
+      std::string readbackError;
+      if (!Renderer::ReadbackDepth32F(s_screenW, s_screenH, s_depthBuf, &readbackError)) {
+        LOG_WARN("DebugHUD: depth readback failed (%s). Rendering labels without occlusion.",
+                 readbackError.c_str());
+        s_depthBuf.clear();
+      }
 
-      for (int i = 0; i < s_labelCount; ++i) {
-        int px = std::clamp(static_cast<int>(s_labels[i].x), 0, s_screenW - 1);
-        int py = std::clamp(s_screenH - 1 - static_cast<int>(s_labels[i].y), 0, s_screenH - 1);
-        float bufDepth =
-            s_depthBuf[static_cast<std::vector<float>::size_type>(py * s_screenW + px)];
-        float labelDepth = (s_labels[i].ndcZ + 1.0f) * 0.5f;
-        if (labelDepth > bufDepth + 0.005f)
-          continue;
-        DrawText(s_labels[i].text, s_labels[i].x, s_labels[i].y, 0.2f, 1.0f, 0.4f, 1.5f);
+      if (!s_depthBuf.empty()) {
+        for (int i = 0; i < s_labelCount; ++i) {
+          int px = std::clamp(static_cast<int>(s_labels[i].x), 0, s_screenW - 1);
+          int py = std::clamp(s_screenH - 1 - static_cast<int>(s_labels[i].y), 0, s_screenH - 1);
+          float bufDepth =
+              s_depthBuf[static_cast<std::vector<float>::size_type>(py * s_screenW + px)];
+          float labelDepth = (s_labels[i].ndcZ + 1.0f) * 0.5f;
+          if (labelDepth > bufDepth + 0.005f)
+            continue;
+          DrawText(s_labels[i].text, s_labels[i].x, s_labels[i].y, 0.2f, 1.0f, 0.4f, 1.5f);
+        }
+      } else {
+        for (int i = 0; i < s_labelCount; ++i)
+          DrawText(s_labels[i].text, s_labels[i].x, s_labels[i].y, 0.2f, 1.0f, 0.4f, 1.5f);
       }
     } else {
       for (int i = 0; i < s_labelCount; ++i)

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -1535,7 +1535,7 @@ void DebugHUD::Render() {
 
   // --- World-space object labels (independent of s_visible / s_settingsOpen) ---
   if (s_labelsVisible && s_labelCount > 0) {
-    if (s_occlusionCulling) {
+    if (s_occlusionCulling && Renderer::GetBackendCapabilities().supportsDepthReadback) {
       int total = s_screenW * s_screenH;
       s_depthBuf.resize(static_cast<std::vector<float>::size_type>(total));
       glReadPixels(0, 0, s_screenW, s_screenH, GL_DEPTH_COMPONENT, GL_FLOAT, s_depthBuf.data());

--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "renderer/RenderBackend.h"
+#include "renderer/RenderTargetHandle.h"
 #include "renderer/RenderTypes.h"
 
 namespace Monolith {
@@ -21,6 +25,20 @@ class IRenderBackend {
   virtual RenderBackendId GetBackendId() const = 0;
   virtual RenderBackendCapabilities GetCapabilities() const = 0;
   virtual int GetDrawCallCount() const = 0;
+  virtual bool ReadbackColorBgr8(int width,
+                                 int height,
+                                 std::vector<uint8_t>& outPixels,
+                                 std::string* outError) = 0;
+  virtual bool ReadbackDepth32F(int width,
+                                int height,
+                                std::vector<float>& outDepth,
+                                std::string* outError) = 0;
+  virtual bool EnsureEditorViewportRenderTarget(uint32_t width,
+                                                uint32_t height,
+                                                std::string* outError) = 0;
+  virtual bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle* outHandle,
+                                                      bool needsYFlip,
+                                                      std::string* outError) = 0;
 };
 
 }  // namespace Monolith

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -4,50 +4,59 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <utility>
 
 #include "math/MathUtils.h"
 
 namespace Monolith {
 
+struct Mesh::GpuStorage {
+  unsigned int vao = 0;
+  unsigned int vbo = 0;
+  unsigned int ebo = 0;
+};
+
+Mesh::Mesh() = default;
+
 Mesh::~Mesh() {
   Release();
 }
 
 Mesh::Mesh(Mesh&& o) noexcept
-    : m_vao(o.m_vao),
-      m_vbo(o.m_vbo),
-      m_ebo(o.m_ebo),
+    : m_gpu(std::move(o.m_gpu)),
       m_indexCount(o.m_indexCount),
       m_halfExtents(o.m_halfExtents),
       m_localAabbCenter(o.m_localAabbCenter) {
-  o.m_vao = o.m_vbo = o.m_ebo = 0;
   o.m_indexCount = 0;
 }
 
 Mesh& Mesh::operator=(Mesh&& o) noexcept {
   if (this != &o) {
     Release();
-    m_vao = o.m_vao;
-    m_vbo = o.m_vbo;
-    m_ebo = o.m_ebo;
+    m_gpu = std::move(o.m_gpu);
     m_indexCount = o.m_indexCount;
     m_halfExtents = o.m_halfExtents;
     m_localAabbCenter = o.m_localAabbCenter;
-    o.m_vao = o.m_vbo = o.m_ebo = 0;
     o.m_indexCount = 0;
   }
   return *this;
 }
 
+bool Mesh::IsValid() const {
+  return m_gpu && m_gpu->vao != 0;
+}
+
 void Mesh::Release() {
-  if (m_ebo)
-    glDeleteBuffers(1, &m_ebo);
-  if (m_vbo)
-    glDeleteBuffers(1, &m_vbo);
-  if (m_vao)
-    glDeleteVertexArrays(1, &m_vao);
-  m_vao = m_vbo = m_ebo = 0;
+  if (m_gpu) {
+    if (m_gpu->ebo)
+      glDeleteBuffers(1, &m_gpu->ebo);
+    if (m_gpu->vbo)
+      glDeleteBuffers(1, &m_gpu->vbo);
+    if (m_gpu->vao)
+      glDeleteVertexArrays(1, &m_gpu->vao);
+    m_gpu.reset();
+  }
   m_indexCount = 0;
 }
 
@@ -74,19 +83,20 @@ void Mesh::SetData(const std::vector<Vertex>& vertices, const std::vector<unsign
 
 void Mesh::Upload(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices) {
   m_indexCount = static_cast<int>(indices.size());
+  m_gpu = std::make_unique<GpuStorage>();
 
-  glGenVertexArrays(1, &m_vao);
-  glBindVertexArray(m_vao);
+  glGenVertexArrays(1, &m_gpu->vao);
+  glBindVertexArray(m_gpu->vao);
 
-  glGenBuffers(1, &m_vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+  glGenBuffers(1, &m_gpu->vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
   glBufferData(GL_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(vertices.size() * sizeof(Vertex)),
                vertices.data(),
                GL_STATIC_DRAW);
 
-  glGenBuffers(1, &m_ebo);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ebo);
+  glGenBuffers(1, &m_gpu->ebo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
                indices.data(),
@@ -130,7 +140,9 @@ void Mesh::Upload(const std::vector<Vertex>& vertices, const std::vector<unsigne
 }
 
 void Mesh::Draw() const {
-  glBindVertexArray(m_vao);
+  if (!m_gpu)
+    return;
+  glBindVertexArray(m_gpu->vao);
   glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
   glBindVertexArray(0);
 }

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -1,8 +1,10 @@
 #include "renderer/Mesh.h"
 
 #include <glad/glad.h>
+#include <GLFW/glfw3.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
 #include <memory>
 #include <utility>
@@ -10,6 +12,11 @@
 #include "math/MathUtils.h"
 
 namespace Monolith {
+namespace {
+bool HasCurrentGlContext() {
+  return glfwGetCurrentContext() != nullptr;
+}
+}  // namespace
 
 struct Mesh::GpuStorage {
   unsigned int vao = 0;
@@ -26,6 +33,8 @@ Mesh::~Mesh() {
 Mesh::Mesh(Mesh&& o) noexcept
     : m_gpu(std::move(o.m_gpu)),
       m_indexCount(o.m_indexCount),
+      m_cpuVertices(std::move(o.m_cpuVertices)),
+      m_cpuIndices(std::move(o.m_cpuIndices)),
       m_halfExtents(o.m_halfExtents),
       m_localAabbCenter(o.m_localAabbCenter) {
   o.m_indexCount = 0;
@@ -36,6 +45,8 @@ Mesh& Mesh::operator=(Mesh&& o) noexcept {
     Release();
     m_gpu = std::move(o.m_gpu);
     m_indexCount = o.m_indexCount;
+    m_cpuVertices = std::move(o.m_cpuVertices);
+    m_cpuIndices = std::move(o.m_cpuIndices);
     m_halfExtents = o.m_halfExtents;
     m_localAabbCenter = o.m_localAabbCenter;
     o.m_indexCount = 0;
@@ -49,15 +60,19 @@ bool Mesh::IsValid() const {
 
 void Mesh::Release() {
   if (m_gpu) {
-    if (m_gpu->ebo)
-      glDeleteBuffers(1, &m_gpu->ebo);
-    if (m_gpu->vbo)
-      glDeleteBuffers(1, &m_gpu->vbo);
-    if (m_gpu->vao)
-      glDeleteVertexArrays(1, &m_gpu->vao);
+    if (HasCurrentGlContext()) {
+      if (m_gpu->ebo)
+        glDeleteBuffers(1, &m_gpu->ebo);
+      if (m_gpu->vbo)
+        glDeleteBuffers(1, &m_gpu->vbo);
+      if (m_gpu->vao)
+        glDeleteVertexArrays(1, &m_gpu->vao);
+    }
     m_gpu.reset();
   }
   m_indexCount = 0;
+  m_cpuVertices.clear();
+  m_cpuIndices.clear();
 }
 
 void Mesh::SetData(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices) {
@@ -82,7 +97,12 @@ void Mesh::SetData(const std::vector<Vertex>& vertices, const std::vector<unsign
 }
 
 void Mesh::Upload(const std::vector<Vertex>& vertices, const std::vector<unsigned int>& indices) {
+  m_cpuVertices = vertices;
+  m_cpuIndices.assign(indices.begin(), indices.end());
   m_indexCount = static_cast<int>(indices.size());
+  if (!HasCurrentGlContext())
+    return;
+
   m_gpu = std::make_unique<GpuStorage>();
 
   glGenVertexArrays(1, &m_gpu->vao);

--- a/renderer/Mesh.h
+++ b/renderer/Mesh.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -29,6 +30,8 @@ class Mesh {
 
   bool IsValid() const;
   int GetIndexCount() const { return m_indexCount; }
+  const std::vector<Vertex>& GetVertices() const { return m_cpuVertices; }
+  const std::vector<uint32_t>& GetIndices() const { return m_cpuIndices; }
   Vec3 GetHalfExtents() const { return m_halfExtents; }
   Vec3 GetLocalAabbCenter() const { return m_localAabbCenter; }
 
@@ -44,6 +47,8 @@ class Mesh {
   struct GpuStorage;
   std::unique_ptr<GpuStorage> m_gpu;
   int m_indexCount = 0;
+  std::vector<Vertex> m_cpuVertices;
+  std::vector<uint32_t> m_cpuIndices;
   Vec3 m_halfExtents = {0.5f, 0.5f, 0.5f};
   Vec3 m_localAabbCenter = Vec3::Zero();
 

--- a/renderer/Mesh.h
+++ b/renderer/Mesh.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <vector>
 
 #include "math/Vec2.h"
@@ -14,7 +15,7 @@ struct Vertex {
 
 class Mesh {
  public:
-  Mesh() = default;
+  Mesh();
   ~Mesh();
 
   Mesh(const Mesh&) = delete;
@@ -26,7 +27,7 @@ class Mesh {
   void Draw() const;
   void DrawWireframe() const;
 
-  bool IsValid() const { return m_vao != 0; }
+  bool IsValid() const;
   int GetIndexCount() const { return m_indexCount; }
   Vec3 GetHalfExtents() const { return m_halfExtents; }
   Vec3 GetLocalAabbCenter() const { return m_localAabbCenter; }
@@ -40,9 +41,8 @@ class Mesh {
   static Mesh CreateQuad();
 
  private:
-  unsigned int m_vao = 0;
-  unsigned int m_vbo = 0;
-  unsigned int m_ebo = 0;
+  struct GpuStorage;
+  std::unique_ptr<GpuStorage> m_gpu;
   int m_indexCount = 0;
   Vec3 m_halfExtents = {0.5f, 0.5f, 0.5f};
   Vec3 m_localAabbCenter = Vec3::Zero();

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -47,6 +47,23 @@ RenderBackendCapabilities OpenGLRenderBackend::GetCapabilities() const {
 
 void OpenGLRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
   MONOLITH_ASSERT(!m_frameActive, "OpenGLRenderBackend::BeginFrame called while a frame is active");
+  glEnable(GL_DEPTH_TEST);
+  glDepthFunc(GL_LEQUAL);
+  glEnable(GL_CULL_FACE);
+  glCullFace(GL_BACK);
+  glFrontFace(GL_CCW);
+  glEnable(GL_MULTISAMPLE);
+
+  GLbitfield clearMask = 0;
+  if (frame.clearColorBuffer) {
+    glClearColor(frame.clearColor.x, frame.clearColor.y, frame.clearColor.z, frame.clearColor.w);
+    clearMask |= GL_COLOR_BUFFER_BIT;
+  }
+  if (frame.clearDepthBuffer)
+    clearMask |= GL_DEPTH_BUFFER_BIT;
+  if (clearMask != 0)
+    glClear(clearMask);
+
   m_lights = frame.lights;
   if (m_lights.size() > 8)
     m_lights.resize(8);

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -45,6 +45,56 @@ RenderBackendCapabilities OpenGLRenderBackend::GetCapabilities() const {
   return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
 }
 
+bool OpenGLRenderBackend::ReadbackColorBgr8(int width,
+                                            int height,
+                                            std::vector<uint8_t>& outPixels,
+                                            std::string* outError) {
+  if (width <= 0 || height <= 0) {
+    if (outError)
+      *outError = "OpenGL color readback requires positive dimensions.";
+    return false;
+  }
+
+  outPixels.resize(static_cast<std::vector<uint8_t>::size_type>(width) *
+                   static_cast<std::vector<uint8_t>::size_type>(height) * 3u);
+  glReadPixels(0, 0, width, height, GL_BGR, GL_UNSIGNED_BYTE, outPixels.data());
+  return true;
+}
+
+bool OpenGLRenderBackend::ReadbackDepth32F(int width,
+                                           int height,
+                                           std::vector<float>& outDepth,
+                                           std::string* outError) {
+  if (width <= 0 || height <= 0) {
+    if (outError)
+      *outError = "OpenGL depth readback requires positive dimensions.";
+    return false;
+  }
+
+  outDepth.resize(static_cast<std::vector<float>::size_type>(width) *
+                  static_cast<std::vector<float>::size_type>(height));
+  glReadPixels(0, 0, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, outDepth.data());
+  return true;
+}
+
+bool OpenGLRenderBackend::EnsureEditorViewportRenderTarget(uint32_t,
+                                                           uint32_t,
+                                                           std::string* outError) {
+  if (outError)
+    *outError = "Editor viewport render-target provisioning is unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::TryGetEditorViewportRenderTargetHandle(RenderTargetHandle* outHandle,
+                                                                 bool,
+                                                                 std::string* outError) {
+  if (outHandle)
+    *outHandle = {};
+  if (outError)
+    *outError = "Editor viewport render-target handle is unavailable on OpenGL backend.";
+  return false;
+}
+
 void OpenGLRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
   MONOLITH_ASSERT(!m_frameActive, "OpenGLRenderBackend::BeginFrame called while a frame is active");
   glEnable(GL_DEPTH_TEST);

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -21,6 +21,20 @@ class OpenGLRenderBackend : public IRenderBackend {
   RenderBackendId GetBackendId() const override { return RenderBackendId::OpenGL; }
   RenderBackendCapabilities GetCapabilities() const override;
   int GetDrawCallCount() const override { return m_drawCalls; }
+  bool ReadbackColorBgr8(int width,
+                         int height,
+                         std::vector<uint8_t>& outPixels,
+                         std::string* outError) override;
+  bool ReadbackDepth32F(int width,
+                        int height,
+                        std::vector<float>& outDepth,
+                        std::string* outError) override;
+  bool EnsureEditorViewportRenderTarget(uint32_t width,
+                                        uint32_t height,
+                                        std::string* outError) override;
+  bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle* outHandle,
+                                              bool needsYFlip,
+                                              std::string* outError) override;
 
  private:
   void UploadLights(const Shader& shader);

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -24,11 +24,13 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
     case RenderBackendId::Auto:
       return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
     case RenderBackendId::OpenGL:
-      return {.supportsWireframeOverlay = true,
+      return {.supportsDebugDraw = true,
+              .supportsWireframeOverlay = true,
               .supportsDebugLabels = false,
               .supportsOffscreenTargets = true,
               .supportsNativeTextureHandles = true,
               .supportsReadback = true,
+              .supportsDepthReadback = true,
               .supportsDebugHud = true,
               .supportsComputePasses = false,
               .supportsGpuTimestamps = false,

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -41,7 +41,11 @@ bool IsRenderBackendSupported(RenderBackendId backendId) {
     case RenderBackendId::OpenGL:
       return true;
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+      return true;
+#else
       return false;
+#endif
     case RenderBackendId::Auto:
       break;
   }

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -36,7 +36,17 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
               .supportsGpuTimestamps = false,
               .supportsBindlessResources = false};
     case RenderBackendId::Vulkan:
-      return {};
+      return {.supportsDebugDraw = false,
+              .supportsWireframeOverlay = false,
+              .supportsDebugLabels = false,
+              .supportsOffscreenTargets = true,
+              .supportsNativeTextureHandles = true,
+              .supportsReadback = false,
+              .supportsDepthReadback = false,
+              .supportsDebugHud = false,
+              .supportsComputePasses = false,
+              .supportsGpuTimestamps = false,
+              .supportsBindlessResources = false};
   }
 
   return {};

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -26,6 +26,10 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
     case RenderBackendId::OpenGL:
       return {.supportsWireframeOverlay = true,
               .supportsDebugLabels = false,
+              .supportsOffscreenTargets = true,
+              .supportsNativeTextureHandles = true,
+              .supportsReadback = true,
+              .supportsDebugHud = true,
               .supportsComputePasses = false,
               .supportsGpuTimestamps = false,
               .supportsBindlessResources = false};

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -20,6 +20,7 @@ struct RenderBackendCapabilities {
 
 struct RenderBackendSelection {
   RenderBackendId requested = RenderBackendId::Auto;
+  void* nativeWindowHandle = nullptr;
 };
 
 struct RenderBackendInitResult {

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -11,11 +11,13 @@ enum class RenderBackendId {
 };
 
 struct RenderBackendCapabilities {
+  bool supportsDebugDraw = false;
   bool supportsWireframeOverlay = false;
   bool supportsDebugLabels = false;
   bool supportsOffscreenTargets = false;
   bool supportsNativeTextureHandles = false;
   bool supportsReadback = false;
+  bool supportsDepthReadback = false;
   bool supportsDebugHud = false;
   bool supportsComputePasses = false;
   bool supportsGpuTimestamps = false;

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -13,6 +13,10 @@ enum class RenderBackendId {
 struct RenderBackendCapabilities {
   bool supportsWireframeOverlay = false;
   bool supportsDebugLabels = false;
+  bool supportsOffscreenTargets = false;
+  bool supportsNativeTextureHandles = false;
+  bool supportsReadback = false;
+  bool supportsDebugHud = false;
   bool supportsComputePasses = false;
   bool supportsGpuTimestamps = false;
   bool supportsBindlessResources = false;

--- a/renderer/RenderBackendFactory.cpp
+++ b/renderer/RenderBackendFactory.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "renderer/OpenGLRenderBackend.h"
+#include "renderer/VulkanRenderBackend.h"
 
 namespace Monolith {
 
@@ -12,9 +13,24 @@ RenderBackendCreateResult CreateRenderBackend(const RenderBackendSelection& sele
     case RenderBackendId::OpenGL:
       return {std::make_unique<OpenGLRenderBackend>(), RenderBackendId::OpenGL, {}};
     case RenderBackendId::Vulkan:
+#if defined(MONOLITH_HAS_VULKAN)
+    {
+      std::unique_ptr<VulkanRenderBackend> backend =
+          std::make_unique<VulkanRenderBackend>(selection.nativeWindowHandle);
+      if (!backend->IsInitialized()) {
+        return {nullptr,
+                RenderBackendId::Vulkan,
+                backend->GetLastError().empty()
+                    ? std::string("Vulkan backend initialization failed.")
+                    : backend->GetLastError()};
+      }
+      return {std::move(backend), RenderBackendId::Vulkan, {}};
+    }
+#else
       return {nullptr,
               RenderBackendId::Vulkan,
-              "Vulkan backend is not integrated yet. Select OpenGL or Auto for now."};
+              "Vulkan backend support is not compiled in. Enable MONOLITH_ENGINE_ENABLE_VULKAN to build it."};
+#endif
     case RenderBackendId::Auto:
       break;
   }

--- a/renderer/RenderContext.cpp
+++ b/renderer/RenderContext.cpp
@@ -1,6 +1,19 @@
 #include "renderer/RenderContext.h"
 
+#include "renderer/Renderer.h"
+
 namespace Monolith {
+
+void RenderContext::Init() {}
+
+void RenderContext::BeginFrame(const Vec4& clearColor) {
+  Renderer::BeginFrame(MakeFrameConfig({}, "compat-render-context-frame", clearColor));
+}
+
+void RenderContext::EndFrame() {
+  if (Renderer::IsFrameActive())
+    Renderer::EndFrame();
+}
 
 RenderFrameConfig RenderContext::MakeFrameConfig(std::vector<Light> lights,
                                                  std::string debugLabel,

--- a/renderer/RenderContext.cpp
+++ b/renderer/RenderContext.cpp
@@ -1,48 +1,19 @@
 #include "renderer/RenderContext.h"
 
-#include <glad/glad.h>
-
 namespace Monolith {
 
-void RenderContext::Init() {
-  glEnable(GL_DEPTH_TEST);
-  glDepthFunc(GL_LEQUAL);
-  glEnable(GL_CULL_FACE);
-  glCullFace(GL_BACK);
-  glFrontFace(GL_CCW);
-  glEnable(GL_MULTISAMPLE);
-}
-
-void RenderContext::BeginFrame(const Vec4& c) {
-  glClearColor(c.x, c.y, c.z, c.w);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-}
-
-void RenderContext::EndFrame() {}
-
-void RenderContext::SetViewport(int x, int y, int w, int h) {
-  glViewport(x, y, w, h);
-}
-
-void RenderContext::SetDepthTest(bool enabled) {
-  enabled ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
-}
-
-void RenderContext::SetCullFace(bool enabled) {
-  enabled ? glEnable(GL_CULL_FACE) : glDisable(GL_CULL_FACE);
-}
-
-void RenderContext::SetWireframe(bool enabled) {
-  glPolygonMode(GL_FRONT_AND_BACK, enabled ? GL_LINE : GL_FILL);
-}
-
-void RenderContext::SetBlend(bool enabled) {
-  if (enabled) {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  } else {
-    glDisable(GL_BLEND);
-  }
+RenderFrameConfig RenderContext::MakeFrameConfig(std::vector<Light> lights,
+                                                 std::string debugLabel,
+                                                 const Vec4& clearColor,
+                                                 bool clearColorBuffer,
+                                                 bool clearDepthBuffer) {
+  RenderFrameConfig frame;
+  frame.lights = std::move(lights);
+  frame.debugLabel = std::move(debugLabel);
+  frame.clearColor = clearColor;
+  frame.clearColorBuffer = clearColorBuffer;
+  frame.clearDepthBuffer = clearDepthBuffer;
+  return frame;
 }
 
 }  // namespace Monolith

--- a/renderer/RenderContext.h
+++ b/renderer/RenderContext.h
@@ -13,6 +13,12 @@ namespace Monolith {
 // Graphics API state is owned by the active render backend, not by this type.
 class RenderContext {
  public:
+  // Legacy compatibility shim for downstream starter apps. No explicit global
+  // graphics initialization remains here; the active backend owns frame state.
+  static void Init();
+  static void BeginFrame(const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f});
+  static void EndFrame();
+
   static RenderFrameConfig MakeFrameConfig(std::vector<Light> lights = {},
                                            std::string debugLabel = {},
                                            const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f},

--- a/renderer/RenderContext.h
+++ b/renderer/RenderContext.h
@@ -1,22 +1,23 @@
 #pragma once
+
+#include <string>
+#include <vector>
+
 #include "math/Vec4.h"
+#include "renderer/Light.h"
+#include "renderer/RenderTypes.h"
 
 namespace Monolith {
 
-// Thin wrapper around OpenGL state that should only be set once per frame
-// rather than per draw call.
+// Compatibility helper for assembling frame-level output configuration.
+// Graphics API state is owned by the active render backend, not by this type.
 class RenderContext {
  public:
-  static void Init();
-
-  static void BeginFrame(const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f});
-  static void EndFrame();
-
-  static void SetViewport(int x, int y, int w, int h);
-  static void SetDepthTest(bool enabled);
-  static void SetCullFace(bool enabled);
-  static void SetWireframe(bool enabled);
-  static void SetBlend(bool enabled);
+  static RenderFrameConfig MakeFrameConfig(std::vector<Light> lights = {},
+                                           std::string debugLabel = {},
+                                           const Vec4& clearColor = {0.1f, 0.1f, 0.15f, 1.0f},
+                                           bool clearColorBuffer = true,
+                                           bool clearDepthBuffer = true);
 };
 
 }  // namespace Monolith

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -4,35 +4,60 @@
 
 #include "renderer/RenderBackend.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-enum class RenderNativeHandleType {
-  None,
-  OpenGLTexture2D,
-  VulkanImGuiDescriptorSet,
-};
+  enum class RenderNativeHandleType
+  {
+    None,
+    OpenGLTexture2D,
+    VulkanImGuiDescriptorSet,
+  };
 
-struct RenderTargetHandle {
-  RenderBackendId backendId = RenderBackendId::Auto;
-  RenderNativeHandleType nativeType = RenderNativeHandleType::None;
-  uint64_t nativeHandle = 0;
-  bool needsYFlip = false;
+  struct RenderTargetHandle
+  {
+    RenderBackendId backendId = RenderBackendId::Auto;
+    RenderNativeHandleType nativeType = RenderNativeHandleType::None;
+    uint64_t nativeHandle = 0;
+    uint64_t auxiliaryHandle = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint64_t generation = 0;
+    bool needsYFlip = false;
 
-  bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
+    bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
 
-  static RenderTargetHandle OpenGLTexture(uint32_t textureId, bool yFlip = false) {
-    return {RenderBackendId::OpenGL,
-            RenderNativeHandleType::OpenGLTexture2D,
-            static_cast<uint64_t>(textureId),
-            yFlip};
-  }
+    static RenderTargetHandle OpenGLTexture(uint32_t textureId,
+                                            bool yFlip = false,
+                                            uint32_t textureWidth = 0,
+                                            uint32_t textureHeight = 0,
+                                            uint64_t textureGeneration = 0)
+    {
+      return {RenderBackendId::OpenGL,
+              RenderNativeHandleType::OpenGLTexture2D,
+              static_cast<uint64_t>(textureId),
+              0,
+              textureWidth,
+              textureHeight,
+              textureGeneration,
+              yFlip};
+    }
 
-  static RenderTargetHandle VulkanDescriptorSet(void* descriptorSet, bool yFlip = false) {
-    return {RenderBackendId::Vulkan,
-            RenderNativeHandleType::VulkanImGuiDescriptorSet,
-            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(descriptorSet)),
-            yFlip};
-  }
-};
+    static RenderTargetHandle VulkanDescriptorSet(void *descriptorSet,
+                                                  bool yFlip = false,
+                                                  uint32_t targetWidth = 0,
+                                                  uint32_t targetHeight = 0,
+                                                  uint64_t targetGeneration = 0)
+    {
+      return {RenderBackendId::Vulkan,
+              RenderNativeHandleType::VulkanImGuiDescriptorSet,
+              static_cast<uint64_t>(reinterpret_cast<uintptr_t>(descriptorSet)),
+              0,
+              targetWidth,
+              targetHeight,
+              targetGeneration,
+              yFlip};
+    }
+  };
 
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#include "renderer/RenderBackend.h"
+
+namespace Monolith {
+
+enum class RenderNativeHandleType {
+  None,
+  OpenGLTexture2D,
+};
+
+struct RenderTargetHandle {
+  RenderBackendId backendId = RenderBackendId::Auto;
+  RenderNativeHandleType nativeType = RenderNativeHandleType::None;
+  uint64_t nativeHandle = 0;
+  bool needsYFlip = false;
+
+  bool IsValid() const { return nativeType != RenderNativeHandleType::None && nativeHandle != 0; }
+
+  static RenderTargetHandle OpenGLTexture(uint32_t textureId, bool yFlip = false) {
+    return {RenderBackendId::OpenGL,
+            RenderNativeHandleType::OpenGLTexture2D,
+            static_cast<uint64_t>(textureId),
+            yFlip};
+  }
+};
+
+}  // namespace Monolith

--- a/renderer/RenderTargetHandle.h
+++ b/renderer/RenderTargetHandle.h
@@ -9,6 +9,7 @@ namespace Monolith {
 enum class RenderNativeHandleType {
   None,
   OpenGLTexture2D,
+  VulkanImGuiDescriptorSet,
 };
 
 struct RenderTargetHandle {
@@ -23,6 +24,13 @@ struct RenderTargetHandle {
     return {RenderBackendId::OpenGL,
             RenderNativeHandleType::OpenGLTexture2D,
             static_cast<uint64_t>(textureId),
+            yFlip};
+  }
+
+  static RenderTargetHandle VulkanDescriptorSet(void* descriptorSet, bool yFlip = false) {
+    return {RenderBackendId::Vulkan,
+            RenderNativeHandleType::VulkanImGuiDescriptorSet,
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(descriptorSet)),
             yFlip};
   }
 };

--- a/renderer/RenderTypes.h
+++ b/renderer/RenderTypes.h
@@ -31,6 +31,9 @@ struct RenderView {
 struct RenderFrameConfig {
   std::vector<Light> lights;
   std::string debugLabel;
+  Vec4 clearColor = {0.1f, 0.1f, 0.15f, 1.0f};
+  bool clearColorBuffer = true;
+  bool clearDepthBuffer = true;
 };
 
 struct RenderPassConfig {

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -64,6 +64,10 @@ RenderBackendCapabilities Renderer::GetBackendCapabilities() {
   return ActiveBackend()->GetCapabilities();
 }
 
+IRenderBackend* Renderer::GetBackendForInterop() {
+  return ActiveBackend();
+}
+
 bool Renderer::IsBackendSupported(RenderBackendId backendId) {
   return Monolith::IsRenderBackendSupported(backendId);
 }

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -5,152 +5,174 @@
 #include "core/Assert.h"
 #include "renderer/RenderBackendFactory.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-namespace {
+  namespace
+  {
 
-std::unique_ptr<IRenderBackend> CreateDefaultOwnedBackend() {
-  RenderBackendCreateResult createResult = CreateRenderBackend({});
-  MONOLITH_ASSERT(createResult.backend != nullptr,
-                  "Failed to create the default OpenGL render backend");
-  return std::move(createResult.backend);
-}
+    std::unique_ptr<IRenderBackend> CreateDefaultOwnedBackend()
+    {
+      RenderBackendCreateResult createResult = CreateRenderBackend({});
+      MONOLITH_ASSERT(createResult.backend != nullptr,
+                      "Failed to create the default OpenGL render backend");
+      return std::move(createResult.backend);
+    }
 
-std::unique_ptr<IRenderBackend> g_ownedBackend = CreateDefaultOwnedBackend();
-IRenderBackend* g_backend = g_ownedBackend.get();
+    std::unique_ptr<IRenderBackend> g_ownedBackend = CreateDefaultOwnedBackend();
+    IRenderBackend *g_backend = g_ownedBackend.get();
 
-IRenderBackend* ResetToDefaultBackend() {
-  g_ownedBackend = CreateDefaultOwnedBackend();
-  g_backend = g_ownedBackend.get();
-  return g_backend;
-}
+    IRenderBackend *ResetToDefaultBackend()
+    {
+      g_ownedBackend = CreateDefaultOwnedBackend();
+      g_backend = g_ownedBackend.get();
+      return g_backend;
+    }
 
-}  // namespace
+  } // namespace
 
-bool Renderer::s_frameActive = false;
-bool Renderer::s_passActive = false;
+  bool Renderer::s_frameActive = false;
+  bool Renderer::s_passActive = false;
 
-IRenderBackend* Renderer::ActiveBackend() {
-  MONOLITH_ASSERT(g_backend != nullptr, "Renderer backend pointer should never be null");
-  return g_backend;
-}
+  IRenderBackend *Renderer::ActiveBackend()
+  {
+    MONOLITH_ASSERT(g_backend != nullptr, "Renderer backend pointer should never be null");
+    return g_backend;
+  }
 
-RenderBackendInitResult Renderer::InitializeBackend(const RenderBackendSelection& selection) {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot initialize render backend while a frame or pass is active");
+  RenderBackendInitResult Renderer::InitializeBackend(const RenderBackendSelection &selection)
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot initialize render backend while a frame or pass is active");
 
-  RenderBackendInitResult out;
-  out.requested = selection.requested;
+    RenderBackendInitResult out;
+    out.requested = selection.requested;
 
-  RenderBackendCreateResult createResult = CreateRenderBackend(selection);
-  out.selected = createResult.selected;
-  out.error = std::move(createResult.error);
-  if (!createResult.backend)
+    RenderBackendCreateResult createResult = CreateRenderBackend(selection);
+    out.selected = createResult.selected;
+    out.error = std::move(createResult.error);
+    if (!createResult.backend)
+      return out;
+
+    g_ownedBackend = std::move(createResult.backend);
+    g_backend = g_ownedBackend.get();
+    out.ok = true;
+    out.selected = g_backend->GetBackendId();
+    out.capabilities = g_backend->GetCapabilities();
     return out;
+  }
 
-  g_ownedBackend = std::move(createResult.backend);
-  g_backend = g_ownedBackend.get();
-  out.ok = true;
-  out.selected = g_backend->GetBackendId();
-  out.capabilities = g_backend->GetCapabilities();
-  return out;
-}
+  RenderBackendId Renderer::GetBackendId()
+  {
+    return ActiveBackend()->GetBackendId();
+  }
 
-RenderBackendId Renderer::GetBackendId() {
-  return ActiveBackend()->GetBackendId();
-}
+  RenderBackendCapabilities Renderer::GetBackendCapabilities()
+  {
+    return ActiveBackend()->GetCapabilities();
+  }
 
-RenderBackendCapabilities Renderer::GetBackendCapabilities() {
-  return ActiveBackend()->GetCapabilities();
-}
+  IRenderBackend *Renderer::GetBackendForInterop()
+  {
+    return ActiveBackend();
+  }
 
-IRenderBackend* Renderer::GetBackendForInterop() {
-  return ActiveBackend();
-}
+  bool Renderer::IsBackendSupported(RenderBackendId backendId)
+  {
+    return Monolith::IsRenderBackendSupported(backendId);
+  }
 
-bool Renderer::IsBackendSupported(RenderBackendId backendId) {
-  return Monolith::IsRenderBackendSupported(backendId);
-}
+  void Renderer::UseBackend(IRenderBackend *backend)
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot swap render backend while a frame or pass is active");
+    g_ownedBackend.reset();
+    g_backend = backend ? backend : ResetToDefaultBackend();
+  }
 
-void Renderer::UseBackend(IRenderBackend* backend) {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot swap render backend while a frame or pass is active");
-  g_ownedBackend.reset();
-  g_backend = backend ? backend : ResetToDefaultBackend();
-}
+  void Renderer::ResetBackend()
+  {
+    MONOLITH_ASSERT(!s_frameActive && !s_passActive,
+                    "Cannot reset render backend while a frame or pass is active");
+    ResetToDefaultBackend();
+  }
 
-void Renderer::ResetBackend() {
-  MONOLITH_ASSERT(!s_frameActive && !s_passActive,
-                  "Cannot reset render backend while a frame or pass is active");
-  ResetToDefaultBackend();
-}
+  void Renderer::BeginFrame(const RenderFrameConfig &frame)
+  {
+    MONOLITH_ASSERT(!s_frameActive, "Renderer::BeginFrame called while a frame is already active");
 
-void Renderer::BeginFrame(const RenderFrameConfig& frame) {
-  MONOLITH_ASSERT(!s_frameActive, "Renderer::BeginFrame called while a frame is already active");
+    ActiveBackend()->BeginFrame(frame);
+    s_frameActive = true;
+  }
 
-  ActiveBackend()->BeginFrame(frame);
-  s_frameActive = true;
-}
+  void Renderer::EndFrame()
+  {
+    MONOLITH_ASSERT(s_frameActive, "Renderer::EndFrame called without an active frame");
+    if (!s_frameActive)
+      return;
 
-void Renderer::EndFrame() {
-  MONOLITH_ASSERT(s_frameActive, "Renderer::EndFrame called without an active frame");
-  if (!s_frameActive)
-    return;
+    if (s_passActive)
+      EndPass();
 
-  if (s_passActive)
-    EndPass();
+    ActiveBackend()->EndFrame();
+    s_frameActive = false;
+  }
 
-  ActiveBackend()->EndFrame();
-  s_frameActive = false;
-}
+  void Renderer::BeginPass(const RenderPassConfig &pass)
+  {
+    MONOLITH_ASSERT(s_frameActive, "Renderer::BeginPass called without an active frame");
+    MONOLITH_ASSERT(!s_passActive, "Renderer::BeginPass called while another pass is still active");
+    if (!s_frameActive || s_passActive)
+      return;
 
-void Renderer::BeginPass(const RenderPassConfig& pass) {
-  MONOLITH_ASSERT(s_frameActive, "Renderer::BeginPass called without an active frame");
-  MONOLITH_ASSERT(!s_passActive, "Renderer::BeginPass called while another pass is still active");
-  if (!s_frameActive || s_passActive)
-    return;
+    ActiveBackend()->BeginPass(pass);
+    s_passActive = true;
+  }
 
-  ActiveBackend()->BeginPass(pass);
-  s_passActive = true;
-}
+  void Renderer::EndPass()
+  {
+    MONOLITH_ASSERT(s_passActive, "Renderer::EndPass called without an active pass");
+    if (!s_passActive)
+      return;
 
-void Renderer::EndPass() {
-  MONOLITH_ASSERT(s_passActive, "Renderer::EndPass called without an active pass");
-  if (!s_passActive)
-    return;
+    ActiveBackend()->EndPass();
+    s_passActive = false;
+  }
 
-  ActiveBackend()->EndPass();
-  s_passActive = false;
-}
+  bool Renderer::IsFrameActive()
+  {
+    return s_frameActive;
+  }
 
-bool Renderer::IsFrameActive() {
-  return s_frameActive;
-}
+  bool Renderer::IsPassActive()
+  {
+    return s_passActive;
+  }
 
-bool Renderer::IsPassActive() {
-  return s_passActive;
-}
+  void Renderer::Submit(const Mesh &mesh, const Mat4 &modelMatrix, Material &material)
+  {
+    ActiveBackend()->DrawMesh(MeshDrawCommand{&mesh, &material, modelMatrix});
+  }
 
-void Renderer::Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material) {
-  ActiveBackend()->DrawMesh(MeshDrawCommand{&mesh, &material, modelMatrix});
-}
+  void Renderer::SubmitSkinned(const SkinnedMesh &mesh,
+                               const Mat4 &modelMatrix,
+                               Material &material,
+                               const std::vector<Mat4> &boneMatrices)
+  {
+    ActiveBackend()->DrawSkinnedMesh(
+        SkinnedMeshDrawCommand{&mesh, &material, modelMatrix, &boneMatrices});
+  }
 
-void Renderer::SubmitSkinned(const SkinnedMesh& mesh,
-                              const Mat4& modelMatrix,
-                              Material& material,
-                              const std::vector<Mat4>& boneMatrices) {
-  ActiveBackend()->DrawSkinnedMesh(
-      SkinnedMeshDrawCommand{&mesh, &material, modelMatrix, &boneMatrices});
-}
+  void Renderer::SubmitWireframe(
+      const Mesh &mesh, const Mat4 &model, Shader &shader, float r, float g, float b)
+  {
+    ActiveBackend()->DrawWireframe(
+        WireframeDrawCommand{&mesh, &shader, model, {r, g, b, 1.0f}});
+  }
 
-void Renderer::SubmitWireframe(
-    const Mesh& mesh, const Mat4& model, Shader& shader, float r, float g, float b) {
-  ActiveBackend()->DrawWireframe(
-      WireframeDrawCommand{&mesh, &shader, model, {r, g, b, 1.0f}});
-}
+  int Renderer::GetDrawCallCount()
+  {
+    return ActiveBackend()->GetDrawCallCount();
+  }
 
-int Renderer::GetDrawCallCount() {
-  return ActiveBackend()->GetDrawCallCount();
-}
-
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -175,4 +175,34 @@ namespace Monolith
     return ActiveBackend()->GetDrawCallCount();
   }
 
+  bool Renderer::ReadbackColorBgr8(int width,
+                                   int height,
+                                   std::vector<uint8_t> &outPixels,
+                                   std::string *outError)
+  {
+    return ActiveBackend()->ReadbackColorBgr8(width, height, outPixels, outError);
+  }
+
+  bool Renderer::ReadbackDepth32F(int width,
+                                   int height,
+                                   std::vector<float> &outDepth,
+                                   std::string *outError)
+  {
+    return ActiveBackend()->ReadbackDepth32F(width, height, outDepth, outError);
+  }
+
+  bool Renderer::EnsureEditorViewportRenderTarget(uint32_t width,
+                                                  uint32_t height,
+                                                  std::string *outError)
+  {
+    return ActiveBackend()->EnsureEditorViewportRenderTarget(width, height, outError);
+  }
+
+  bool Renderer::TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                        bool needsYFlip,
+                                                        std::string *outError)
+  {
+    return ActiveBackend()->TryGetEditorViewportRenderTargetHandle(outHandle, needsYFlip, outError);
+  }
+
 } // namespace Monolith

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -7,56 +7,58 @@
 #include "renderer/IRenderBackend.h"
 #include "renderer/RenderTypes.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-class Mesh;
-class Shader;
-class Material;
-class SkinnedMesh;
+  class Mesh;
+  class Shader;
+  class Material;
+  class SkinnedMesh;
 
-class Renderer {
- public:
-  static RenderBackendInitResult InitializeBackend(const RenderBackendSelection& selection = {});
-  static RenderBackendId GetBackendId();
-  static RenderBackendCapabilities GetBackendCapabilities();
-  static bool IsBackendSupported(RenderBackendId backendId);
-  static IRenderBackend* GetBackendForInterop();
+  class Renderer
+  {
+  public:
+    static RenderBackendInitResult InitializeBackend(const RenderBackendSelection &selection = {});
+    static RenderBackendId GetBackendId();
+    static RenderBackendCapabilities GetBackendCapabilities();
+    static bool IsBackendSupported(RenderBackendId backendId);
+    static IRenderBackend *GetBackendForInterop();
 
-  // Test seam: temporarily override the active backend with an externally owned implementation.
-  static void UseBackend(IRenderBackend* backend);
-  static void ResetBackend();
+    // Test seam: temporarily override the active backend with an externally owned implementation.
+    static void UseBackend(IRenderBackend *backend);
+    static void ResetBackend();
 
-  static void BeginFrame(const RenderFrameConfig& frame);
-  static void EndFrame();
-  static void BeginPass(const RenderPassConfig& pass);
-  static void EndPass();
-  static bool IsFrameActive();
-  static bool IsPassActive();
+    static void BeginFrame(const RenderFrameConfig &frame);
+    static void EndFrame();
+    static void BeginPass(const RenderPassConfig &pass);
+    static void EndPass();
+    static bool IsFrameActive();
+    static bool IsPassActive();
 
-  // Submit a mesh for rendering with a given model matrix and material
-  static void Submit(const Mesh& mesh, const Mat4& modelMatrix, Material& material);
+    // Submit a mesh for rendering with a given model matrix and material
+    static void Submit(const Mesh &mesh, const Mat4 &modelMatrix, Material &material);
 
-  // Submit a skinned mesh — uploads boneMatrices to u_boneMatrices[0..N] via SetMat4Array.
-  static void SubmitSkinned(const SkinnedMesh& mesh,
-                             const Mat4& modelMatrix,
-                             Material& material,
-                             const std::vector<Mat4>& boneMatrices);
+    // Submit a skinned mesh — uploads boneMatrices to u_boneMatrices[0..N] via SetMat4Array.
+    static void SubmitSkinned(const SkinnedMesh &mesh,
+                              const Mat4 &modelMatrix,
+                              Material &material,
+                              const std::vector<Mat4> &boneMatrices);
 
-  // Submit a mesh in wireframe mode using a plain color
-  static void SubmitWireframe(const Mesh& mesh,
-                              const Mat4& modelMatrix,
-                              Shader& shader,
-                              float r = 0.2f,
-                              float g = 0.8f,
-                              float b = 0.2f);
+    // Submit a mesh in wireframe mode using a plain color
+    static void SubmitWireframe(const Mesh &mesh,
+                                const Mat4 &modelMatrix,
+                                Shader &shader,
+                                float r = 0.2f,
+                                float g = 0.8f,
+                                float b = 0.2f);
 
-  static int GetDrawCallCount();
+    static int GetDrawCallCount();
 
- private:
-  static IRenderBackend* ActiveBackend();
+  private:
+    static IRenderBackend *ActiveBackend();
 
-  static bool s_frameActive;
-  static bool s_passActive;
-};
+    static bool s_frameActive;
+    static bool s_passActive;
+  };
 
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -20,6 +20,7 @@ class Renderer {
   static RenderBackendId GetBackendId();
   static RenderBackendCapabilities GetBackendCapabilities();
   static bool IsBackendSupported(RenderBackendId backendId);
+  static IRenderBackend* GetBackendForInterop();
 
   // Test seam: temporarily override the active backend with an externally owned implementation.
   static void UseBackend(IRenderBackend* backend);

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -1,10 +1,12 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "math/Mat4.h"
 #include "renderer/RenderBackend.h"
 #include "renderer/IRenderBackend.h"
+#include "renderer/RenderTargetHandle.h"
 #include "renderer/RenderTypes.h"
 
 namespace Monolith
@@ -53,6 +55,20 @@ namespace Monolith
                                 float b = 0.2f);
 
     static int GetDrawCallCount();
+    static bool ReadbackColorBgr8(int width,
+                                  int height,
+                                  std::vector<uint8_t> &outPixels,
+                                  std::string *outError = nullptr);
+    static bool ReadbackDepth32F(int width,
+                                 int height,
+                                 std::vector<float> &outDepth,
+                                 std::string *outError = nullptr);
+    static bool EnsureEditorViewportRenderTarget(uint32_t width,
+                                                 uint32_t height,
+                                                 std::string *outError = nullptr);
+    static bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                       bool needsYFlip = false,
+                                                       std::string *outError = nullptr);
 
   private:
     static IRenderBackend *ActiveBackend();

--- a/renderer/Shader.cpp
+++ b/renderer/Shader.cpp
@@ -3,32 +3,45 @@
 #include <glad/glad.h>
 
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
 
 #include "core/Logger.h"
 
 namespace Monolith {
 
+struct Shader::ProgramStorage {
+  unsigned int program = 0;
+  std::unordered_map<std::string, int> uniformCache;
+};
+
+Shader::Shader() = default;
+
 Shader::~Shader() {
-  if (m_program)
-    glDeleteProgram(m_program);
+  if (m_programStorage && m_programStorage->program)
+    glDeleteProgram(m_programStorage->program);
 }
 
 Shader::Shader(Shader&& o) noexcept
-    : m_program(o.m_program), m_uniformCache(std::move(o.m_uniformCache)) {
-  o.m_program = 0;
-}
+    : m_programStorage(std::move(o.m_programStorage)) {}
 
 Shader& Shader::operator=(Shader&& o) noexcept {
   if (this != &o) {
-    if (m_program)
-      glDeleteProgram(m_program);
-    m_program = o.m_program;
-    m_uniformCache = std::move(o.m_uniformCache);
-    o.m_program = 0;
+    if (m_programStorage && m_programStorage->program)
+      glDeleteProgram(m_programStorage->program);
+    m_programStorage = std::move(o.m_programStorage);
   }
   return *this;
+}
+
+bool Shader::IsValid() const {
+  return m_programStorage && m_programStorage->program != 0;
+}
+
+unsigned int Shader::GetProgramID() const {
+  return m_programStorage ? m_programStorage->program : 0;
 }
 
 static std::string ReadFile(const std::string& path) {
@@ -46,9 +59,10 @@ Shader Shader::FromFiles(const std::string& vertPath, const std::string& fragPat
 
 Shader Shader::FromSource(const std::string& vertSrc, const std::string& fragSrc) {
   Shader s;
+  s.m_programStorage = std::make_unique<ProgramStorage>();
   unsigned int vert = CompileShader(GL_VERTEX_SHADER, vertSrc);
   unsigned int frag = CompileShader(GL_FRAGMENT_SHADER, fragSrc);
-  s.m_program = LinkProgram(vert, frag);
+  s.m_programStorage->program = LinkProgram(vert, frag);
   glDeleteShader(vert);
   glDeleteShader(frag);
   return s;
@@ -91,19 +105,22 @@ unsigned int Shader::LinkProgram(unsigned int vert, unsigned int frag) {
 }
 
 void Shader::Bind() const {
-  glUseProgram(m_program);
+  glUseProgram(GetProgramID());
 }
 void Shader::Unbind() const {
   glUseProgram(0);
 }
 
 int Shader::GetUniformLocation(const std::string& name) const {
-  auto it = m_uniformCache.find(name);
-  if (it != m_uniformCache.end())
+  if (!m_programStorage)
+    return -1;
+
+  auto it = m_programStorage->uniformCache.find(name);
+  if (it != m_programStorage->uniformCache.end())
     return it->second;
 
-  int loc = glGetUniformLocation(m_program, name.c_str());
-  m_uniformCache[name] = loc;
+  int loc = glGetUniformLocation(m_programStorage->program, name.c_str());
+  m_programStorage->uniformCache[name] = loc;
   return loc;
 }
 

--- a/renderer/Shader.h
+++ b/renderer/Shader.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <memory>
 #include <string>
-#include <unordered_map>
 
 #include "math/Mat3.h"
 #include "math/Mat4.h"
@@ -11,7 +11,7 @@ namespace Monolith {
 
 class Shader {
  public:
-  Shader() = default;
+  Shader();
   ~Shader();
 
   Shader(const Shader&) = delete;
@@ -28,8 +28,8 @@ class Shader {
   void Bind() const;
   void Unbind() const;
 
-  bool IsValid() const { return m_program != 0; }
-  unsigned int GetProgramID() const { return m_program; }
+  bool IsValid() const;
+  unsigned int GetProgramID() const;
 
   // Uniform setters
   void SetInt(const std::string& name, int v) const;
@@ -45,8 +45,8 @@ class Shader {
   void SetMat4Array(const std::string& name, int count, const float* data) const;
 
  private:
-  unsigned int m_program = 0;
-  mutable std::unordered_map<std::string, int> m_uniformCache;
+  struct ProgramStorage;
+  std::unique_ptr<ProgramStorage> m_programStorage;
 
   int GetUniformLocation(const std::string& name) const;
   static unsigned int CompileShader(unsigned int type, const std::string& src);

--- a/renderer/SkinnedMesh.cpp
+++ b/renderer/SkinnedMesh.cpp
@@ -4,9 +4,18 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <memory>
 #include <utility>
 
 namespace Monolith {
+
+struct SkinnedMesh::GpuStorage {
+  unsigned int vao = 0;
+  unsigned int vbo = 0;
+  unsigned int ebo = 0;
+};
+
+SkinnedMesh::SkinnedMesh() = default;
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -17,29 +26,27 @@ SkinnedMesh::~SkinnedMesh() {
 }
 
 SkinnedMesh::SkinnedMesh(SkinnedMesh&& o) noexcept
-    : m_vao(o.m_vao),
-      m_vbo(o.m_vbo),
-      m_ebo(o.m_ebo),
+    : m_gpu(std::move(o.m_gpu)),
       m_indexCount(o.m_indexCount),
       m_halfExtents(o.m_halfExtents),
       m_localAabbCenter(o.m_localAabbCenter) {
-  o.m_vao = o.m_vbo = o.m_ebo = 0;
   o.m_indexCount = 0;
 }
 
 SkinnedMesh& SkinnedMesh::operator=(SkinnedMesh&& o) noexcept {
   if (this != &o) {
     Release();
-    m_vao              = o.m_vao;
-    m_vbo              = o.m_vbo;
-    m_ebo              = o.m_ebo;
+    m_gpu              = std::move(o.m_gpu);
     m_indexCount       = o.m_indexCount;
     m_halfExtents      = o.m_halfExtents;
     m_localAabbCenter  = o.m_localAabbCenter;
-    o.m_vao = o.m_vbo = o.m_ebo = 0;
     o.m_indexCount = 0;
   }
   return *this;
+}
+
+bool SkinnedMesh::IsValid() const {
+  return m_gpu && m_gpu->vao != 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -53,7 +60,9 @@ void SkinnedMesh::SetData(const std::vector<SkinnedVertex>& vertices,
 }
 
 void SkinnedMesh::Draw() const {
-  glBindVertexArray(m_vao);
+  if (!m_gpu)
+    return;
+  glBindVertexArray(m_gpu->vao);
   glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
   glBindVertexArray(0);
 }
@@ -65,21 +74,22 @@ void SkinnedMesh::Draw() const {
 void SkinnedMesh::Upload(const std::vector<SkinnedVertex>& vertices,
                          const std::vector<unsigned int>& indices) {
   m_indexCount = static_cast<int>(indices.size());
+  m_gpu = std::make_unique<GpuStorage>();
 
-  glGenVertexArrays(1, &m_vao);
-  glBindVertexArray(m_vao);
+  glGenVertexArrays(1, &m_gpu->vao);
+  glBindVertexArray(m_gpu->vao);
 
   // --- VBO ---
-  glGenBuffers(1, &m_vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+  glGenBuffers(1, &m_gpu->vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
   glBufferData(GL_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(vertices.size() * sizeof(SkinnedVertex)),
                vertices.data(),
                GL_STATIC_DRAW);
 
   // --- EBO ---
-  glGenBuffers(1, &m_ebo);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ebo);
+  glGenBuffers(1, &m_gpu->ebo);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
                indices.data(),
@@ -152,13 +162,15 @@ void SkinnedMesh::Upload(const std::vector<SkinnedVertex>& vertices,
 }
 
 void SkinnedMesh::Release() {
-  if (m_ebo)
-    glDeleteBuffers(1, &m_ebo);
-  if (m_vbo)
-    glDeleteBuffers(1, &m_vbo);
-  if (m_vao)
-    glDeleteVertexArrays(1, &m_vao);
-  m_vao = m_vbo = m_ebo = 0;
+  if (m_gpu) {
+    if (m_gpu->ebo)
+      glDeleteBuffers(1, &m_gpu->ebo);
+    if (m_gpu->vbo)
+      glDeleteBuffers(1, &m_gpu->vbo);
+    if (m_gpu->vao)
+      glDeleteVertexArrays(1, &m_gpu->vao);
+    m_gpu.reset();
+  }
   m_indexCount = 0;
 }
 

--- a/renderer/SkinnedMesh.h
+++ b/renderer/SkinnedMesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "math/Vec3.h"
@@ -24,7 +25,7 @@ namespace Monolith {
 // Non-copyable (owns GPU resources).  Move-only, matching the Mesh convention.
 class SkinnedMesh {
  public:
-  SkinnedMesh() = default;
+  SkinnedMesh();
   ~SkinnedMesh();
 
   SkinnedMesh(const SkinnedMesh&) = delete;
@@ -42,7 +43,7 @@ class SkinnedMesh {
   // Bind the VAO and issue a single glDrawElements call.
   void Draw() const;
 
-  bool IsValid() const { return m_vao != 0; }
+  bool IsValid() const;
   int  GetIndexCount() const { return m_indexCount; }
 
   // Axis-aligned bounding box in local (bind-pose) space.
@@ -50,9 +51,8 @@ class SkinnedMesh {
   Vec3 GetLocalAabbCenter() const { return m_localAabbCenter; }
 
  private:
-  unsigned int m_vao = 0;
-  unsigned int m_vbo = 0;
-  unsigned int m_ebo = 0;
+  struct GpuStorage;
+  std::unique_ptr<GpuStorage> m_gpu;
   int  m_indexCount = 0;
   Vec3 m_halfExtents     = {0.5f, 0.5f, 0.5f};
   Vec3 m_localAabbCenter = Vec3::Zero();

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -44,6 +44,10 @@ unsigned int Texture::GetNativeId() const {
   return m_textureStorage ? m_textureStorage->id : 0;
 }
 
+RenderTargetHandle Texture::GetRenderTargetHandle(bool needsYFlip) const {
+  return RenderTargetHandle::OpenGLTexture(GetNativeId(), needsYFlip);
+}
+
 Texture Texture::FromFile(const std::string& path, bool flipY) {
   stbi_set_flip_vertically_on_load(flipY ? 1 : 0);
   int w, h, ch;

--- a/renderer/Texture.cpp
+++ b/renderer/Texture.cpp
@@ -5,29 +5,43 @@
 #include <glad/glad.h>
 #include <stb_image.h>
 
+#include <memory>
+
 #include "core/Logger.h"
 
 namespace Monolith {
 
+struct Texture::TextureStorage {
+  unsigned int id = 0;
+};
+
+Texture::Texture() = default;
+
 Texture::~Texture() {
-  if (m_id)
-    glDeleteTextures(1, &m_id);
+  if (m_textureStorage && m_textureStorage->id)
+    glDeleteTextures(1, &m_textureStorage->id);
 }
 
-Texture::Texture(Texture&& o) noexcept : m_id(o.m_id), m_width(o.m_width), m_height(o.m_height) {
-  o.m_id = 0;
-}
+Texture::Texture(Texture&& o) noexcept
+    : m_textureStorage(std::move(o.m_textureStorage)), m_width(o.m_width), m_height(o.m_height) {}
 
 Texture& Texture::operator=(Texture&& o) noexcept {
   if (this != &o) {
-    if (m_id)
-      glDeleteTextures(1, &m_id);
-    m_id = o.m_id;
+    if (m_textureStorage && m_textureStorage->id)
+      glDeleteTextures(1, &m_textureStorage->id);
+    m_textureStorage = std::move(o.m_textureStorage);
     m_width = o.m_width;
     m_height = o.m_height;
-    o.m_id = 0;
   }
   return *this;
+}
+
+bool Texture::IsValid() const {
+  return m_textureStorage && m_textureStorage->id != 0;
+}
+
+unsigned int Texture::GetNativeId() const {
+  return m_textureStorage ? m_textureStorage->id : 0;
 }
 
 Texture Texture::FromFile(const std::string& path, bool flipY) {
@@ -40,8 +54,9 @@ Texture Texture::FromFile(const std::string& path, bool flipY) {
   }
 
   Texture t;
-  glGenTextures(1, &t.m_id);
-  glBindTexture(GL_TEXTURE_2D, t.m_id);
+  t.m_textureStorage = std::make_unique<TextureStorage>();
+  glGenTextures(1, &t.m_textureStorage->id);
+  glBindTexture(GL_TEXTURE_2D, t.m_textureStorage->id);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
   glGenerateMipmap(GL_TEXTURE_2D);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
@@ -57,8 +72,9 @@ Texture Texture::FromFile(const std::string& path, bool flipY) {
 
 Texture Texture::CreateWhite1x1() {
   Texture t;
-  glGenTextures(1, &t.m_id);
-  glBindTexture(GL_TEXTURE_2D, t.m_id);
+  t.m_textureStorage = std::make_unique<TextureStorage>();
+  glGenTextures(1, &t.m_textureStorage->id);
+  glBindTexture(GL_TEXTURE_2D, t.m_textureStorage->id);
   unsigned char white[4] = {255, 255, 255, 255};
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, white);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -70,7 +86,7 @@ Texture Texture::CreateWhite1x1() {
 
 void Texture::Bind(unsigned int slot) const {
   glActiveTexture(GL_TEXTURE0 + slot);
-  glBindTexture(GL_TEXTURE_2D, m_id);
+  glBindTexture(GL_TEXTURE_2D, GetNativeId());
 }
 
 void Texture::Unbind() const {

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -1,11 +1,12 @@
 #pragma once
+#include <memory>
 #include <string>
 
 namespace Monolith {
 
 class Texture {
  public:
-  Texture() = default;
+  Texture();
   ~Texture();
 
   Texture(const Texture&) = delete;
@@ -19,13 +20,16 @@ class Texture {
   void Bind(unsigned int slot = 0) const;
   void Unbind() const;
 
-  bool IsValid() const { return m_id != 0; }
+  bool IsValid() const;
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
-  unsigned int GetNativeId() const { return m_id; }
+  // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
+  // texture presentation is fully backend-neutral.
+  unsigned int GetNativeId() const;
 
  private:
-  unsigned int m_id = 0;
+  struct TextureStorage;
+  std::unique_ptr<TextureStorage> m_textureStorage;
   int m_width = 0;
   int m_height = 0;
 };

--- a/renderer/Texture.h
+++ b/renderer/Texture.h
@@ -2,6 +2,8 @@
 #include <memory>
 #include <string>
 
+#include "renderer/RenderTargetHandle.h"
+
 namespace Monolith {
 
 class Texture {
@@ -26,6 +28,7 @@ class Texture {
   // Temporary OpenGL escape hatch used by editor integration until offscreen/ImGui
   // texture presentation is fully backend-neutral.
   unsigned int GetNativeId() const;
+  RenderTargetHandle GetRenderTargetHandle(bool needsYFlip = false) const;
 
  private:
   struct TextureStorage;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <fstream>
 #include <limits>
 #include <optional>
 #include <set>
@@ -18,1093 +19,1495 @@
 #include <GLFW/glfw3.h>
 #endif
 
-namespace Monolith {
+namespace Monolith
+{
 
 #if defined(MONOLITH_HAS_VULKAN)
 
-namespace {
+  namespace
+  {
 
-constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
+    constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
 
-const char* VkResultName(VkResult result) {
-  switch (result) {
-    case VK_SUCCESS:
-      return "VK_SUCCESS";
-    case VK_NOT_READY:
-      return "VK_NOT_READY";
-    case VK_TIMEOUT:
-      return "VK_TIMEOUT";
-    case VK_EVENT_SET:
-      return "VK_EVENT_SET";
-    case VK_EVENT_RESET:
-      return "VK_EVENT_RESET";
-    case VK_INCOMPLETE:
-      return "VK_INCOMPLETE";
-    case VK_ERROR_OUT_OF_HOST_MEMORY:
-      return "VK_ERROR_OUT_OF_HOST_MEMORY";
-    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-      return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
-    case VK_ERROR_INITIALIZATION_FAILED:
-      return "VK_ERROR_INITIALIZATION_FAILED";
-    case VK_ERROR_DEVICE_LOST:
-      return "VK_ERROR_DEVICE_LOST";
-    case VK_ERROR_SURFACE_LOST_KHR:
-      return "VK_ERROR_SURFACE_LOST_KHR";
-    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
-      return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
-    case VK_SUBOPTIMAL_KHR:
-      return "VK_SUBOPTIMAL_KHR";
-    case VK_ERROR_OUT_OF_DATE_KHR:
-      return "VK_ERROR_OUT_OF_DATE_KHR";
-    default:
-      return "VK_ERROR_UNKNOWN";
-  }
-}
-
-bool CheckVk(VkResult result, std::string& outError, const char* context) {
-  if (result == VK_SUCCESS)
-    return true;
-  outError = std::string(context) + " failed: " + VkResultName(result);
-  return false;
-}
-
-}  // namespace
-
-struct VulkanRenderBackend::Context {
-  GLFWwindow* window = nullptr;
-  VkInstance instance = VK_NULL_HANDLE;
-  VkSurfaceKHR surface = VK_NULL_HANDLE;
-  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
-  VkDevice device = VK_NULL_HANDLE;
-  VkQueue graphicsQueue = VK_NULL_HANDLE;
-  VkQueue presentQueue = VK_NULL_HANDLE;
-  uint32_t graphicsQueueFamily = kInvalidQueueFamily;
-  uint32_t presentQueueFamily = kInvalidQueueFamily;
-  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
-  VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
-  VkExtent2D swapchainExtent = {1, 1};
-  VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
-  VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
-  VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
-  std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
-  std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
-  bool opaqueShaderPipelineScaffoldReady = false;
-  bool opaqueGraphicsPipelineScaffoldReady = false;
-  std::vector<VkImage> swapchainImages;
-  std::vector<VkImageView> swapchainImageViews;
-  std::vector<VkFramebuffer> opaqueFramebuffers;
-  std::vector<VkCommandBuffer> commandBuffers;
-  std::vector<bool> imageWasPresented;
-  VkCommandPool commandPool = VK_NULL_HANDLE;
-  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
-  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
-  VkFence inFlightFence = VK_NULL_HANDLE;
-  uint32_t activeImageIndex = 0;
-  bool frameCommandsRecorded = false;
-};
-
-namespace {
-
-constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
-  return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
-}
-
-}  // namespace
-
-VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
-    const Material& material) {
-  TranslatedMaterialState translated;
-  translated.baseColor = material.color;
-  translated.roughness = material.roughness;
-  translated.metallic = material.metallic;
-  translated.uvScale = material.uvScale;
-  translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
-  translated.usesCustomShader = material.shader && material.shader->IsValid();
-  return translated;
-}
-
-int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
-  return mesh.GetIndexCount();
-}
-
-VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
-    const TranslatedMaterialState& materialState) {
-  OpaquePipelineKey key;
-  key.usesAlbedoMap = materialState.usesAlbedoMap;
-  key.usesCustomShader = materialState.usesCustomShader;
-  key.writesDepth = true;
-  key.depthTestEnabled = true;
-  return key;
-}
-
-VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
-  Initialize(nativeWindowHandle);
-}
-
-VulkanRenderBackend::~VulkanRenderBackend() {
-  Shutdown();
-}
-
-RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
-  RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
-  caps.supportsDebugDraw = false;
-  caps.supportsDebugLabels = false;
-  caps.supportsOffscreenTargets = false;
-  caps.supportsNativeTextureHandles = false;
-  caps.supportsReadback = false;
-  caps.supportsDepthReadback = false;
-  caps.supportsDebugHud = false;
-  caps.supportsComputePasses = false;
-  caps.supportsGpuTimestamps = false;
-  caps.supportsBindlessResources = false;
-  return caps;
-}
-
-bool VulkanRenderBackend::IsInitialized() const {
-  return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
-}
-
-bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
-  return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
-         m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-         m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
-         !m_context->opaqueFramebuffers.empty();
-}
-
-bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
-  return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
-}
-
-bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
-  return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
-}
-
-bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const {
-  return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
-}
-
-bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
-  m_lastError.clear();
-  if (!nativeWindowHandle) {
-    m_lastError = "Vulkan backend requires a native GLFW window handle.";
-    return false;
-  }
-
-  if (!glfwVulkanSupported()) {
-    m_lastError = "GLFW reports that Vulkan is not supported on this system.";
-    return false;
-  }
-
-  if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
-    return false;
-
-  m_context = std::make_unique<Context>();
-  m_context->window = static_cast<GLFWwindow*>(nativeWindowHandle);
-
-  uint32_t extensionCount = 0;
-  const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
-  if (!glfwExtensions || extensionCount == 0) {
-    m_lastError = "GLFW did not provide required Vulkan instance extensions.";
-    Shutdown();
-    return false;
-  }
-
-  const VkApplicationInfo appInfo{
-      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
-      .pNext = nullptr,
-      .pApplicationName = "MonolithEngine",
-      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
-      .pEngineName = "MonolithEngine",
-      .engineVersion = VK_MAKE_VERSION(0, 1, 0),
-      .apiVersion = VK_API_VERSION_1_1,
-  };
-
-  std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
-  const VkInstanceCreateInfo instanceInfo{
-      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .pApplicationInfo = &appInfo,
-      .enabledLayerCount = 0,
-      .ppEnabledLayerNames = nullptr,
-      .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
-      .ppEnabledExtensionNames = instanceExtensions.data(),
-  };
-  if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
-               "vkCreateInstance")) {
-    Shutdown();
-    return false;
-  }
-
-  volkLoadInstance(m_context->instance);
-
-  if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
-                                       &m_context->surface),
-               m_lastError,
-               "glfwCreateWindowSurface")) {
-    Shutdown();
-    return false;
-  }
-
-  uint32_t physicalDeviceCount = 0;
-  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
-               m_lastError,
-               "vkEnumeratePhysicalDevices(count)")) {
-    Shutdown();
-    return false;
-  }
-  if (physicalDeviceCount == 0) {
-    m_lastError = "No Vulkan physical devices were found.";
-    Shutdown();
-    return false;
-  }
-
-  std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
-                                          physicalDevices.data()),
-               m_lastError,
-               "vkEnumeratePhysicalDevices")) {
-    Shutdown();
-    return false;
-  }
-
-  const std::array<const char*, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
-  for (VkPhysicalDevice device : physicalDevices) {
-    uint32_t queueFamilyCount = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
-    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
-    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
-
-    std::optional<uint32_t> graphicsFamily;
-    std::optional<uint32_t> presentFamily;
-    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
-      if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
-        graphicsFamily = i;
-
-      VkBool32 presentSupported = VK_FALSE;
-      vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
-      if (presentSupported == VK_TRUE)
-        presentFamily = i;
+    const char *VkResultName(VkResult result)
+    {
+      switch (result)
+      {
+      case VK_SUCCESS:
+        return "VK_SUCCESS";
+      case VK_NOT_READY:
+        return "VK_NOT_READY";
+      case VK_TIMEOUT:
+        return "VK_TIMEOUT";
+      case VK_EVENT_SET:
+        return "VK_EVENT_SET";
+      case VK_EVENT_RESET:
+        return "VK_EVENT_RESET";
+      case VK_INCOMPLETE:
+        return "VK_INCOMPLETE";
+      case VK_ERROR_OUT_OF_HOST_MEMORY:
+        return "VK_ERROR_OUT_OF_HOST_MEMORY";
+      case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+        return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+      case VK_ERROR_INITIALIZATION_FAILED:
+        return "VK_ERROR_INITIALIZATION_FAILED";
+      case VK_ERROR_DEVICE_LOST:
+        return "VK_ERROR_DEVICE_LOST";
+      case VK_ERROR_SURFACE_LOST_KHR:
+        return "VK_ERROR_SURFACE_LOST_KHR";
+      case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+        return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+      case VK_SUBOPTIMAL_KHR:
+        return "VK_SUBOPTIMAL_KHR";
+      case VK_ERROR_OUT_OF_DATE_KHR:
+        return "VK_ERROR_OUT_OF_DATE_KHR";
+      default:
+        return "VK_ERROR_UNKNOWN";
+      }
     }
 
-    if (!graphicsFamily || !presentFamily)
-      continue;
+    bool CheckVk(VkResult result, std::string &outError, const char *context)
+    {
+      if (result == VK_SUCCESS)
+        return true;
+      outError = std::string(context) + " failed: " + VkResultName(result);
+      return false;
+    }
 
-    uint32_t extensionCountAvailable = 0;
-    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
-    std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
-    vkEnumerateDeviceExtensionProperties(device,
+    std::vector<char> ReadBinaryFile(const std::string &filePath)
+    {
+      std::ifstream stream(filePath, std::ios::binary | std::ios::ate);
+      if (!stream)
+        return {};
+
+      const std::streamsize fileSize = stream.tellg();
+      if (fileSize <= 0)
+        return {};
+
+      std::vector<char> bytes(static_cast<size_t>(fileSize));
+      stream.seekg(0, std::ios::beg);
+      if (!stream.read(bytes.data(), fileSize))
+        return {};
+      return bytes;
+    }
+
+    bool TryCreateShaderModule(VkDevice device,
+                               const std::vector<char> &spirvBytes,
+                               VkShaderModule *outShaderModule,
+                               std::string &outError,
+                               const char *context)
+    {
+      if (!outShaderModule)
+        return false;
+      *outShaderModule = VK_NULL_HANDLE;
+
+      if (spirvBytes.empty())
+        return false;
+      if ((spirvBytes.size() % sizeof(uint32_t)) != 0)
+      {
+        outError = std::string(context) + " failed: SPIR-V bytecode size is not a multiple of 4.";
+        return false;
+      }
+
+      const VkShaderModuleCreateInfo shaderModuleInfo{
+          .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .codeSize = spirvBytes.size(),
+          .pCode = reinterpret_cast<const uint32_t *>(spirvBytes.data()),
+      };
+      return CheckVk(vkCreateShaderModule(device, &shaderModuleInfo, nullptr, outShaderModule),
+                     outError,
+                     context);
+    }
+
+  } // namespace
+
+  struct VulkanRenderBackend::Context
+  {
+    GLFWwindow *window = nullptr;
+    VkInstance instance = VK_NULL_HANDLE;
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+    VkQueue graphicsQueue = VK_NULL_HANDLE;
+    VkQueue presentQueue = VK_NULL_HANDLE;
+    uint32_t graphicsQueueFamily = kInvalidQueueFamily;
+    uint32_t presentQueueFamily = kInvalidQueueFamily;
+    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+    VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+    VkExtent2D swapchainExtent = {1, 1};
+    VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
+    VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
+    VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+    std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
+    std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
+    VkShaderModule opaqueVertexShaderModule = VK_NULL_HANDLE;
+    VkShaderModule opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    VkPipeline opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    bool opaqueShaderPipelineScaffoldReady = false;
+    bool opaqueGraphicsPipelineScaffoldReady = false;
+    bool opaqueGraphicsPipelineExecutable = false;
+    std::vector<VkImage> swapchainImages;
+    std::vector<VkImageView> swapchainImageViews;
+    std::vector<VkFramebuffer> opaqueFramebuffers;
+    std::vector<VkCommandBuffer> commandBuffers;
+    std::vector<bool> imageWasPresented;
+    VkCommandPool commandPool = VK_NULL_HANDLE;
+    VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+    VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+    VkFence inFlightFence = VK_NULL_HANDLE;
+    uint32_t activeImageIndex = 0;
+    bool frameCommandsRecorded = false;
+  };
+
+  namespace
+  {
+
+    constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId)
+    {
+      return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+    }
+
+  } // namespace
+
+  VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
+      const Material &material)
+  {
+    TranslatedMaterialState translated;
+    translated.baseColor = material.color;
+    translated.roughness = material.roughness;
+    translated.metallic = material.metallic;
+    translated.uvScale = material.uvScale;
+    translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
+    translated.usesCustomShader = material.shader && material.shader->IsValid();
+    return translated;
+  }
+
+  int VulkanRenderBackend::ResolveIndexCount(const Mesh &mesh)
+  {
+    return mesh.GetIndexCount();
+  }
+
+  VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
+      const TranslatedMaterialState &materialState)
+  {
+    OpaquePipelineKey key;
+    key.usesAlbedoMap = materialState.usesAlbedoMap;
+    key.usesCustomShader = materialState.usesCustomShader;
+    key.writesDepth = true;
+    key.depthTestEnabled = true;
+    return key;
+  }
+
+  VulkanRenderBackend::VulkanRenderBackend(void *nativeWindowHandle)
+  {
+    Initialize(nativeWindowHandle);
+  }
+
+  VulkanRenderBackend::~VulkanRenderBackend()
+  {
+    Shutdown();
+  }
+
+  RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const
+  {
+    RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+    caps.supportsDebugDraw = false;
+    caps.supportsDebugLabels = false;
+    caps.supportsOffscreenTargets = false;
+    caps.supportsNativeTextureHandles = false;
+    caps.supportsReadback = false;
+    caps.supportsDepthReadback = false;
+    caps.supportsDebugHud = false;
+    caps.supportsComputePasses = false;
+    caps.supportsGpuTimestamps = false;
+    caps.supportsBindlessResources = false;
+    return caps;
+  }
+
+  bool VulkanRenderBackend::IsInitialized() const
+  {
+    return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueRasterScaffold() const
+  {
+    return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+           m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+           m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
+           !m_context->opaqueFramebuffers.empty();
+  }
+
+  bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const
+  {
+    return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const
+  {
+    return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const
+  {
+    return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
+  }
+
+  bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
+  {
+    m_lastError.clear();
+    if (!nativeWindowHandle)
+    {
+      m_lastError = "Vulkan backend requires a native GLFW window handle.";
+      return false;
+    }
+
+    if (!glfwVulkanSupported())
+    {
+      m_lastError = "GLFW reports that Vulkan is not supported on this system.";
+      return false;
+    }
+
+    if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
+      return false;
+
+    m_context = std::make_unique<Context>();
+    m_context->window = static_cast<GLFWwindow *>(nativeWindowHandle);
+
+    uint32_t extensionCount = 0;
+    const char **glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
+    if (!glfwExtensions || extensionCount == 0)
+    {
+      m_lastError = "GLFW did not provide required Vulkan instance extensions.";
+      Shutdown();
+      return false;
+    }
+
+    const VkApplicationInfo appInfo{
+        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pNext = nullptr,
+        .pApplicationName = "MonolithEngine",
+        .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+        .pEngineName = "MonolithEngine",
+        .engineVersion = VK_MAKE_VERSION(0, 1, 0),
+        .apiVersion = VK_API_VERSION_1_1,
+    };
+
+    std::vector<const char *> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
+    const VkInstanceCreateInfo instanceInfo{
+        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .pApplicationInfo = &appInfo,
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
+        .ppEnabledExtensionNames = instanceExtensions.data(),
+    };
+    if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
+                 "vkCreateInstance"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    volkLoadInstance(m_context->instance);
+
+    if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
+                                         &m_context->surface),
+                 m_lastError,
+                 "glfwCreateWindowSurface"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    uint32_t physicalDeviceCount = 0;
+    if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
+                 m_lastError,
+                 "vkEnumeratePhysicalDevices(count)"))
+    {
+      Shutdown();
+      return false;
+    }
+    if (physicalDeviceCount == 0)
+    {
+      m_lastError = "No Vulkan physical devices were found.";
+      Shutdown();
+      return false;
+    }
+
+    std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+    if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
+                                            physicalDevices.data()),
+                 m_lastError,
+                 "vkEnumeratePhysicalDevices"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const std::array<const char *, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+    for (VkPhysicalDevice device : physicalDevices)
+    {
+      uint32_t queueFamilyCount = 0;
+      vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+      std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+      vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+      std::optional<uint32_t> graphicsFamily;
+      std::optional<uint32_t> presentFamily;
+      for (uint32_t i = 0; i < queueFamilyCount; ++i)
+      {
+        if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+          graphicsFamily = i;
+
+        VkBool32 presentSupported = VK_FALSE;
+        vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
+        if (presentSupported == VK_TRUE)
+          presentFamily = i;
+      }
+
+      if (!graphicsFamily || !presentFamily)
+        continue;
+
+      uint32_t extensionCountAvailable = 0;
+      vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
+      std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
+      vkEnumerateDeviceExtensionProperties(device,
+                                           nullptr,
+                                           &extensionCountAvailable,
+                                           extensions.data());
+      std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
+                                              requiredDeviceExtensions.end());
+      for (const auto &extension : extensions)
+        missingExtensions.erase(extension.extensionName);
+      if (!missingExtensions.empty())
+        continue;
+
+      uint32_t surfaceFormatCount = 0;
+      vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+      uint32_t presentModeCount = 0;
+      vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+                                                m_context->surface,
+                                                &presentModeCount,
+                                                nullptr);
+      if (surfaceFormatCount == 0 || presentModeCount == 0)
+        continue;
+
+      m_context->physicalDevice = device;
+      m_context->graphicsQueueFamily = *graphicsFamily;
+      m_context->presentQueueFamily = *presentFamily;
+      break;
+    }
+
+    if (m_context->physicalDevice == VK_NULL_HANDLE)
+    {
+      m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
+      Shutdown();
+      return false;
+    }
+
+    const float queuePriority = 1.0f;
+    std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
+                                              m_context->presentQueueFamily};
+    std::vector<VkDeviceQueueCreateInfo> queueInfos;
+    queueInfos.reserve(uniqueQueueFamilies.size());
+    for (uint32_t queueFamily : uniqueQueueFamilies)
+    {
+      queueInfos.push_back(VkDeviceQueueCreateInfo{
+          .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .queueFamilyIndex = queueFamily,
+          .queueCount = 1,
+          .pQueuePriorities = &queuePriority,
+      });
+    }
+
+    const VkDeviceCreateInfo deviceInfo{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
+        .pQueueCreateInfos = queueInfos.data(),
+        .enabledLayerCount = 0,
+        .ppEnabledLayerNames = nullptr,
+        .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
+        .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
+        .pEnabledFeatures = nullptr,
+    };
+    if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
+                 m_lastError,
+                 "vkCreateDevice"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    volkLoadDevice(m_context->device);
+    vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
+    vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
+
+    const VkCommandPoolCreateInfo commandPoolInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+        .queueFamilyIndex = m_context->graphicsQueueFamily,
+    };
+    if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
+                                     &m_context->commandPool),
+                 m_lastError,
+                 "vkCreateCommandPool"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+                                              .pNext = nullptr,
+                                              .flags = 0};
+    if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                   &m_context->imageAvailableSemaphore),
+                 m_lastError,
+                 "vkCreateSemaphore(imageAvailable)"))
+    {
+      Shutdown();
+      return false;
+    }
+    if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                   &m_context->renderFinishedSemaphore),
+                 m_lastError,
+                 "vkCreateSemaphore(renderFinished)"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                                      .pNext = nullptr,
+                                      .flags = VK_FENCE_CREATE_SIGNALED_BIT};
+    if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
+                 m_lastError,
+                 "vkCreateFence"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 0,
+        .pSetLayouts = nullptr,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
+    if (!CheckVk(vkCreatePipelineLayout(m_context->device,
+                                        &pipelineLayoutInfo,
+                                        nullptr,
+                                        &m_context->opaquePipelineLayout),
+                 m_lastError,
+                 "vkCreatePipelineLayout"))
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!CreateOpaquePipelineCreationScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!CreateOpaqueShaderPipelineScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!RecreateSwapchain())
+    {
+      Shutdown();
+      return false;
+    }
+
+    return true;
+  }
+
+  void VulkanRenderBackend::Shutdown()
+  {
+    if (!m_context)
+      return;
+
+    if (m_context->device != VK_NULL_HANDLE)
+      vkDeviceWaitIdle(m_context->device);
+
+    DestroyOpaqueGraphicsPipelineScaffold();
+    DestroySwapchain();
+
+    DestroyOpaqueShaderPipelineScaffold();
+    DestroyOpaquePipelineCreationScaffold();
+
+    if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
+      vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
+
+    if (m_context->inFlightFence != VK_NULL_HANDLE)
+      vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
+    if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
+      vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
+    if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
+      vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
+    if (m_context->commandPool != VK_NULL_HANDLE)
+      vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
+    if (m_context->device != VK_NULL_HANDLE)
+      vkDestroyDevice(m_context->device, nullptr);
+    if (m_context->surface != VK_NULL_HANDLE)
+      vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
+    if (m_context->instance != VK_NULL_HANDLE)
+      vkDestroyInstance(m_context->instance, nullptr);
+
+    m_context.reset();
+    m_frameActive = false;
+    m_passActive = false;
+  }
+
+  void VulkanRenderBackend::DestroySwapchain()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    DestroyOpaqueRasterScaffold();
+
+    if (!m_context->commandBuffers.empty())
+    {
+      vkFreeCommandBuffers(m_context->device,
+                           m_context->commandPool,
+                           static_cast<uint32_t>(m_context->commandBuffers.size()),
+                           m_context->commandBuffers.data());
+      m_context->commandBuffers.clear();
+    }
+
+    for (VkImageView imageView : m_context->swapchainImageViews)
+      vkDestroyImageView(m_context->device, imageView, nullptr);
+    m_context->swapchainImageViews.clear();
+    m_context->swapchainImages.clear();
+    m_context->imageWasPresented.clear();
+
+    if (m_context->swapchain != VK_NULL_HANDLE)
+    {
+      vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
+      m_context->swapchain = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueRasterScaffold()
+  {
+    const VkAttachmentDescription colorAttachment{
+        .flags = 0,
+        .format = m_context->swapchainFormat,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+        .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+        .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    };
+    const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    const VkSubpassDescription subpass{
+        .flags = 0,
+        .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+        .inputAttachmentCount = 0,
+        .pInputAttachments = nullptr,
+        .colorAttachmentCount = 1,
+        .pColorAttachments = &colorAttachmentRef,
+        .pResolveAttachments = nullptr,
+        .pDepthStencilAttachment = nullptr,
+        .preserveAttachmentCount = 0,
+        .pPreserveAttachments = nullptr,
+    };
+    const VkSubpassDependency dependency{
+        .srcSubpass = VK_SUBPASS_EXTERNAL,
+        .dstSubpass = 0,
+        .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .srcAccessMask = 0,
+        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .dependencyFlags = 0,
+    };
+    const VkRenderPassCreateInfo renderPassInfo{
+        .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .attachmentCount = 1,
+        .pAttachments = &colorAttachment,
+        .subpassCount = 1,
+        .pSubpasses = &subpass,
+        .dependencyCount = 1,
+        .pDependencies = &dependency,
+    };
+    if (!CheckVk(vkCreateRenderPass(m_context->device,
+                                    &renderPassInfo,
+                                    nullptr,
+                                    &m_context->opaqueRenderPass),
+                 m_lastError,
+                 "vkCreateRenderPass"))
+    {
+      return false;
+    }
+
+    m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
+    for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i)
+    {
+      const VkImageView attachment = m_context->swapchainImageViews[i];
+      const VkFramebufferCreateInfo framebufferInfo{
+          .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .renderPass = m_context->opaqueRenderPass,
+          .attachmentCount = 1,
+          .pAttachments = &attachment,
+          .width = m_context->swapchainExtent.width,
+          .height = m_context->swapchainExtent.height,
+          .layers = 1,
+      };
+      if (!CheckVk(vkCreateFramebuffer(m_context->device,
+                                       &framebufferInfo,
+                                       nullptr,
+                                       &m_context->opaqueFramebuffers[i]),
+                   m_lastError,
+                   "vkCreateFramebuffer"))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueRasterScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers)
+    {
+      if (framebuffer != VK_NULL_HANDLE)
+        vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
+    }
+    m_context->opaqueFramebuffers.clear();
+
+    if (m_context->opaqueRenderPass != VK_NULL_HANDLE)
+    {
+      vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
+      m_context->opaqueRenderPass = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold()
+  {
+    const VkPipelineCacheCreateInfo pipelineCacheInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .initialDataSize = 0,
+        .pInitialData = nullptr,
+    };
+    return CheckVk(vkCreatePipelineCache(m_context->device,
+                                         &pipelineCacheInfo,
                                          nullptr,
-                                         &extensionCountAvailable,
-                                         extensions.data());
-    std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
-                                            requiredDeviceExtensions.end());
-    for (const auto& extension : extensions)
-      missingExtensions.erase(extension.extensionName);
-    if (!missingExtensions.empty())
-      continue;
+                                         &m_context->opaquePipelineCache),
+                   m_lastError,
+                   "vkCreatePipelineCache");
+  }
+
+  void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaquePipelineCache != VK_NULL_HANDLE)
+    {
+      vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
+      m_context->opaquePipelineCache = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold()
+  {
+    const auto tryLoadShaderModule = [&](const std::array<std::string, 2> &candidatePaths,
+                                         VkShaderModule *outModule,
+                                         const char *context)
+    {
+      for (const std::string &path : candidatePaths)
+      {
+        const std::vector<char> bytes = ReadBinaryFile(path);
+        if (bytes.empty())
+          continue;
+        if (TryCreateShaderModule(m_context->device, bytes, outModule, m_lastError, context))
+          return true;
+        return false;
+      }
+      return false;
+    };
+
+    m_context->opaqueVertexShaderModule = VK_NULL_HANDLE;
+    m_context->opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    m_context->opaqueShaderStages = {};
+
+    const bool vertexShaderLoaded = tryLoadShaderModule(
+        {"assets/shaders/vulkan/opaque_scene.vert.spv", "renderer/shaders/vulkan/opaque_scene.vert.spv"},
+        &m_context->opaqueVertexShaderModule,
+        "vkCreateShaderModule(vertex)");
+    const bool fragmentShaderLoaded = tryLoadShaderModule(
+        {"assets/shaders/vulkan/opaque_scene.frag.spv", "renderer/shaders/vulkan/opaque_scene.frag.spv"},
+        &m_context->opaqueFragmentShaderModule,
+        "vkCreateShaderModule(fragment)");
+
+    m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = VK_SHADER_STAGE_VERTEX_BIT,
+        .module = m_context->opaqueVertexShaderModule,
+        .pName = m_context->opaqueShaderEntryNames[0].c_str(),
+        .pSpecializationInfo = nullptr,
+    };
+    m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+        .module = m_context->opaqueFragmentShaderModule,
+        .pName = m_context->opaqueShaderEntryNames[1].c_str(),
+        .pSpecializationInfo = nullptr,
+    };
+
+    if ((!vertexShaderLoaded || !fragmentShaderLoaded) && m_lastError.empty())
+    {
+      m_lastError =
+          "Vulkan opaque shader modules are not available yet. Expected precompiled SPIR-V files at "
+          "assets/shaders/vulkan/opaque_scene.{vert,frag}.spv or "
+          "renderer/shaders/vulkan/opaque_scene.{vert,frag}.spv";
+    }
+
+    m_context->opaqueShaderPipelineScaffoldReady =
+        m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+        m_context->opaquePipelineCache != VK_NULL_HANDLE &&
+        m_context->opaqueShaderStages[0].pName != nullptr &&
+        m_context->opaqueShaderStages[1].pName != nullptr;
+    return m_context->opaqueShaderPipelineScaffoldReady;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaqueVertexShaderModule != VK_NULL_HANDLE)
+    {
+      vkDestroyShaderModule(m_context->device, m_context->opaqueVertexShaderModule, nullptr);
+      m_context->opaqueVertexShaderModule = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueFragmentShaderModule != VK_NULL_HANDLE)
+    {
+      vkDestroyShaderModule(m_context->device, m_context->opaqueFragmentShaderModule, nullptr);
+      m_context->opaqueFragmentShaderModule = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueShaderStages = {};
+    m_context->opaqueShaderPipelineScaffoldReady = false;
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold()
+  {
+    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
+    {
+      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
+      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueGraphicsPipelineScaffoldReady =
+        m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
+    m_context->opaqueGraphicsPipelineExecutable = false;
+    if (!m_context->opaqueGraphicsPipelineScaffoldReady)
+    {
+      m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
+      return false;
+    }
+
+    if (m_context->opaqueShaderStages[0].module == VK_NULL_HANDLE ||
+        m_context->opaqueShaderStages[1].module == VK_NULL_HANDLE)
+    {
+      return true;
+    }
+
+    const VkPipelineVertexInputStateCreateInfo vertexInputState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .vertexBindingDescriptionCount = 0,
+        .pVertexBindingDescriptions = nullptr,
+        .vertexAttributeDescriptionCount = 0,
+        .pVertexAttributeDescriptions = nullptr,
+    };
+    const VkPipelineInputAssemblyStateCreateInfo inputAssemblyState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+        .primitiveRestartEnable = VK_FALSE,
+    };
+    const VkPipelineViewportStateCreateInfo viewportState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .viewportCount = 1,
+        .pViewports = nullptr,
+        .scissorCount = 1,
+        .pScissors = nullptr,
+    };
+    const VkPipelineRasterizationStateCreateInfo rasterizationState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .depthClampEnable = VK_FALSE,
+        .rasterizerDiscardEnable = VK_FALSE,
+        .polygonMode = VK_POLYGON_MODE_FILL,
+        .cullMode = VK_CULL_MODE_NONE,
+        .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+        .depthBiasEnable = VK_FALSE,
+        .depthBiasConstantFactor = 0.0f,
+        .depthBiasClamp = 0.0f,
+        .depthBiasSlopeFactor = 0.0f,
+        .lineWidth = 1.0f,
+    };
+    const VkPipelineMultisampleStateCreateInfo multisampleState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+        .sampleShadingEnable = VK_FALSE,
+        .minSampleShading = 1.0f,
+        .pSampleMask = nullptr,
+        .alphaToCoverageEnable = VK_FALSE,
+        .alphaToOneEnable = VK_FALSE,
+    };
+    const VkPipelineColorBlendAttachmentState colorBlendAttachment{
+        .blendEnable = VK_FALSE,
+        .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+        .dstColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .colorBlendOp = VK_BLEND_OP_ADD,
+        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .alphaBlendOp = VK_BLEND_OP_ADD,
+        .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+    };
+    const VkPipelineColorBlendStateCreateInfo colorBlendState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .logicOpEnable = VK_FALSE,
+        .logicOp = VK_LOGIC_OP_COPY,
+        .attachmentCount = 1,
+        .pAttachments = &colorBlendAttachment,
+        .blendConstants = {0.0f, 0.0f, 0.0f, 0.0f},
+    };
+    const std::array<VkDynamicState, 2> dynamicStates = {VK_DYNAMIC_STATE_VIEWPORT,
+                                                         VK_DYNAMIC_STATE_SCISSOR};
+    const VkPipelineDynamicStateCreateInfo dynamicState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .dynamicStateCount = static_cast<uint32_t>(dynamicStates.size()),
+        .pDynamicStates = dynamicStates.data(),
+    };
+    const VkGraphicsPipelineCreateInfo pipelineInfo{
+        .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stageCount = static_cast<uint32_t>(m_context->opaqueShaderStages.size()),
+        .pStages = m_context->opaqueShaderStages.data(),
+        .pVertexInputState = &vertexInputState,
+        .pInputAssemblyState = &inputAssemblyState,
+        .pTessellationState = nullptr,
+        .pViewportState = &viewportState,
+        .pRasterizationState = &rasterizationState,
+        .pMultisampleState = &multisampleState,
+        .pDepthStencilState = nullptr,
+        .pColorBlendState = &colorBlendState,
+        .pDynamicState = &dynamicState,
+        .layout = m_context->opaquePipelineLayout,
+        .renderPass = m_context->opaqueRenderPass,
+        .subpass = 0,
+        .basePipelineHandle = VK_NULL_HANDLE,
+        .basePipelineIndex = -1,
+    };
+    if (!CheckVk(vkCreateGraphicsPipelines(m_context->device,
+                                           m_context->opaquePipelineCache,
+                                           1,
+                                           &pipelineInfo,
+                                           nullptr,
+                                           &m_context->opaqueGraphicsPipeline),
+                 m_lastError,
+                 "vkCreateGraphicsPipelines(opaque)"))
+    {
+      return false;
+    }
+
+    m_context->opaqueGraphicsPipelineExecutable = true;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
+    {
+      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
+      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    }
+
+    m_context->opaqueGraphicsPipelineExecutable = false;
+    m_context->opaqueGraphicsPipelineScaffoldReady = false;
+  }
+
+  bool VulkanRenderBackend::RecreateSwapchain()
+  {
+    DestroyOpaqueGraphicsPipelineScaffold();
+    DestroySwapchain();
+
+    VkSurfaceCapabilitiesKHR surfaceCapabilities{};
+    if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
+                                                           m_context->surface,
+                                                           &surfaceCapabilities),
+                 m_lastError,
+                 "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"))
+    {
+      return false;
+    }
 
     uint32_t surfaceFormatCount = 0;
-    vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                         m_context->surface,
+                                         &surfaceFormatCount,
+                                         nullptr);
+    std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                         m_context->surface,
+                                         &surfaceFormatCount,
+                                         surfaceFormats.data());
+    VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
+    for (const auto &candidate : surfaceFormats)
+    {
+      if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
+          candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+      {
+        chosenFormat = candidate;
+        break;
+      }
+    }
+    m_context->swapchainFormat = chosenFormat.format;
+
     uint32_t presentModeCount = 0;
-    vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+    vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
                                               m_context->surface,
                                               &presentModeCount,
                                               nullptr);
-    if (surfaceFormatCount == 0 || presentModeCount == 0)
-      continue;
+    std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+    vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                              m_context->surface,
+                                              &presentModeCount,
+                                              presentModes.data());
+    VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+    for (VkPresentModeKHR presentMode : presentModes)
+    {
+      if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR)
+      {
+        chosenPresentMode = presentMode;
+        break;
+      }
+    }
 
-    m_context->physicalDevice = device;
-    m_context->graphicsQueueFamily = *graphicsFamily;
-    m_context->presentQueueFamily = *presentFamily;
-    break;
-  }
+    int framebufferWidth = 0;
+    int framebufferHeight = 0;
+    glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
+    framebufferWidth = std::max(framebufferWidth, 1);
+    framebufferHeight = std::max(framebufferHeight, 1);
 
-  if (m_context->physicalDevice == VK_NULL_HANDLE) {
-    m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
-    Shutdown();
-    return false;
-  }
+    if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max())
+    {
+      m_context->swapchainExtent = surfaceCapabilities.currentExtent;
+    }
+    else
+    {
+      m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
+                                                    surfaceCapabilities.minImageExtent.width,
+                                                    surfaceCapabilities.maxImageExtent.width);
+      m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
+                                                     surfaceCapabilities.minImageExtent.height,
+                                                     surfaceCapabilities.maxImageExtent.height);
+    }
 
-  const float queuePriority = 1.0f;
-  std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
-                                            m_context->presentQueueFamily};
-  std::vector<VkDeviceQueueCreateInfo> queueInfos;
-  queueInfos.reserve(uniqueQueueFamilies.size());
-  for (uint32_t queueFamily : uniqueQueueFamilies) {
-    queueInfos.push_back(VkDeviceQueueCreateInfo{
-        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+    uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
+    if (surfaceCapabilities.maxImageCount > 0)
+      imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
+
+    std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
+                                                  m_context->presentQueueFamily};
+    const bool usesSeparatePresentQueue =
+        m_context->graphicsQueueFamily != m_context->presentQueueFamily;
+
+    const VkSwapchainCreateInfoKHR swapchainInfo{
+        .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
         .pNext = nullptr,
         .flags = 0,
-        .queueFamilyIndex = queueFamily,
-        .queueCount = 1,
-        .pQueuePriorities = &queuePriority,
-    });
-  }
-
-  const VkDeviceCreateInfo deviceInfo{
-      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
-      .pQueueCreateInfos = queueInfos.data(),
-      .enabledLayerCount = 0,
-      .ppEnabledLayerNames = nullptr,
-      .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
-      .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
-      .pEnabledFeatures = nullptr,
-  };
-  if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
-               m_lastError,
-               "vkCreateDevice")) {
-    Shutdown();
-    return false;
-  }
-
-  volkLoadDevice(m_context->device);
-  vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
-  vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
-
-  const VkCommandPoolCreateInfo commandPoolInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-      .queueFamilyIndex = m_context->graphicsQueueFamily,
-  };
-  if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
-                                   &m_context->commandPool),
-               m_lastError,
-               "vkCreateCommandPool")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
-                                             .pNext = nullptr,
-                                             .flags = 0};
-  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
-                                 &m_context->imageAvailableSemaphore),
-               m_lastError,
-               "vkCreateSemaphore(imageAvailable)")) {
-    Shutdown();
-    return false;
-  }
-  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
-                                 &m_context->renderFinishedSemaphore),
-               m_lastError,
-               "vkCreateSemaphore(renderFinished)")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
-                                    .pNext = nullptr,
-                                    .flags = VK_FENCE_CREATE_SIGNALED_BIT};
-  if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
-               m_lastError,
-               "vkCreateFence")) {
-    Shutdown();
-    return false;
-  }
-
-  const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .setLayoutCount = 0,
-      .pSetLayouts = nullptr,
-      .pushConstantRangeCount = 0,
-      .pPushConstantRanges = nullptr,
-  };
-  if (!CheckVk(vkCreatePipelineLayout(m_context->device,
-                                      &pipelineLayoutInfo,
-                                      nullptr,
-                                      &m_context->opaquePipelineLayout),
-               m_lastError,
-               "vkCreatePipelineLayout")) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaquePipelineCreationScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaqueShaderPipelineScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!RecreateSwapchain()) {
-    Shutdown();
-    return false;
-  }
-
-  if (!CreateOpaqueGraphicsPipelineScaffold()) {
-    Shutdown();
-    return false;
-  }
-
-  return true;
-}
-
-void VulkanRenderBackend::Shutdown() {
-  if (!m_context)
-    return;
-
-  if (m_context->device != VK_NULL_HANDLE)
-    vkDeviceWaitIdle(m_context->device);
-
-  DestroySwapchain();
-
-  DestroyOpaqueGraphicsPipelineScaffold();
-  DestroyOpaqueShaderPipelineScaffold();
-  DestroyOpaquePipelineCreationScaffold();
-
-  if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
-    vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
-
-  if (m_context->inFlightFence != VK_NULL_HANDLE)
-    vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
-  if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
-    vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
-  if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
-    vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
-  if (m_context->commandPool != VK_NULL_HANDLE)
-    vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
-  if (m_context->device != VK_NULL_HANDLE)
-    vkDestroyDevice(m_context->device, nullptr);
-  if (m_context->surface != VK_NULL_HANDLE)
-    vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
-  if (m_context->instance != VK_NULL_HANDLE)
-    vkDestroyInstance(m_context->instance, nullptr);
-
-  m_context.reset();
-  m_frameActive = false;
-  m_passActive = false;
-}
-
-void VulkanRenderBackend::DestroySwapchain() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  DestroyOpaqueRasterScaffold();
-
-  if (!m_context->commandBuffers.empty()) {
-    vkFreeCommandBuffers(m_context->device,
-                         m_context->commandPool,
-                         static_cast<uint32_t>(m_context->commandBuffers.size()),
-                         m_context->commandBuffers.data());
-    m_context->commandBuffers.clear();
-  }
-
-  for (VkImageView imageView : m_context->swapchainImageViews)
-    vkDestroyImageView(m_context->device, imageView, nullptr);
-  m_context->swapchainImageViews.clear();
-  m_context->swapchainImages.clear();
-  m_context->imageWasPresented.clear();
-
-  if (m_context->swapchain != VK_NULL_HANDLE) {
-    vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
-    m_context->swapchain = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaqueRasterScaffold() {
-  const VkAttachmentDescription colorAttachment{
-      .flags = 0,
-      .format = m_context->swapchainFormat,
-      .samples = VK_SAMPLE_COUNT_1_BIT,
-      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
-      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-      .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-      .initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-      .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-  };
-  const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-  const VkSubpassDescription subpass{
-      .flags = 0,
-      .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
-      .inputAttachmentCount = 0,
-      .pInputAttachments = nullptr,
-      .colorAttachmentCount = 1,
-      .pColorAttachments = &colorAttachmentRef,
-      .pResolveAttachments = nullptr,
-      .pDepthStencilAttachment = nullptr,
-      .preserveAttachmentCount = 0,
-      .pPreserveAttachments = nullptr,
-  };
-  const VkSubpassDependency dependency{
-      .srcSubpass = VK_SUBPASS_EXTERNAL,
-      .dstSubpass = 0,
-      .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-      .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-      .srcAccessMask = 0,
-      .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-      .dependencyFlags = 0,
-  };
-  const VkRenderPassCreateInfo renderPassInfo{
-      .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .attachmentCount = 1,
-      .pAttachments = &colorAttachment,
-      .subpassCount = 1,
-      .pSubpasses = &subpass,
-      .dependencyCount = 1,
-      .pDependencies = &dependency,
-  };
-  if (!CheckVk(vkCreateRenderPass(m_context->device,
-                                  &renderPassInfo,
-                                  nullptr,
-                                  &m_context->opaqueRenderPass),
-               m_lastError,
-               "vkCreateRenderPass")) {
-    return false;
-  }
-
-  m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
-  for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i) {
-    const VkImageView attachment = m_context->swapchainImageViews[i];
-    const VkFramebufferCreateInfo framebufferInfo{
-        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-        .renderPass = m_context->opaqueRenderPass,
-        .attachmentCount = 1,
-        .pAttachments = &attachment,
-        .width = m_context->swapchainExtent.width,
-        .height = m_context->swapchainExtent.height,
-        .layers = 1,
+        .surface = m_context->surface,
+        .minImageCount = imageCount,
+        .imageFormat = chosenFormat.format,
+        .imageColorSpace = chosenFormat.colorSpace,
+        .imageExtent = m_context->swapchainExtent,
+        .imageArrayLayers = 1,
+        .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
+                                                     : VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
+        .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
+        .preTransform = surfaceCapabilities.currentTransform,
+        .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+        .presentMode = chosenPresentMode,
+        .clipped = VK_TRUE,
+        .oldSwapchain = VK_NULL_HANDLE,
     };
-    if (!CheckVk(vkCreateFramebuffer(m_context->device,
-                                     &framebufferInfo,
+    if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
+                                      &m_context->swapchain),
+                 m_lastError,
+                 "vkCreateSwapchainKHR"))
+    {
+      return false;
+    }
+
+    uint32_t swapchainImageCount = 0;
+    vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
+    m_context->swapchainImages.resize(swapchainImageCount);
+    vkGetSwapchainImagesKHR(m_context->device,
+                            m_context->swapchain,
+                            &swapchainImageCount,
+                            m_context->swapchainImages.data());
+    m_context->swapchainImageViews.resize(swapchainImageCount);
+    m_context->imageWasPresented.assign(swapchainImageCount, false);
+
+    for (size_t i = 0; i < m_context->swapchainImages.size(); ++i)
+    {
+      const VkImageViewCreateInfo imageViewInfo{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .image = m_context->swapchainImages[i],
+          .viewType = VK_IMAGE_VIEW_TYPE_2D,
+          .format = m_context->swapchainFormat,
+          .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY,
+                         VK_COMPONENT_SWIZZLE_IDENTITY},
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      if (!CheckVk(vkCreateImageView(m_context->device,
+                                     &imageViewInfo,
                                      nullptr,
-                                     &m_context->opaqueFramebuffers[i]),
+                                     &m_context->swapchainImageViews[i]),
+                   m_lastError,
+                   "vkCreateImageView"))
+      {
+        return false;
+      }
+    }
+
+    m_context->commandBuffers.resize(swapchainImageCount);
+    const VkCommandBufferAllocateInfo commandBufferInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .commandPool = m_context->commandPool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = swapchainImageCount,
+    };
+    if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
+                                          &commandBufferInfo,
+                                          m_context->commandBuffers.data()),
                  m_lastError,
-                 "vkCreateFramebuffer")) {
+                 "vkAllocateCommandBuffers"))
+    {
       return false;
     }
+
+    if (!CreateOpaqueRasterScaffold())
+      return false;
+
+    if (m_context->opaqueShaderPipelineScaffoldReady && !CreateOpaqueGraphicsPipelineScaffold())
+      return false;
+
+    return true;
   }
 
-  return true;
-}
+  bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig &frame)
+  {
+    VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
+    if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
+      return false;
 
-void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers) {
-    if (framebuffer != VK_NULL_HANDLE)
-      vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
-  }
-  m_context->opaqueFramebuffers.clear();
-
-  if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
-    vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
-    m_context->opaqueRenderPass = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold() {
-  const VkPipelineCacheCreateInfo pipelineCacheInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .initialDataSize = 0,
-      .pInitialData = nullptr,
-  };
-  return CheckVk(vkCreatePipelineCache(m_context->device,
-                                       &pipelineCacheInfo,
-                                       nullptr,
-                                       &m_context->opaquePipelineCache),
-                 m_lastError,
-                 "vkCreatePipelineCache");
-}
-
-void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
-  if (!m_context || m_context->device == VK_NULL_HANDLE)
-    return;
-
-  if (m_context->opaquePipelineCache != VK_NULL_HANDLE) {
-    vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
-    m_context->opaquePipelineCache = VK_NULL_HANDLE;
-  }
-}
-
-bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
-  m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .stage = VK_SHADER_STAGE_VERTEX_BIT,
-      .module = VK_NULL_HANDLE,
-      .pName = m_context->opaqueShaderEntryNames[0].c_str(),
-      .pSpecializationInfo = nullptr,
-  };
-  m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
-      .module = VK_NULL_HANDLE,
-      .pName = m_context->opaqueShaderEntryNames[1].c_str(),
-      .pSpecializationInfo = nullptr,
-  };
-
-  m_context->opaqueShaderPipelineScaffoldReady =
-      m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-      m_context->opaquePipelineCache != VK_NULL_HANDLE &&
-      m_context->opaqueShaderStages[0].pName != nullptr &&
-      m_context->opaqueShaderStages[1].pName != nullptr;
-  return m_context->opaqueShaderPipelineScaffoldReady;
-}
-
-void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
-  if (!m_context)
-    return;
-  m_context->opaqueShaderStages = {};
-  m_context->opaqueShaderPipelineScaffoldReady = false;
-}
-
-bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold() {
-  m_context->opaqueGraphicsPipelineScaffoldReady =
-      m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
-  if (!m_context->opaqueGraphicsPipelineScaffoldReady) {
-    m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
-  }
-  return m_context->opaqueGraphicsPipelineScaffoldReady;
-}
-
-void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold() {
-  if (!m_context)
-    return;
-  m_context->opaqueGraphicsPipelineScaffoldReady = false;
-}
-
-bool VulkanRenderBackend::RecreateSwapchain() {
-  DestroySwapchain();
-
-  VkSurfaceCapabilitiesKHR surfaceCapabilities{};
-  if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
-                                                         m_context->surface,
-                                                         &surfaceCapabilities),
-               m_lastError,
-               "vkGetPhysicalDeviceSurfaceCapabilitiesKHR")) {
-    return false;
-  }
-
-  uint32_t surfaceFormatCount = 0;
-  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
-                                       m_context->surface,
-                                       &surfaceFormatCount,
-                                       nullptr);
-  std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
-  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
-                                       m_context->surface,
-                                       &surfaceFormatCount,
-                                       surfaceFormats.data());
-  VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
-  for (const auto& candidate : surfaceFormats) {
-    if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
-        candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
-      chosenFormat = candidate;
-      break;
-    }
-  }
-  m_context->swapchainFormat = chosenFormat.format;
-
-  uint32_t presentModeCount = 0;
-  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
-                                            m_context->surface,
-                                            &presentModeCount,
-                                            nullptr);
-  std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
-                                            m_context->surface,
-                                            &presentModeCount,
-                                            presentModes.data());
-  VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
-  for (VkPresentModeKHR presentMode : presentModes) {
-    if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
-      chosenPresentMode = presentMode;
-      break;
-    }
-  }
-
-  int framebufferWidth = 0;
-  int framebufferHeight = 0;
-  glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
-  framebufferWidth = std::max(framebufferWidth, 1);
-  framebufferHeight = std::max(framebufferHeight, 1);
-
-  if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
-    m_context->swapchainExtent = surfaceCapabilities.currentExtent;
-  } else {
-    m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
-                                                  surfaceCapabilities.minImageExtent.width,
-                                                  surfaceCapabilities.maxImageExtent.width);
-    m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
-                                                   surfaceCapabilities.minImageExtent.height,
-                                                   surfaceCapabilities.maxImageExtent.height);
-  }
-
-  uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
-  if (surfaceCapabilities.maxImageCount > 0)
-    imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
-
-  std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
-                                                m_context->presentQueueFamily};
-  const bool usesSeparatePresentQueue =
-      m_context->graphicsQueueFamily != m_context->presentQueueFamily;
-
-  const VkSwapchainCreateInfoKHR swapchainInfo{
-      .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
-      .pNext = nullptr,
-      .flags = 0,
-      .surface = m_context->surface,
-      .minImageCount = imageCount,
-      .imageFormat = chosenFormat.format,
-      .imageColorSpace = chosenFormat.colorSpace,
-      .imageExtent = m_context->swapchainExtent,
-      .imageArrayLayers = 1,
-      .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-      .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
-                                                   : VK_SHARING_MODE_EXCLUSIVE,
-      .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
-      .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
-      .preTransform = surfaceCapabilities.currentTransform,
-      .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
-      .presentMode = chosenPresentMode,
-      .clipped = VK_TRUE,
-      .oldSwapchain = VK_NULL_HANDLE,
-  };
-  if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
-                                    &m_context->swapchain),
-               m_lastError,
-               "vkCreateSwapchainKHR")) {
-    return false;
-  }
-
-  uint32_t swapchainImageCount = 0;
-  vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
-  m_context->swapchainImages.resize(swapchainImageCount);
-  vkGetSwapchainImagesKHR(m_context->device,
-                          m_context->swapchain,
-                          &swapchainImageCount,
-                          m_context->swapchainImages.data());
-  m_context->swapchainImageViews.resize(swapchainImageCount);
-  m_context->imageWasPresented.assign(swapchainImageCount, false);
-
-  for (size_t i = 0; i < m_context->swapchainImages.size(); ++i) {
-    const VkImageViewCreateInfo imageViewInfo{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+    const VkCommandBufferBeginInfo beginInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .image = m_context->swapchainImages[i],
-        .viewType = VK_IMAGE_VIEW_TYPE_2D,
-        .format = m_context->swapchainFormat,
-        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY,
-                       VK_COMPONENT_SWIZZLE_IDENTITY},
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        .pInheritanceInfo = nullptr,
     };
-    if (!CheckVk(vkCreateImageView(m_context->device,
-                                   &imageViewInfo,
-                                   nullptr,
-                                   &m_context->swapchainImageViews[i]),
-                 m_lastError,
-                 "vkCreateImageView")) {
+    if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
+                 "vkBeginCommandBuffer"))
+    {
       return false;
     }
-  }
 
-  m_context->commandBuffers.resize(swapchainImageCount);
-  const VkCommandBufferAllocateInfo commandBufferInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
-      .pNext = nullptr,
-      .commandPool = m_context->commandPool,
-      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
-      .commandBufferCount = swapchainImageCount,
-  };
-  if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
-                                        &commandBufferInfo,
-                                        m_context->commandBuffers.data()),
-               m_lastError,
-               "vkAllocateCommandBuffers")) {
-    return false;
-  }
-
-  if (!CreateOpaqueRasterScaffold())
-    return false;
-
-  return true;
-}
-
-bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
-  VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
-  if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
-    return false;
-
-  const VkCommandBufferBeginInfo beginInfo{
-      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .pInheritanceInfo = nullptr,
-  };
-  if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
-               "vkBeginCommandBuffer")) {
-    return false;
-  }
-
-  if (frame.clearColorBuffer) {
-    if (!m_pendingOpaqueDraws.empty()) {
-      // Placeholder for the first opaque-scene submission slice: keep the current
-      // clear/present bootstrap, but make frame recording aware that opaque scene
-      // work was queued through the backend seam.
-      m_lastError.clear();
+    const bool hasQueuedOpaqueDraws = !m_pendingOpaqueDraws.empty();
+    const bool hasExecutableOpaquePipeline =
+        m_context->opaqueGraphicsPipelineExecutable &&
+        m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
+    if (hasQueuedOpaqueDraws && !hasExecutableOpaquePipeline)
+    {
+      m_lastError =
+          "Opaque scene draw submissions are queued, but Vulkan draw execution is not ready: "
+          "shader modules and graphics pipeline are still scaffold-only. Pending draws: " +
+          std::to_string(m_pendingOpaqueDraws.size());
     }
 
-    const VkImageMemoryBarrier toTransfer{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        .pNext = nullptr,
-        .srcAccessMask = 0,
-        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
-                         ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-                         : VK_IMAGE_LAYOUT_UNDEFINED,
-        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .image = m_context->swapchainImages[m_context->activeImageIndex],
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-    };
-    vkCmdPipelineBarrier(commandBuffer,
-                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                         VK_PIPELINE_STAGE_TRANSFER_BIT,
-                         0,
-                         0,
-                         nullptr,
-                         0,
-                         nullptr,
-                         1,
-                         &toTransfer);
+    if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
+    {
+      const VkImageMemoryBarrier toColorAttachment{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = 0,
+          .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+          .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                           ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                           : VK_IMAGE_LAYOUT_UNDEFINED,
+          .newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toColorAttachment);
 
-    const VkClearColorValue clearColor = {{frame.clearColor.x,
-                                           frame.clearColor.y,
-                                           frame.clearColor.z,
-                                           frame.clearColor.w}};
-    const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vkCmdClearColorImage(commandBuffer,
-                         m_context->swapchainImages[m_context->activeImageIndex],
-                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                         &clearColor,
-                         1,
-                         &clearRange);
+      const VkClearValue clearValue = {
+          .color = {{frame.clearColor.x, frame.clearColor.y, frame.clearColor.z, frame.clearColor.w}}};
+      const VkRenderPassBeginInfo renderPassBeginInfo{
+          .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+          .pNext = nullptr,
+          .renderPass = m_context->opaqueRenderPass,
+          .framebuffer = m_context->opaqueFramebuffers[m_context->activeImageIndex],
+          .renderArea = {{0, 0}, m_context->swapchainExtent},
+          .clearValueCount = 1,
+          .pClearValues = &clearValue,
+      };
+      vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
-    const VkImageMemoryBarrier toPresent{
-        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-        .pNext = nullptr,
-        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .dstAccessMask = 0,
-        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-        .image = m_context->swapchainImages[m_context->activeImageIndex],
-        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
-    };
-    vkCmdPipelineBarrier(commandBuffer,
-                         VK_PIPELINE_STAGE_TRANSFER_BIT,
-                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                         0,
-                         0,
-                         nullptr,
-                         0,
-                         nullptr,
-                         1,
-                         &toPresent);
+      const VkViewport viewport{
+          .x = 0.0f,
+          .y = 0.0f,
+          .width = static_cast<float>(m_context->swapchainExtent.width),
+          .height = static_cast<float>(m_context->swapchainExtent.height),
+          .minDepth = 0.0f,
+          .maxDepth = 1.0f,
+      };
+      const VkRect2D scissor{{0, 0}, m_context->swapchainExtent};
+      vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
+      vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
+      vkCmdBindPipeline(commandBuffer,
+                        VK_PIPELINE_BIND_POINT_GRAPHICS,
+                        m_context->opaqueGraphicsPipeline);
+
+      for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+      {
+        if (draw.indexCount <= 0)
+          continue;
+        vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+      }
+
+      vkCmdEndRenderPass(commandBuffer);
+    }
+    else if (frame.clearColorBuffer)
+    {
+      const VkImageMemoryBarrier toTransfer{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = 0,
+          .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+          .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                           ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                           : VK_IMAGE_LAYOUT_UNDEFINED,
+          .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toTransfer);
+
+      const VkClearColorValue clearColor = {{frame.clearColor.x,
+                                             frame.clearColor.y,
+                                             frame.clearColor.z,
+                                             frame.clearColor.w}};
+      const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+      vkCmdClearColorImage(commandBuffer,
+                           m_context->swapchainImages[m_context->activeImageIndex],
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           &clearColor,
+                           1,
+                           &clearRange);
+
+      const VkImageMemoryBarrier toPresent{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+          .dstAccessMask = 0,
+          .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+          .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toPresent);
+    }
+
+    if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
+      return false;
+
+    m_context->frameCommandsRecorded = true;
+    return true;
   }
 
-  if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
-    return false;
+  void VulkanRenderBackend::BeginFrame(const RenderFrameConfig &frame)
+  {
+    MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
+    MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
+    if (!IsInitialized() || m_frameActive)
+      return;
 
-  m_context->frameCommandsRecorded = true;
-  return true;
-}
+    m_lastError.clear();
 
-void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
-  MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
-  MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
-  if (!IsInitialized() || m_frameActive)
-    return;
+    if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+                 m_lastError,
+                 "vkWaitForFences"))
+    {
+      return;
+    }
 
-  if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
-               m_lastError,
-               "vkWaitForFences")) {
-    return;
-  }
+    VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                                   m_context->swapchain,
+                                                   UINT64_MAX,
+                                                   m_context->imageAvailableSemaphore,
+                                                   VK_NULL_HANDLE,
+                                                   &m_context->activeImageIndex);
+    if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR)
+    {
+      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+      acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                            m_context->swapchain,
+                                            UINT64_MAX,
+                                            m_context->imageAvailableSemaphore,
+                                            VK_NULL_HANDLE,
+                                            &m_context->activeImageIndex);
+    }
+    MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
 
-  VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
-                                                 m_context->swapchain,
-                                                 UINT64_MAX,
-                                                 m_context->imageAvailableSemaphore,
-                                                 VK_NULL_HANDLE,
-                                                 &m_context->activeImageIndex);
-  if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR) {
-    MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
-    acquireResult = vkAcquireNextImageKHR(m_context->device,
-                                          m_context->swapchain,
-                                          UINT64_MAX,
-                                          m_context->imageAvailableSemaphore,
-                                          VK_NULL_HANDLE,
-                                          &m_context->activeImageIndex);
-  }
-  MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
-
-  MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
-                          m_lastError,
-                          "vkResetFences"),
-                  m_lastError.c_str());
-
-  m_activeFrame = frame;
-  m_activeView = {};
-  m_pendingOpaqueDraws.clear();
-  m_context->frameCommandsRecorded = false;
-  m_drawCalls = 0;
-  m_frameActive = true;
-}
-
-void VulkanRenderBackend::EndFrame() {
-  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
-  if (!m_frameActive)
-    return;
-
-  if (m_passActive)
-    EndPass();
-
-  if (!m_context->frameCommandsRecorded) {
-    MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
-  }
-
-  if (m_context->frameCommandsRecorded) {
-    const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
-    const VkSubmitInfo submitInfo{
-        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-        .pNext = nullptr,
-        .waitSemaphoreCount = 1,
-        .pWaitSemaphores = &m_context->imageAvailableSemaphore,
-        .pWaitDstStageMask = waitStages,
-        .commandBufferCount = 1,
-        .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
-        .signalSemaphoreCount = 1,
-        .pSignalSemaphores = &m_context->renderFinishedSemaphore,
-    };
-    MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
-                                          1,
-                                          &submitInfo,
-                                          m_context->inFlightFence),
+    MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
                             m_lastError,
-                            "vkQueueSubmit"),
+                            "vkResetFences"),
                     m_lastError.c_str());
 
-    const VkPresentInfoKHR presentInfo{
-        .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-        .pNext = nullptr,
-        .waitSemaphoreCount = 1,
-        .pWaitSemaphores = &m_context->renderFinishedSemaphore,
-        .swapchainCount = 1,
-        .pSwapchains = &m_context->swapchain,
-        .pImageIndices = &m_context->activeImageIndex,
-        .pResults = nullptr,
-    };
-    const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
-    if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
-      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
-    } else {
-      MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
-    }
-
-    m_context->imageWasPresented[m_context->activeImageIndex] = true;
+    m_activeFrame = frame;
+    m_activeView = {};
+    m_pendingOpaqueDraws.clear();
     m_context->frameCommandsRecorded = false;
+    m_drawCalls = 0;
+    m_frameActive = true;
   }
 
-  m_frameActive = false;
-  m_pendingOpaqueDraws.clear();
-}
+  void VulkanRenderBackend::EndFrame()
+  {
+    MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
+    if (!m_frameActive)
+      return;
 
-void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
-  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
-  MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
-  if (!m_frameActive || m_passActive)
-    return;
+    if (m_passActive)
+      EndPass();
 
-  m_activePassId = pass.id;
-  m_activeView = pass.view;
-  m_passActive = true;
-}
+    if (!m_context->frameCommandsRecorded)
+    {
+      MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
+    }
 
-void VulkanRenderBackend::EndPass() {
-  MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
-  if (!m_passActive)
-    return;
-  m_passActive = false;
-}
+    if (m_context->frameCommandsRecorded)
+    {
+      const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_ALL_COMMANDS_BIT};
+      const VkSubmitInfo submitInfo{
+          .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+          .pNext = nullptr,
+          .waitSemaphoreCount = 1,
+          .pWaitSemaphores = &m_context->imageAvailableSemaphore,
+          .pWaitDstStageMask = waitStages,
+          .commandBufferCount = 1,
+          .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
+          .signalSemaphoreCount = 1,
+          .pSignalSemaphores = &m_context->renderFinishedSemaphore,
+      };
+      MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
+                                            1,
+                                            &submitInfo,
+                                            m_context->inFlightFence),
+                              m_lastError,
+                              "vkQueueSubmit"),
+                      m_lastError.c_str());
 
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
-  if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
-    return;
+      const VkPresentInfoKHR presentInfo{
+          .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+          .pNext = nullptr,
+          .waitSemaphoreCount = 1,
+          .pWaitSemaphores = &m_context->renderFinishedSemaphore,
+          .swapchainCount = 1,
+          .pSwapchains = &m_context->swapchain,
+          .pImageIndices = &m_context->activeImageIndex,
+          .pResults = nullptr,
+      };
+      const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
+      if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR)
+      {
+        MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+      }
+      else
+      {
+        MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
+      }
 
-  m_pendingOpaqueDraws.push_back(
-      PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
-                        command.modelMatrix,
-                        TranslateMaterialState(*command.material),
-                        {}});
-  m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
-  ++m_drawCalls;
-}
+      m_context->imageWasPresented[m_context->activeImageIndex] = true;
+      m_context->frameCommandsRecorded = false;
+    }
 
-void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+    m_frameActive = false;
+    m_pendingOpaqueDraws.clear();
+  }
 
-void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+  void VulkanRenderBackend::BeginPass(const RenderPassConfig &pass)
+  {
+    MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
+    MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
+    if (!m_frameActive || m_passActive)
+      return;
+
+    m_activePassId = pass.id;
+    m_activeView = pass.view;
+    m_passActive = true;
+  }
+
+  void VulkanRenderBackend::EndPass()
+  {
+    MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
+    if (!m_passActive)
+      return;
+    m_passActive = false;
+  }
+
+  void VulkanRenderBackend::DrawMesh(const MeshDrawCommand &command)
+  {
+    if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
+      return;
+
+    m_pendingOpaqueDraws.push_back(
+        PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
+                          command.modelMatrix,
+                          TranslateMaterialState(*command.material),
+                          {}});
+    m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
+    ++m_drawCalls;
+  }
+
+  void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand &) {}
+
+  void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand &) {}
 
 #else
 
-struct VulkanRenderBackend::Context {};
+  struct VulkanRenderBackend::Context
+  {
+  };
 
-VulkanRenderBackend::VulkanRenderBackend(void*) {
-  m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
-}
+  VulkanRenderBackend::VulkanRenderBackend(void *)
+  {
+    m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
+  }
 
-VulkanRenderBackend::~VulkanRenderBackend() = default;
+  VulkanRenderBackend::~VulkanRenderBackend() = default;
 
-RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
-  return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
-}
+  RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const
+  {
+    return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  }
 
-bool VulkanRenderBackend::IsInitialized() const {
-  return false;
-}
+  bool VulkanRenderBackend::IsInitialized() const
+  {
+    return false;
+  }
 
-bool VulkanRenderBackend::Initialize(void*) {
-  return false;
-}
+  bool VulkanRenderBackend::Initialize(void *)
+  {
+    return false;
+  }
 
-void VulkanRenderBackend::Shutdown() {}
-bool VulkanRenderBackend::RecreateSwapchain() { return false; }
-void VulkanRenderBackend::DestroySwapchain() {}
-bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig&) { return false; }
-void VulkanRenderBackend::BeginFrame(const RenderFrameConfig&) {}
-void VulkanRenderBackend::EndFrame() {}
-void VulkanRenderBackend::BeginPass(const RenderPassConfig&) {}
-void VulkanRenderBackend::EndPass() {}
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
-void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
-void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+  void VulkanRenderBackend::Shutdown() {}
+  bool VulkanRenderBackend::RecreateSwapchain() { return false; }
+  void VulkanRenderBackend::DestroySwapchain() {}
+  bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig &) { return false; }
+  void VulkanRenderBackend::BeginFrame(const RenderFrameConfig &) {}
+  void VulkanRenderBackend::EndFrame() {}
+  void VulkanRenderBackend::BeginPass(const RenderPassConfig &) {}
+  void VulkanRenderBackend::EndPass() {}
+  void VulkanRenderBackend::DrawMesh(const MeshDrawCommand &) {}
+  void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand &) {}
+  void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand &) {}
 
 #endif
 
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -103,6 +103,10 @@ VulkanRenderBackend::~VulkanRenderBackend() {
 RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
   RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   caps.supportsDebugLabels = false;
+  caps.supportsOffscreenTargets = false;
+  caps.supportsNativeTextureHandles = false;
+  caps.supportsReadback = false;
+  caps.supportsDebugHud = false;
   caps.supportsComputePasses = false;
   caps.supportsGpuTimestamps = false;
   caps.supportsBindlessResources = false;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 
 #include "core/Assert.h"
+#include "renderer/Material.h"
+#include "renderer/Mesh.h"
 
 #if defined(MONOLITH_HAS_VULKAN)
 #include <volk.h>
@@ -100,6 +102,22 @@ constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
 }
 
 }  // namespace
+
+VulkanRenderBackend::TranslatedMaterialState VulkanRenderBackend::TranslateMaterialState(
+    const Material& material) {
+  TranslatedMaterialState translated;
+  translated.baseColor = material.color;
+  translated.roughness = material.roughness;
+  translated.metallic = material.metallic;
+  translated.uvScale = material.uvScale;
+  translated.usesAlbedoMap = material.albedoMap && material.albedoMap->IsValid();
+  translated.usesCustomShader = material.shader && material.shader->IsValid();
+  return translated;
+}
+
+int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
+  return mesh.GetIndexCount();
+}
 
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
@@ -784,7 +802,10 @@ void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
   if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
     return;
 
-  m_pendingOpaqueDraws.push_back(PendingOpaqueDraw{command.mesh, command.material, command.modelMatrix});
+  m_pendingOpaqueDraws.push_back(
+      PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
+                        command.modelMatrix,
+                        TranslateMaterialState(*command.material)});
   ++m_drawCalls;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -111,10 +111,12 @@ VulkanRenderBackend::~VulkanRenderBackend() {
 
 RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
   RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  caps.supportsDebugDraw = false;
   caps.supportsDebugLabels = false;
   caps.supportsOffscreenTargets = false;
   caps.supportsNativeTextureHandles = false;
   caps.supportsReadback = false;
+  caps.supportsDepthReadback = false;
   caps.supportsDebugHud = false;
   caps.supportsComputePasses = false;
   caps.supportsGpuTimestamps = false;

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -302,6 +302,22 @@ namespace Monolith
   void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback callback,
                                                        void *userData)
   {
+    if (!m_frameActive)
+    {
+      m_pendingOverlayRenderCallback = nullptr;
+      m_pendingOverlayRenderUserData = nullptr;
+      m_lastError =
+          "Vulkan overlay render callbacks must be queued during an active frame.";
+      return;
+    }
+
+    if (!callback || !userData)
+    {
+      m_pendingOverlayRenderCallback = nullptr;
+      m_pendingOverlayRenderUserData = nullptr;
+      return;
+    }
+
     m_pendingOverlayRenderCallback = callback;
     m_pendingOverlayRenderUserData = userData;
   }

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -1,0 +1,794 @@
+#include "renderer/VulkanRenderBackend.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "core/Assert.h"
+
+#if defined(MONOLITH_HAS_VULKAN)
+#include <volk.h>
+#include <GLFW/glfw3.h>
+#endif
+
+namespace Monolith {
+
+#if defined(MONOLITH_HAS_VULKAN)
+
+namespace {
+
+constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
+
+const char* VkResultName(VkResult result) {
+  switch (result) {
+    case VK_SUCCESS:
+      return "VK_SUCCESS";
+    case VK_NOT_READY:
+      return "VK_NOT_READY";
+    case VK_TIMEOUT:
+      return "VK_TIMEOUT";
+    case VK_EVENT_SET:
+      return "VK_EVENT_SET";
+    case VK_EVENT_RESET:
+      return "VK_EVENT_RESET";
+    case VK_INCOMPLETE:
+      return "VK_INCOMPLETE";
+    case VK_ERROR_OUT_OF_HOST_MEMORY:
+      return "VK_ERROR_OUT_OF_HOST_MEMORY";
+    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+      return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+    case VK_ERROR_INITIALIZATION_FAILED:
+      return "VK_ERROR_INITIALIZATION_FAILED";
+    case VK_ERROR_DEVICE_LOST:
+      return "VK_ERROR_DEVICE_LOST";
+    case VK_ERROR_SURFACE_LOST_KHR:
+      return "VK_ERROR_SURFACE_LOST_KHR";
+    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+      return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+    case VK_SUBOPTIMAL_KHR:
+      return "VK_SUBOPTIMAL_KHR";
+    case VK_ERROR_OUT_OF_DATE_KHR:
+      return "VK_ERROR_OUT_OF_DATE_KHR";
+    default:
+      return "VK_ERROR_UNKNOWN";
+  }
+}
+
+bool CheckVk(VkResult result, std::string& outError, const char* context) {
+  if (result == VK_SUCCESS)
+    return true;
+  outError = std::string(context) + " failed: " + VkResultName(result);
+  return false;
+}
+
+}  // namespace
+
+struct VulkanRenderBackend::Context {
+  GLFWwindow* window = nullptr;
+  VkInstance instance = VK_NULL_HANDLE;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  VkQueue graphicsQueue = VK_NULL_HANDLE;
+  VkQueue presentQueue = VK_NULL_HANDLE;
+  uint32_t graphicsQueueFamily = kInvalidQueueFamily;
+  uint32_t presentQueueFamily = kInvalidQueueFamily;
+  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+  VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+  VkExtent2D swapchainExtent = {1, 1};
+  std::vector<VkImage> swapchainImages;
+  std::vector<VkImageView> swapchainImageViews;
+  std::vector<VkCommandBuffer> commandBuffers;
+  std::vector<bool> imageWasPresented;
+  VkCommandPool commandPool = VK_NULL_HANDLE;
+  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+  VkFence inFlightFence = VK_NULL_HANDLE;
+  uint32_t activeImageIndex = 0;
+  bool frameCommandsRecorded = false;
+};
+
+VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
+  Initialize(nativeWindowHandle);
+}
+
+VulkanRenderBackend::~VulkanRenderBackend() {
+  Shutdown();
+}
+
+RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
+  RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  caps.supportsDebugLabels = false;
+  caps.supportsComputePasses = false;
+  caps.supportsGpuTimestamps = false;
+  caps.supportsBindlessResources = false;
+  return caps;
+}
+
+bool VulkanRenderBackend::IsInitialized() const {
+  return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
+  m_lastError.clear();
+  if (!nativeWindowHandle) {
+    m_lastError = "Vulkan backend requires a native GLFW window handle.";
+    return false;
+  }
+
+  if (!glfwVulkanSupported()) {
+    m_lastError = "GLFW reports that Vulkan is not supported on this system.";
+    return false;
+  }
+
+  if (!CheckVk(volkInitialize(), m_lastError, "volkInitialize"))
+    return false;
+
+  m_context = std::make_unique<Context>();
+  m_context->window = static_cast<GLFWwindow*>(nativeWindowHandle);
+
+  uint32_t extensionCount = 0;
+  const char** glfwExtensions = glfwGetRequiredInstanceExtensions(&extensionCount);
+  if (!glfwExtensions || extensionCount == 0) {
+    m_lastError = "GLFW did not provide required Vulkan instance extensions.";
+    Shutdown();
+    return false;
+  }
+
+  const VkApplicationInfo appInfo{
+      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+      .pNext = nullptr,
+      .pApplicationName = "MonolithEngine",
+      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+      .pEngineName = "MonolithEngine",
+      .engineVersion = VK_MAKE_VERSION(0, 1, 0),
+      .apiVersion = VK_API_VERSION_1_1,
+  };
+
+  std::vector<const char*> instanceExtensions(glfwExtensions, glfwExtensions + extensionCount);
+  const VkInstanceCreateInfo instanceInfo{
+      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .pApplicationInfo = &appInfo,
+      .enabledLayerCount = 0,
+      .ppEnabledLayerNames = nullptr,
+      .enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size()),
+      .ppEnabledExtensionNames = instanceExtensions.data(),
+  };
+  if (!CheckVk(vkCreateInstance(&instanceInfo, nullptr, &m_context->instance), m_lastError,
+               "vkCreateInstance")) {
+    Shutdown();
+    return false;
+  }
+
+  volkLoadInstance(m_context->instance);
+
+  if (!CheckVk(glfwCreateWindowSurface(m_context->instance, m_context->window, nullptr,
+                                       &m_context->surface),
+               m_lastError,
+               "glfwCreateWindowSurface")) {
+    Shutdown();
+    return false;
+  }
+
+  uint32_t physicalDeviceCount = 0;
+  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount, nullptr),
+               m_lastError,
+               "vkEnumeratePhysicalDevices(count)")) {
+    Shutdown();
+    return false;
+  }
+  if (physicalDeviceCount == 0) {
+    m_lastError = "No Vulkan physical devices were found.";
+    Shutdown();
+    return false;
+  }
+
+  std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+  if (!CheckVk(vkEnumeratePhysicalDevices(m_context->instance, &physicalDeviceCount,
+                                          physicalDevices.data()),
+               m_lastError,
+               "vkEnumeratePhysicalDevices")) {
+    Shutdown();
+    return false;
+  }
+
+  const std::array<const char*, 1> requiredDeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  for (VkPhysicalDevice device : physicalDevices) {
+    uint32_t queueFamilyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
+    std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
+
+    std::optional<uint32_t> graphicsFamily;
+    std::optional<uint32_t> presentFamily;
+    for (uint32_t i = 0; i < queueFamilyCount; ++i) {
+      if ((queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+        graphicsFamily = i;
+
+      VkBool32 presentSupported = VK_FALSE;
+      vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_context->surface, &presentSupported);
+      if (presentSupported == VK_TRUE)
+        presentFamily = i;
+    }
+
+    if (!graphicsFamily || !presentFamily)
+      continue;
+
+    uint32_t extensionCountAvailable = 0;
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCountAvailable, nullptr);
+    std::vector<VkExtensionProperties> extensions(extensionCountAvailable);
+    vkEnumerateDeviceExtensionProperties(device,
+                                         nullptr,
+                                         &extensionCountAvailable,
+                                         extensions.data());
+    std::set<std::string> missingExtensions(requiredDeviceExtensions.begin(),
+                                            requiredDeviceExtensions.end());
+    for (const auto& extension : extensions)
+      missingExtensions.erase(extension.extensionName);
+    if (!missingExtensions.empty())
+      continue;
+
+    uint32_t surfaceFormatCount = 0;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(device, m_context->surface, &surfaceFormatCount, nullptr);
+    uint32_t presentModeCount = 0;
+    vkGetPhysicalDeviceSurfacePresentModesKHR(device,
+                                              m_context->surface,
+                                              &presentModeCount,
+                                              nullptr);
+    if (surfaceFormatCount == 0 || presentModeCount == 0)
+      continue;
+
+    m_context->physicalDevice = device;
+    m_context->graphicsQueueFamily = *graphicsFamily;
+    m_context->presentQueueFamily = *presentFamily;
+    break;
+  }
+
+  if (m_context->physicalDevice == VK_NULL_HANDLE) {
+    m_lastError = "No Vulkan physical device supports graphics, present, and swapchain requirements.";
+    Shutdown();
+    return false;
+  }
+
+  const float queuePriority = 1.0f;
+  std::set<uint32_t> uniqueQueueFamilies = {m_context->graphicsQueueFamily,
+                                            m_context->presentQueueFamily};
+  std::vector<VkDeviceQueueCreateInfo> queueInfos;
+  queueInfos.reserve(uniqueQueueFamilies.size());
+  for (uint32_t queueFamily : uniqueQueueFamilies) {
+    queueInfos.push_back(VkDeviceQueueCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .queueFamilyIndex = queueFamily,
+        .queueCount = 1,
+        .pQueuePriorities = &queuePriority,
+    });
+  }
+
+  const VkDeviceCreateInfo deviceInfo{
+      .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .queueCreateInfoCount = static_cast<uint32_t>(queueInfos.size()),
+      .pQueueCreateInfos = queueInfos.data(),
+      .enabledLayerCount = 0,
+      .ppEnabledLayerNames = nullptr,
+      .enabledExtensionCount = static_cast<uint32_t>(requiredDeviceExtensions.size()),
+      .ppEnabledExtensionNames = requiredDeviceExtensions.data(),
+      .pEnabledFeatures = nullptr,
+  };
+  if (!CheckVk(vkCreateDevice(m_context->physicalDevice, &deviceInfo, nullptr, &m_context->device),
+               m_lastError,
+               "vkCreateDevice")) {
+    Shutdown();
+    return false;
+  }
+
+  volkLoadDevice(m_context->device);
+  vkGetDeviceQueue(m_context->device, m_context->graphicsQueueFamily, 0, &m_context->graphicsQueue);
+  vkGetDeviceQueue(m_context->device, m_context->presentQueueFamily, 0, &m_context->presentQueue);
+
+  const VkCommandPoolCreateInfo commandPoolInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+      .queueFamilyIndex = m_context->graphicsQueueFamily,
+  };
+  if (!CheckVk(vkCreateCommandPool(m_context->device, &commandPoolInfo, nullptr,
+                                   &m_context->commandPool),
+               m_lastError,
+               "vkCreateCommandPool")) {
+    Shutdown();
+    return false;
+  }
+
+  const VkSemaphoreCreateInfo semaphoreInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+                                             .pNext = nullptr,
+                                             .flags = 0};
+  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                 &m_context->imageAvailableSemaphore),
+               m_lastError,
+               "vkCreateSemaphore(imageAvailable)")) {
+    Shutdown();
+    return false;
+  }
+  if (!CheckVk(vkCreateSemaphore(m_context->device, &semaphoreInfo, nullptr,
+                                 &m_context->renderFinishedSemaphore),
+               m_lastError,
+               "vkCreateSemaphore(renderFinished)")) {
+    Shutdown();
+    return false;
+  }
+
+  const VkFenceCreateInfo fenceInfo{.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                                    .pNext = nullptr,
+                                    .flags = VK_FENCE_CREATE_SIGNALED_BIT};
+  if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &m_context->inFlightFence),
+               m_lastError,
+               "vkCreateFence")) {
+    Shutdown();
+    return false;
+  }
+
+  if (!RecreateSwapchain()) {
+    Shutdown();
+    return false;
+  }
+
+  return true;
+}
+
+void VulkanRenderBackend::Shutdown() {
+  if (!m_context)
+    return;
+
+  if (m_context->device != VK_NULL_HANDLE)
+    vkDeviceWaitIdle(m_context->device);
+
+  DestroySwapchain();
+
+  if (m_context->inFlightFence != VK_NULL_HANDLE)
+    vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
+  if (m_context->renderFinishedSemaphore != VK_NULL_HANDLE)
+    vkDestroySemaphore(m_context->device, m_context->renderFinishedSemaphore, nullptr);
+  if (m_context->imageAvailableSemaphore != VK_NULL_HANDLE)
+    vkDestroySemaphore(m_context->device, m_context->imageAvailableSemaphore, nullptr);
+  if (m_context->commandPool != VK_NULL_HANDLE)
+    vkDestroyCommandPool(m_context->device, m_context->commandPool, nullptr);
+  if (m_context->device != VK_NULL_HANDLE)
+    vkDestroyDevice(m_context->device, nullptr);
+  if (m_context->surface != VK_NULL_HANDLE)
+    vkDestroySurfaceKHR(m_context->instance, m_context->surface, nullptr);
+  if (m_context->instance != VK_NULL_HANDLE)
+    vkDestroyInstance(m_context->instance, nullptr);
+
+  m_context.reset();
+  m_frameActive = false;
+  m_passActive = false;
+}
+
+void VulkanRenderBackend::DestroySwapchain() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  if (!m_context->commandBuffers.empty()) {
+    vkFreeCommandBuffers(m_context->device,
+                         m_context->commandPool,
+                         static_cast<uint32_t>(m_context->commandBuffers.size()),
+                         m_context->commandBuffers.data());
+    m_context->commandBuffers.clear();
+  }
+
+  for (VkImageView imageView : m_context->swapchainImageViews)
+    vkDestroyImageView(m_context->device, imageView, nullptr);
+  m_context->swapchainImageViews.clear();
+  m_context->swapchainImages.clear();
+  m_context->imageWasPresented.clear();
+
+  if (m_context->swapchain != VK_NULL_HANDLE) {
+    vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
+    m_context->swapchain = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::RecreateSwapchain() {
+  DestroySwapchain();
+
+  VkSurfaceCapabilitiesKHR surfaceCapabilities{};
+  if (!CheckVk(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context->physicalDevice,
+                                                         m_context->surface,
+                                                         &surfaceCapabilities),
+               m_lastError,
+               "vkGetPhysicalDeviceSurfaceCapabilitiesKHR")) {
+    return false;
+  }
+
+  uint32_t surfaceFormatCount = 0;
+  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                       m_context->surface,
+                                       &surfaceFormatCount,
+                                       nullptr);
+  std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
+  vkGetPhysicalDeviceSurfaceFormatsKHR(m_context->physicalDevice,
+                                       m_context->surface,
+                                       &surfaceFormatCount,
+                                       surfaceFormats.data());
+  VkSurfaceFormatKHR chosenFormat = surfaceFormats.front();
+  for (const auto& candidate : surfaceFormats) {
+    if (candidate.format == VK_FORMAT_B8G8R8A8_UNORM &&
+        candidate.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+      chosenFormat = candidate;
+      break;
+    }
+  }
+  m_context->swapchainFormat = chosenFormat.format;
+
+  uint32_t presentModeCount = 0;
+  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                            m_context->surface,
+                                            &presentModeCount,
+                                            nullptr);
+  std::vector<VkPresentModeKHR> presentModes(presentModeCount);
+  vkGetPhysicalDeviceSurfacePresentModesKHR(m_context->physicalDevice,
+                                            m_context->surface,
+                                            &presentModeCount,
+                                            presentModes.data());
+  VkPresentModeKHR chosenPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+  for (VkPresentModeKHR presentMode : presentModes) {
+    if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
+      chosenPresentMode = presentMode;
+      break;
+    }
+  }
+
+  int framebufferWidth = 0;
+  int framebufferHeight = 0;
+  glfwGetFramebufferSize(m_context->window, &framebufferWidth, &framebufferHeight);
+  framebufferWidth = std::max(framebufferWidth, 1);
+  framebufferHeight = std::max(framebufferHeight, 1);
+
+  if (surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
+    m_context->swapchainExtent = surfaceCapabilities.currentExtent;
+  } else {
+    m_context->swapchainExtent.width = std::clamp(static_cast<uint32_t>(framebufferWidth),
+                                                  surfaceCapabilities.minImageExtent.width,
+                                                  surfaceCapabilities.maxImageExtent.width);
+    m_context->swapchainExtent.height = std::clamp(static_cast<uint32_t>(framebufferHeight),
+                                                   surfaceCapabilities.minImageExtent.height,
+                                                   surfaceCapabilities.maxImageExtent.height);
+  }
+
+  uint32_t imageCount = std::max(surfaceCapabilities.minImageCount, 2u);
+  if (surfaceCapabilities.maxImageCount > 0)
+    imageCount = std::min(imageCount, surfaceCapabilities.maxImageCount);
+
+  std::array<uint32_t, 2> queueFamilyIndices = {m_context->graphicsQueueFamily,
+                                                m_context->presentQueueFamily};
+  const bool usesSeparatePresentQueue =
+      m_context->graphicsQueueFamily != m_context->presentQueueFamily;
+
+  const VkSwapchainCreateInfoKHR swapchainInfo{
+      .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
+      .pNext = nullptr,
+      .flags = 0,
+      .surface = m_context->surface,
+      .minImageCount = imageCount,
+      .imageFormat = chosenFormat.format,
+      .imageColorSpace = chosenFormat.colorSpace,
+      .imageExtent = m_context->swapchainExtent,
+      .imageArrayLayers = 1,
+      .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+      .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
+                                                   : VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
+      .pQueueFamilyIndices = usesSeparatePresentQueue ? queueFamilyIndices.data() : nullptr,
+      .preTransform = surfaceCapabilities.currentTransform,
+      .compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+      .presentMode = chosenPresentMode,
+      .clipped = VK_TRUE,
+      .oldSwapchain = VK_NULL_HANDLE,
+  };
+  if (!CheckVk(vkCreateSwapchainKHR(m_context->device, &swapchainInfo, nullptr,
+                                    &m_context->swapchain),
+               m_lastError,
+               "vkCreateSwapchainKHR")) {
+    return false;
+  }
+
+  uint32_t swapchainImageCount = 0;
+  vkGetSwapchainImagesKHR(m_context->device, m_context->swapchain, &swapchainImageCount, nullptr);
+  m_context->swapchainImages.resize(swapchainImageCount);
+  vkGetSwapchainImagesKHR(m_context->device,
+                          m_context->swapchain,
+                          &swapchainImageCount,
+                          m_context->swapchainImages.data());
+  m_context->swapchainImageViews.resize(swapchainImageCount);
+  m_context->imageWasPresented.assign(swapchainImageCount, false);
+
+  for (size_t i = 0; i < m_context->swapchainImages.size(); ++i) {
+    const VkImageViewCreateInfo imageViewInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = m_context->swapchainImages[i],
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = m_context->swapchainFormat,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    if (!CheckVk(vkCreateImageView(m_context->device,
+                                   &imageViewInfo,
+                                   nullptr,
+                                   &m_context->swapchainImageViews[i]),
+                 m_lastError,
+                 "vkCreateImageView")) {
+      return false;
+    }
+  }
+
+  m_context->commandBuffers.resize(swapchainImageCount);
+  const VkCommandBufferAllocateInfo commandBufferInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .commandPool = m_context->commandPool,
+      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = swapchainImageCount,
+  };
+  if (!CheckVk(vkAllocateCommandBuffers(m_context->device,
+                                        &commandBufferInfo,
+                                        m_context->commandBuffers.data()),
+               m_lastError,
+               "vkAllocateCommandBuffers")) {
+    return false;
+  }
+
+  return true;
+}
+
+bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
+  VkCommandBuffer commandBuffer = m_context->commandBuffers[m_context->activeImageIndex];
+  if (!CheckVk(vkResetCommandBuffer(commandBuffer, 0), m_lastError, "vkResetCommandBuffer"))
+    return false;
+
+  const VkCommandBufferBeginInfo beginInfo{
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .pInheritanceInfo = nullptr,
+  };
+  if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo), m_lastError,
+               "vkBeginCommandBuffer")) {
+    return false;
+  }
+
+  if (frame.clearColorBuffer) {
+    const VkImageMemoryBarrier toTransfer{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = 0,
+        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .oldLayout = m_context->imageWasPresented[m_context->activeImageIndex]
+                         ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                         : VK_IMAGE_LAYOUT_UNDEFINED,
+        .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image = m_context->swapchainImages[m_context->activeImageIndex],
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    vkCmdPipelineBarrier(commandBuffer,
+                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         0,
+                         0,
+                         nullptr,
+                         0,
+                         nullptr,
+                         1,
+                         &toTransfer);
+
+    const VkClearColorValue clearColor = {{frame.clearColor.x,
+                                           frame.clearColor.y,
+                                           frame.clearColor.z,
+                                           frame.clearColor.w}};
+    const VkImageSubresourceRange clearRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkCmdClearColorImage(commandBuffer,
+                         m_context->swapchainImages[m_context->activeImageIndex],
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                         &clearColor,
+                         1,
+                         &clearRange);
+
+    const VkImageMemoryBarrier toPresent{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .pNext = nullptr,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = 0,
+        .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image = m_context->swapchainImages[m_context->activeImageIndex],
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    vkCmdPipelineBarrier(commandBuffer,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         0,
+                         0,
+                         nullptr,
+                         0,
+                         nullptr,
+                         1,
+                         &toPresent);
+  }
+
+  if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer"))
+    return false;
+
+  m_context->frameCommandsRecorded = true;
+  return true;
+}
+
+void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
+  MONOLITH_ASSERT(IsInitialized(), "VulkanRenderBackend::BeginFrame called before initialization");
+  MONOLITH_ASSERT(!m_frameActive, "VulkanRenderBackend::BeginFrame called while a frame is active");
+  if (!IsInitialized() || m_frameActive)
+    return;
+
+  if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+               m_lastError,
+               "vkWaitForFences")) {
+    return;
+  }
+
+  VkResult acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                                 m_context->swapchain,
+                                                 UINT64_MAX,
+                                                 m_context->imageAvailableSemaphore,
+                                                 VK_NULL_HANDLE,
+                                                 &m_context->activeImageIndex);
+  if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR || acquireResult == VK_SUBOPTIMAL_KHR) {
+    MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+    acquireResult = vkAcquireNextImageKHR(m_context->device,
+                                          m_context->swapchain,
+                                          UINT64_MAX,
+                                          m_context->imageAvailableSemaphore,
+                                          VK_NULL_HANDLE,
+                                          &m_context->activeImageIndex);
+  }
+  MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
+
+  MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
+                          m_lastError,
+                          "vkResetFences"),
+                  m_lastError.c_str());
+  MONOLITH_ASSERT(RecordFrameCommands(frame), m_lastError.c_str());
+
+  m_drawCalls = 0;
+  m_frameActive = true;
+}
+
+void VulkanRenderBackend::EndFrame() {
+  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::EndFrame called without an active frame");
+  if (!m_frameActive)
+    return;
+
+  if (m_passActive)
+    EndPass();
+
+  if (m_context->frameCommandsRecorded) {
+    const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
+    const VkSubmitInfo submitInfo{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 1,
+        .pWaitSemaphores = &m_context->imageAvailableSemaphore,
+        .pWaitDstStageMask = waitStages,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &m_context->commandBuffers[m_context->activeImageIndex],
+        .signalSemaphoreCount = 1,
+        .pSignalSemaphores = &m_context->renderFinishedSemaphore,
+    };
+    MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
+                                          1,
+                                          &submitInfo,
+                                          m_context->inFlightFence),
+                            m_lastError,
+                            "vkQueueSubmit"),
+                    m_lastError.c_str());
+
+    const VkPresentInfoKHR presentInfo{
+        .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 1,
+        .pWaitSemaphores = &m_context->renderFinishedSemaphore,
+        .swapchainCount = 1,
+        .pSwapchains = &m_context->swapchain,
+        .pImageIndices = &m_context->activeImageIndex,
+        .pResults = nullptr,
+    };
+    const VkResult presentResult = vkQueuePresentKHR(m_context->presentQueue, &presentInfo);
+    if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
+      MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
+    } else {
+      MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
+    }
+
+    m_context->imageWasPresented[m_context->activeImageIndex] = true;
+    m_context->frameCommandsRecorded = false;
+  }
+
+  m_frameActive = false;
+}
+
+void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
+  MONOLITH_ASSERT(m_frameActive, "VulkanRenderBackend::BeginPass called without an active frame");
+  MONOLITH_ASSERT(!m_passActive, "VulkanRenderBackend::BeginPass called while a pass is active");
+  if (!m_frameActive || m_passActive)
+    return;
+
+  m_activePassId = pass.id;
+  m_passActive = true;
+}
+
+void VulkanRenderBackend::EndPass() {
+  MONOLITH_ASSERT(m_passActive, "VulkanRenderBackend::EndPass called without an active pass");
+  if (!m_passActive)
+    return;
+  m_passActive = false;
+}
+
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+
+void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+
+void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+
+#else
+
+struct VulkanRenderBackend::Context {};
+
+VulkanRenderBackend::VulkanRenderBackend(void*) {
+  m_lastError = "Vulkan backend was compiled without Vulkan dependency support.";
+}
+
+VulkanRenderBackend::~VulkanRenderBackend() = default;
+
+RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
+  return GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+}
+
+bool VulkanRenderBackend::IsInitialized() const {
+  return false;
+}
+
+bool VulkanRenderBackend::Initialize(void*) {
+  return false;
+}
+
+void VulkanRenderBackend::Shutdown() {}
+bool VulkanRenderBackend::RecreateSwapchain() { return false; }
+void VulkanRenderBackend::DestroySwapchain() {}
+bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig&) { return false; }
+void VulkanRenderBackend::BeginFrame(const RenderFrameConfig&) {}
+void VulkanRenderBackend::EndFrame() {}
+void VulkanRenderBackend::BeginPass(const RenderPassConfig&) {}
+void VulkanRenderBackend::EndPass() {}
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
+void VulkanRenderBackend::DrawWireframe(const WireframeDrawCommand&) {}
+
+#endif
+
+}  // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -119,6 +119,16 @@ int VulkanRenderBackend::ResolveIndexCount(const Mesh& mesh) {
   return mesh.GetIndexCount();
 }
 
+VulkanRenderBackend::OpaquePipelineKey VulkanRenderBackend::BuildOpaquePipelineKey(
+    const TranslatedMaterialState& materialState) {
+  OpaquePipelineKey key;
+  key.usesAlbedoMap = materialState.usesAlbedoMap;
+  key.usesCustomShader = materialState.usesCustomShader;
+  key.writesDepth = true;
+  key.depthTestEnabled = true;
+  return key;
+}
+
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
 }
@@ -805,7 +815,9 @@ void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
   m_pendingOpaqueDraws.push_back(
       PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
                         command.modelMatrix,
-                        TranslateMaterialState(*command.material)});
+                        TranslateMaterialState(*command.material),
+                        {}});
+  m_pendingOpaqueDraws.back().pipelineKey = BuildOpaquePipelineKey(m_pendingOpaqueDraws.back().material);
   ++m_drawCalls;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -86,6 +86,8 @@ struct VulkanRenderBackend::Context {
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+  std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
+  std::array<VkPipelineShaderStageCreateInfo, 2> opaqueShaderStages{};
   bool opaqueShaderPipelineScaffoldReady = false;
   bool opaqueGraphicsPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
@@ -633,14 +635,37 @@ void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
 }
 
 bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
-  m_context->opaqueShaderPipelineScaffoldReady = m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
-                                                 m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  m_context->opaqueShaderStages[0] = VkPipelineShaderStageCreateInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .stage = VK_SHADER_STAGE_VERTEX_BIT,
+      .module = VK_NULL_HANDLE,
+      .pName = m_context->opaqueShaderEntryNames[0].c_str(),
+      .pSpecializationInfo = nullptr,
+  };
+  m_context->opaqueShaderStages[1] = VkPipelineShaderStageCreateInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+      .module = VK_NULL_HANDLE,
+      .pName = m_context->opaqueShaderEntryNames[1].c_str(),
+      .pSpecializationInfo = nullptr,
+  };
+
+  m_context->opaqueShaderPipelineScaffoldReady =
+      m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+      m_context->opaquePipelineCache != VK_NULL_HANDLE &&
+      m_context->opaqueShaderStages[0].pName != nullptr &&
+      m_context->opaqueShaderStages[1].pName != nullptr;
   return m_context->opaqueShaderPipelineScaffoldReady;
 }
 
 void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
   if (!m_context)
     return;
+  m_context->opaqueShaderStages = {};
   m_context->opaqueShaderPipelineScaffoldReady = false;
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -254,6 +254,51 @@ namespace Monolith
     return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
   }
 
+  bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **outInstance,
+                                                      void **outPhysicalDevice,
+                                                      void **outDevice,
+                                                      uint32_t *outQueueFamily,
+                                                      void **outQueue,
+                                                      void **outRenderPass,
+                                                      uint32_t *outImageCount) const
+  {
+    if (!IsInitialized() || !m_context)
+      return false;
+
+    if (outInstance)
+      *outInstance = reinterpret_cast<void *>(m_context->instance);
+    if (outPhysicalDevice)
+      *outPhysicalDevice = reinterpret_cast<void *>(m_context->physicalDevice);
+    if (outDevice)
+      *outDevice = reinterpret_cast<void *>(m_context->device);
+    if (outQueueFamily)
+      *outQueueFamily = m_context->graphicsQueueFamily;
+    if (outQueue)
+      *outQueue = reinterpret_cast<void *>(m_context->graphicsQueue);
+    if (outRenderPass)
+      *outRenderPass = reinterpret_cast<void *>(m_context->opaqueRenderPass);
+    if (outImageCount)
+      *outImageCount = static_cast<uint32_t>(m_context->swapchainImages.size());
+
+    return m_context->instance != VK_NULL_HANDLE &&
+           m_context->physicalDevice != VK_NULL_HANDLE &&
+           m_context->device != VK_NULL_HANDLE &&
+           m_context->graphicsQueue != VK_NULL_HANDLE &&
+           m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+           !m_context->swapchainImages.empty();
+  }
+
+  void *VulkanRenderBackend::GetActiveCommandBufferHandle() const
+  {
+    if (!m_context || m_context->commandBuffers.empty() ||
+        m_context->activeImageIndex >= m_context->commandBuffers.size())
+    {
+      return nullptr;
+    }
+
+    return reinterpret_cast<void *>(m_context->commandBuffers[m_context->activeImageIndex]);
+  }
+
   bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
   {
     m_lastError.clear();
@@ -1489,6 +1534,22 @@ namespace Monolith
   bool VulkanRenderBackend::IsInitialized() const
   {
     return false;
+  }
+
+  bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **,
+                                                      void **,
+                                                      void **,
+                                                      uint32_t *,
+                                                      void **,
+                                                      void **,
+                                                      uint32_t *) const
+  {
+    return false;
+  }
+
+  void *VulkanRenderBackend::GetActiveCommandBufferHandle() const
+  {
+    return nullptr;
   }
 
   bool VulkanRenderBackend::Initialize(void *)

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -87,6 +87,7 @@ struct VulkanRenderBackend::Context {
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
   bool opaqueShaderPipelineScaffoldReady = false;
+  bool opaqueGraphicsPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -174,6 +175,10 @@ bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
 
 bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
   return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
+}
+
+bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const {
+  return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -434,6 +439,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaqueGraphicsPipelineScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   return true;
 }
 
@@ -446,6 +456,7 @@ void VulkanRenderBackend::Shutdown() {
 
   DestroySwapchain();
 
+  DestroyOpaqueGraphicsPipelineScaffold();
   DestroyOpaqueShaderPipelineScaffold();
   DestroyOpaquePipelineCreationScaffold();
 
@@ -631,6 +642,21 @@ void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
   if (!m_context)
     return;
   m_context->opaqueShaderPipelineScaffoldReady = false;
+}
+
+bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold() {
+  m_context->opaqueGraphicsPipelineScaffoldReady =
+      m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
+  if (!m_context->opaqueGraphicsPipelineScaffoldReady) {
+    m_lastError = "Opaque graphics pipeline scaffold prerequisites are incomplete.";
+  }
+  return m_context->opaqueGraphicsPipelineScaffoldReady;
+}
+
+void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold() {
+  if (!m_context)
+    return;
+  m_context->opaqueGraphicsPipelineScaffoldReady = false;
 }
 
 bool VulkanRenderBackend::RecreateSwapchain() {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -86,6 +86,7 @@ struct VulkanRenderBackend::Context {
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
+  bool opaqueShaderPipelineScaffoldReady = false;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -169,6 +170,10 @@ bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
 
 bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
   return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const {
+  return HasOpaquePipelineCreationScaffold() && m_context && m_context->opaqueShaderPipelineScaffoldReady;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -419,6 +424,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaqueShaderPipelineScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -436,6 +446,7 @@ void VulkanRenderBackend::Shutdown() {
 
   DestroySwapchain();
 
+  DestroyOpaqueShaderPipelineScaffold();
   DestroyOpaquePipelineCreationScaffold();
 
   if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
@@ -608,6 +619,18 @@ void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
     vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
     m_context->opaquePipelineCache = VK_NULL_HANDLE;
   }
+}
+
+bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() {
+  m_context->opaqueShaderPipelineScaffoldReady = m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+                                                 m_context->opaquePipelineCache != VK_NULL_HANDLE;
+  return m_context->opaqueShaderPipelineScaffoldReady;
+}
+
+void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {
+  if (!m_context)
+    return;
+  m_context->opaqueShaderPipelineScaffoldReady = false;
 }
 
 bool VulkanRenderBackend::RecreateSwapchain() {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -83,8 +83,11 @@ struct VulkanRenderBackend::Context {
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
   VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkExtent2D swapchainExtent = {1, 1};
+  VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
+  VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
+  std::vector<VkFramebuffer> opaqueFramebuffers;
   std::vector<VkCommandBuffer> commandBuffers;
   std::vector<bool> imageWasPresented;
   VkCommandPool commandPool = VK_NULL_HANDLE;
@@ -154,6 +157,13 @@ RenderBackendCapabilities VulkanRenderBackend::GetCapabilities() const {
 
 bool VulkanRenderBackend::IsInitialized() const {
   return m_context && m_context->device != VK_NULL_HANDLE && m_context->swapchain != VK_NULL_HANDLE;
+}
+
+bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
+  return m_context && m_context->opaqueRenderPass != VK_NULL_HANDLE &&
+         m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
+         m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
+         !m_context->opaqueFramebuffers.empty();
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -380,6 +390,25 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .setLayoutCount = 0,
+      .pSetLayouts = nullptr,
+      .pushConstantRangeCount = 0,
+      .pPushConstantRanges = nullptr,
+  };
+  if (!CheckVk(vkCreatePipelineLayout(m_context->device,
+                                      &pipelineLayoutInfo,
+                                      nullptr,
+                                      &m_context->opaquePipelineLayout),
+               m_lastError,
+               "vkCreatePipelineLayout")) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -396,6 +425,9 @@ void VulkanRenderBackend::Shutdown() {
     vkDeviceWaitIdle(m_context->device);
 
   DestroySwapchain();
+
+  if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
+    vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
 
   if (m_context->inFlightFence != VK_NULL_HANDLE)
     vkDestroyFence(m_context->device, m_context->inFlightFence, nullptr);
@@ -421,6 +453,8 @@ void VulkanRenderBackend::DestroySwapchain() {
   if (!m_context || m_context->device == VK_NULL_HANDLE)
     return;
 
+  DestroyOpaqueRasterScaffold();
+
   if (!m_context->commandBuffers.empty()) {
     vkFreeCommandBuffers(m_context->device,
                          m_context->commandPool,
@@ -438,6 +472,103 @@ void VulkanRenderBackend::DestroySwapchain() {
   if (m_context->swapchain != VK_NULL_HANDLE) {
     vkDestroySwapchainKHR(m_context->device, m_context->swapchain, nullptr);
     m_context->swapchain = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::CreateOpaqueRasterScaffold() {
+  const VkAttachmentDescription colorAttachment{
+      .flags = 0,
+      .format = m_context->swapchainFormat,
+      .samples = VK_SAMPLE_COUNT_1_BIT,
+      .loadOp = VK_ATTACHMENT_LOAD_OP_LOAD,
+      .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+      .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+      .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+      .initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+      .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+  };
+  const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+  const VkSubpassDescription subpass{
+      .flags = 0,
+      .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+      .inputAttachmentCount = 0,
+      .pInputAttachments = nullptr,
+      .colorAttachmentCount = 1,
+      .pColorAttachments = &colorAttachmentRef,
+      .pResolveAttachments = nullptr,
+      .pDepthStencilAttachment = nullptr,
+      .preserveAttachmentCount = 0,
+      .pPreserveAttachments = nullptr,
+  };
+  const VkSubpassDependency dependency{
+      .srcSubpass = VK_SUBPASS_EXTERNAL,
+      .dstSubpass = 0,
+      .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+      .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+      .srcAccessMask = 0,
+      .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+      .dependencyFlags = 0,
+  };
+  const VkRenderPassCreateInfo renderPassInfo{
+      .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .attachmentCount = 1,
+      .pAttachments = &colorAttachment,
+      .subpassCount = 1,
+      .pSubpasses = &subpass,
+      .dependencyCount = 1,
+      .pDependencies = &dependency,
+  };
+  if (!CheckVk(vkCreateRenderPass(m_context->device,
+                                  &renderPassInfo,
+                                  nullptr,
+                                  &m_context->opaqueRenderPass),
+               m_lastError,
+               "vkCreateRenderPass")) {
+    return false;
+  }
+
+  m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
+  for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i) {
+    const VkImageView attachment = m_context->swapchainImageViews[i];
+    const VkFramebufferCreateInfo framebufferInfo{
+        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .renderPass = m_context->opaqueRenderPass,
+        .attachmentCount = 1,
+        .pAttachments = &attachment,
+        .width = m_context->swapchainExtent.width,
+        .height = m_context->swapchainExtent.height,
+        .layers = 1,
+    };
+    if (!CheckVk(vkCreateFramebuffer(m_context->device,
+                                     &framebufferInfo,
+                                     nullptr,
+                                     &m_context->opaqueFramebuffers[i]),
+                 m_lastError,
+                 "vkCreateFramebuffer")) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  for (VkFramebuffer framebuffer : m_context->opaqueFramebuffers) {
+    if (framebuffer != VK_NULL_HANDLE)
+      vkDestroyFramebuffer(m_context->device, framebuffer, nullptr);
+  }
+  m_context->opaqueFramebuffers.clear();
+
+  if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
+    vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
+    m_context->opaqueRenderPass = VK_NULL_HANDLE;
   }
 }
 
@@ -594,6 +725,9 @@ bool VulkanRenderBackend::RecreateSwapchain() {
                "vkAllocateCommandBuffers")) {
     return false;
   }
+
+  if (!CreateOpaqueRasterScaffold())
+    return false;
 
   return true;
 }

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -299,6 +299,13 @@ namespace Monolith
     return reinterpret_cast<void *>(m_context->commandBuffers[m_context->activeImageIndex]);
   }
 
+  void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback callback,
+                                                       void *userData)
+  {
+    m_pendingOverlayRenderCallback = callback;
+    m_pendingOverlayRenderUserData = userData;
+  }
+
   bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
   {
     m_lastError.clear();
@@ -1219,6 +1226,7 @@ namespace Monolith
     }
 
     const bool hasQueuedOpaqueDraws = !m_pendingOpaqueDraws.empty();
+    const bool hasQueuedOverlayRender = m_pendingOverlayRenderCallback != nullptr;
     const bool hasExecutableOpaquePipeline =
         m_context->opaqueGraphicsPipelineExecutable &&
         m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
@@ -1230,7 +1238,7 @@ namespace Monolith
           std::to_string(m_pendingOpaqueDraws.size());
     }
 
-    if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
+    if (hasQueuedOpaqueDraws || hasQueuedOverlayRender)
     {
       const VkImageMemoryBarrier toColorAttachment{
           .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -1281,15 +1289,24 @@ namespace Monolith
       const VkRect2D scissor{{0, 0}, m_context->swapchainExtent};
       vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
       vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
-      vkCmdBindPipeline(commandBuffer,
-                        VK_PIPELINE_BIND_POINT_GRAPHICS,
-                        m_context->opaqueGraphicsPipeline);
-
-      for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+      if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
       {
-        if (draw.indexCount <= 0)
-          continue;
-        vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+        vkCmdBindPipeline(commandBuffer,
+                          VK_PIPELINE_BIND_POINT_GRAPHICS,
+                          m_context->opaqueGraphicsPipeline);
+
+        for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+        {
+          if (draw.indexCount <= 0)
+            continue;
+          vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+        }
+      }
+
+      if (hasQueuedOverlayRender)
+      {
+        m_pendingOverlayRenderCallback(m_pendingOverlayRenderUserData,
+                                       reinterpret_cast<void *>(commandBuffer));
       }
 
       vkCmdEndRenderPass(commandBuffer);
@@ -1473,6 +1490,8 @@ namespace Monolith
 
     m_frameActive = false;
     m_pendingOpaqueDraws.clear();
+    m_pendingOverlayRenderCallback = nullptr;
+    m_pendingOverlayRenderUserData = nullptr;
   }
 
   void VulkanRenderBackend::BeginPass(const RenderPassConfig &pass)
@@ -1551,6 +1570,8 @@ namespace Monolith
   {
     return nullptr;
   }
+
+  void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback, void *) {}
 
   bool VulkanRenderBackend::Initialize(void *)
   {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -85,6 +85,7 @@ struct VulkanRenderBackend::Context {
   VkExtent2D swapchainExtent = {1, 1};
   VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
   VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
+  VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
   std::vector<VkImage> swapchainImages;
   std::vector<VkImageView> swapchainImageViews;
   std::vector<VkFramebuffer> opaqueFramebuffers;
@@ -164,6 +165,10 @@ bool VulkanRenderBackend::HasOpaqueRasterScaffold() const {
          m_context->opaquePipelineLayout != VK_NULL_HANDLE &&
          m_context->opaqueFramebuffers.size() == m_context->swapchainImageViews.size() &&
          !m_context->opaqueFramebuffers.empty();
+}
+
+bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const {
+  return HasOpaqueRasterScaffold() && m_context && m_context->opaquePipelineCache != VK_NULL_HANDLE;
 }
 
 bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
@@ -409,6 +414,11 @@ bool VulkanRenderBackend::Initialize(void* nativeWindowHandle) {
     return false;
   }
 
+  if (!CreateOpaquePipelineCreationScaffold()) {
+    Shutdown();
+    return false;
+  }
+
   if (!RecreateSwapchain()) {
     Shutdown();
     return false;
@@ -425,6 +435,8 @@ void VulkanRenderBackend::Shutdown() {
     vkDeviceWaitIdle(m_context->device);
 
   DestroySwapchain();
+
+  DestroyOpaquePipelineCreationScaffold();
 
   if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
     vkDestroyPipelineLayout(m_context->device, m_context->opaquePipelineLayout, nullptr);
@@ -569,6 +581,32 @@ void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {
   if (m_context->opaqueRenderPass != VK_NULL_HANDLE) {
     vkDestroyRenderPass(m_context->device, m_context->opaqueRenderPass, nullptr);
     m_context->opaqueRenderPass = VK_NULL_HANDLE;
+  }
+}
+
+bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold() {
+  const VkPipelineCacheCreateInfo pipelineCacheInfo{
+      .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .initialDataSize = 0,
+      .pInitialData = nullptr,
+  };
+  return CheckVk(vkCreatePipelineCache(m_context->device,
+                                       &pipelineCacheInfo,
+                                       nullptr,
+                                       &m_context->opaquePipelineCache),
+                 m_lastError,
+                 "vkCreatePipelineCache");
+}
+
+void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {
+  if (!m_context || m_context->device == VK_NULL_HANDLE)
+    return;
+
+  if (m_context->opaquePipelineCache != VK_NULL_HANDLE) {
+    vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
+    m_context->opaquePipelineCache = VK_NULL_HANDLE;
   }
 }
 

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <cstring>
 #include <fstream>
 #include <limits>
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -17,6 +20,8 @@
 #if defined(MONOLITH_HAS_VULKAN)
 #include <volk.h>
 #include <GLFW/glfw3.h>
+#include <imgui.h>
+#include <imgui_impl_vulkan.h>
 #endif
 
 namespace Monolith
@@ -28,6 +33,8 @@ namespace Monolith
   {
 
     constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
+    constexpr VkFormat kOffscreenTargetFormat = VK_FORMAT_R8G8B8A8_UNORM;
+    constexpr const char *kEditorViewportTargetKey = "__editor.viewport.scene";
 
     const char *VkResultName(VkResult result)
     {
@@ -121,10 +128,183 @@ namespace Monolith
                      context);
     }
 
+    uint32_t FindMemoryTypeIndex(VkPhysicalDevice physicalDevice,
+                                 uint32_t memoryTypeBits,
+                                 VkMemoryPropertyFlags requiredFlags)
+    {
+      VkPhysicalDeviceMemoryProperties memoryProperties{};
+      vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memoryProperties);
+      for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i)
+      {
+        if ((memoryTypeBits & (1u << i)) == 0)
+          continue;
+        if ((memoryProperties.memoryTypes[i].propertyFlags & requiredFlags) == requiredFlags)
+          return i;
+      }
+      return kInvalidQueueFamily;
+    }
+
+    bool CreateHostVisibleBuffer(VkPhysicalDevice physicalDevice,
+                                 VkDevice device,
+                                 VkDeviceSize size,
+                                 VkBufferUsageFlags usage,
+                                 VkBuffer *outBuffer,
+                                 VkDeviceMemory *outMemory,
+                                 std::string &outError,
+                                 const char *context)
+    {
+      if (!outBuffer || !outMemory)
+        return false;
+
+      *outBuffer = VK_NULL_HANDLE;
+      *outMemory = VK_NULL_HANDLE;
+
+      const VkBufferCreateInfo bufferInfo{
+          .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .size = size,
+          .usage = usage,
+          .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+          .queueFamilyIndexCount = 0,
+          .pQueueFamilyIndices = nullptr,
+      };
+      if (!CheckVk(vkCreateBuffer(device, &bufferInfo, nullptr, outBuffer), outError, context))
+        return false;
+
+      VkMemoryRequirements memoryRequirements{};
+      vkGetBufferMemoryRequirements(device, *outBuffer, &memoryRequirements);
+      const uint32_t memoryTypeIndex =
+          FindMemoryTypeIndex(physicalDevice,
+                              memoryRequirements.memoryTypeBits,
+                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+      if (memoryTypeIndex == kInvalidQueueFamily)
+      {
+        outError = std::string(context) + " failed: no host-visible coherent memory type.";
+        vkDestroyBuffer(device, *outBuffer, nullptr);
+        *outBuffer = VK_NULL_HANDLE;
+        return false;
+      }
+
+      const VkMemoryAllocateInfo allocInfo{
+          .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+          .pNext = nullptr,
+          .allocationSize = memoryRequirements.size,
+          .memoryTypeIndex = memoryTypeIndex,
+      };
+      if (!CheckVk(vkAllocateMemory(device, &allocInfo, nullptr, outMemory), outError, context))
+      {
+        vkDestroyBuffer(device, *outBuffer, nullptr);
+        *outBuffer = VK_NULL_HANDLE;
+        return false;
+      }
+
+      if (!CheckVk(vkBindBufferMemory(device, *outBuffer, *outMemory, 0), outError, context))
+      {
+        vkFreeMemory(device, *outMemory, nullptr);
+        vkDestroyBuffer(device, *outBuffer, nullptr);
+        *outMemory = VK_NULL_HANDLE;
+        *outBuffer = VK_NULL_HANDLE;
+        return false;
+      }
+
+      return true;
+    }
+
+    bool HasFormatFeature(VkPhysicalDevice physicalDevice,
+                          VkFormat format,
+                          VkFormatFeatureFlags requiredFeatures)
+    {
+      VkFormatProperties properties{};
+      vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &properties);
+      return (properties.optimalTilingFeatures & requiredFeatures) == requiredFeatures;
+    }
+
+    bool FindSupportedDepthFormat(VkPhysicalDevice physicalDevice,
+                                  bool requireTransferSrc,
+                                  VkFormat *outFormat)
+    {
+      if (!outFormat)
+        return false;
+      *outFormat = VK_FORMAT_UNDEFINED;
+
+      const std::array<VkFormat, 3> candidates = {
+          VK_FORMAT_D32_SFLOAT,
+          VK_FORMAT_D32_SFLOAT_S8_UINT,
+          VK_FORMAT_D24_UNORM_S8_UINT,
+      };
+      for (VkFormat candidate : candidates)
+      {
+        if (!HasFormatFeature(physicalDevice,
+                              candidate,
+                              VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT))
+        {
+          continue;
+        }
+
+        if (requireTransferSrc &&
+            !HasFormatFeature(physicalDevice, candidate, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT))
+        {
+          continue;
+        }
+
+        *outFormat = candidate;
+        return true;
+      }
+
+      return false;
+    }
+
+    struct OpaqueMaterialGpuData
+    {
+      float baseColor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+      float roughness = 0.5f;
+      float metallic = 0.0f;
+      float uvScale = 1.0f;
+      float padding = 0.0f;
+    };
+
+    constexpr uint32_t kOpaqueMaterialDescriptorCapacity = 2048u;
+    constexpr uint32_t kFallbackOpaqueIndexCount = 3u;
+    constexpr std::array<uint32_t, kFallbackOpaqueIndexCount> kFallbackOpaqueIndices = {0u, 1u, 2u};
+
+    bool IsImGuiVulkanTextureApiReady()
+    {
+      if (ImGui::GetCurrentContext() == nullptr)
+        return false;
+      const ImGuiIO &io = ImGui::GetIO();
+      return io.BackendRendererUserData != nullptr;
+    }
+
   } // namespace
 
   struct VulkanRenderBackend::Context
   {
+    struct MeshGpuBuffers
+    {
+      VkBuffer vertexBuffer = VK_NULL_HANDLE;
+      VkDeviceMemory vertexMemory = VK_NULL_HANDLE;
+      VkBuffer indexBuffer = VK_NULL_HANDLE;
+      VkDeviceMemory indexMemory = VK_NULL_HANDLE;
+      uint32_t indexCount = 0;
+    };
+
+    struct OffscreenRenderTarget
+    {
+      uint32_t width = 0;
+      uint32_t height = 0;
+      uint64_t generation = 0;
+      VkImage image = VK_NULL_HANDLE;
+      VkDeviceMemory memory = VK_NULL_HANDLE;
+      VkImageView imageView = VK_NULL_HANDLE;
+      VkSampler sampler = VK_NULL_HANDLE;
+      VkFramebuffer framebuffer = VK_NULL_HANDLE;
+      VkDescriptorSet imguiDescriptorSet = VK_NULL_HANDLE;
+      bool readyForSampling = false;
+      VkImageLayout currentLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    };
+
     GLFWwindow *window = nullptr;
     VkInstance instance = VK_NULL_HANDLE;
     VkSurfaceKHR surface = VK_NULL_HANDLE;
@@ -137,7 +317,12 @@ namespace Monolith
     VkSwapchainKHR swapchain = VK_NULL_HANDLE;
     VkFormat swapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
     VkExtent2D swapchainExtent = {1, 1};
+    VkImage depthImage = VK_NULL_HANDLE;
+    VkDeviceMemory depthImageMemory = VK_NULL_HANDLE;
+    VkImageView depthImageView = VK_NULL_HANDLE;
+    VkFormat depthFormat = VK_FORMAT_UNDEFINED;
     VkRenderPass opaqueRenderPass = VK_NULL_HANDLE;
+    VkRenderPass offscreenRenderPass = VK_NULL_HANDLE;
     VkPipelineLayout opaquePipelineLayout = VK_NULL_HANDLE;
     VkPipelineCache opaquePipelineCache = VK_NULL_HANDLE;
     std::array<std::string, 2> opaqueShaderEntryNames = {"main", "main"};
@@ -145,6 +330,17 @@ namespace Monolith
     VkShaderModule opaqueVertexShaderModule = VK_NULL_HANDLE;
     VkShaderModule opaqueFragmentShaderModule = VK_NULL_HANDLE;
     VkPipeline opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    std::unordered_map<uint8_t, VkPipeline> opaquePipelineCacheByKey;
+    std::unordered_map<const Mesh *, MeshGpuBuffers> opaqueMeshGpuBuffers;
+    std::unordered_map<std::string, OffscreenRenderTarget> offscreenTargets;
+    VkDescriptorSetLayout opaqueMaterialSetLayout = VK_NULL_HANDLE;
+    VkDescriptorPool opaqueMaterialDescriptorPool = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSet> opaqueMaterialDescriptorSets;
+    VkBuffer opaqueMaterialBuffer = VK_NULL_HANDLE;
+    VkDeviceMemory opaqueMaterialBufferMemory = VK_NULL_HANDLE;
+    void *opaqueMaterialBufferMapped = nullptr;
+    VkBuffer opaqueFallbackIndexBuffer = VK_NULL_HANDLE;
+    VkDeviceMemory opaqueFallbackIndexBufferMemory = VK_NULL_HANDLE;
     bool opaqueShaderPipelineScaffoldReady = false;
     bool opaqueGraphicsPipelineScaffoldReady = false;
     bool opaqueGraphicsPipelineExecutable = false;
@@ -153,6 +349,16 @@ namespace Monolith
     std::vector<VkFramebuffer> opaqueFramebuffers;
     std::vector<VkCommandBuffer> commandBuffers;
     std::vector<bool> imageWasPresented;
+    VkBuffer colorReadbackBuffer = VK_NULL_HANDLE;
+    VkDeviceMemory colorReadbackMemory = VK_NULL_HANDLE;
+    VkBuffer depthReadbackBuffer = VK_NULL_HANDLE;
+    VkDeviceMemory depthReadbackMemory = VK_NULL_HANDLE;
+    VkDeviceSize colorReadbackSize = 0;
+    VkDeviceSize depthReadbackSize = 0;
+    bool supportsColorReadback = false;
+    bool supportsDepthReadback = false;
+    bool hasColorReadbackData = false;
+    bool hasDepthReadbackData = false;
     VkCommandPool commandPool = VK_NULL_HANDLE;
     VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
     VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
@@ -167,6 +373,16 @@ namespace Monolith
     constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId)
     {
       return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+    }
+
+    uint8_t PackOpaquePipelineKey(const VulkanRenderBackend::OpaquePipelineKey &key)
+    {
+      uint8_t packed = 0u;
+      packed |= key.usesAlbedoMap ? (1u << 0) : 0u;
+      packed |= key.usesCustomShader ? (1u << 1) : 0u;
+      packed |= key.writesDepth ? (1u << 2) : 0u;
+      packed |= key.depthTestEnabled ? (1u << 3) : 0u;
+      return packed;
     }
 
   } // namespace
@@ -215,10 +431,10 @@ namespace Monolith
     RenderBackendCapabilities caps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
     caps.supportsDebugDraw = false;
     caps.supportsDebugLabels = false;
-    caps.supportsOffscreenTargets = false;
-    caps.supportsNativeTextureHandles = false;
-    caps.supportsReadback = false;
-    caps.supportsDepthReadback = false;
+    caps.supportsOffscreenTargets = true;
+    caps.supportsNativeTextureHandles = true;
+    caps.supportsReadback = m_context && m_context->supportsColorReadback;
+    caps.supportsDepthReadback = m_context && m_context->supportsDepthReadback;
     caps.supportsDebugHud = false;
     caps.supportsComputePasses = false;
     caps.supportsGpuTimestamps = false;
@@ -252,6 +468,16 @@ namespace Monolith
   bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const
   {
     return HasOpaqueShaderPipelineScaffold() && m_context && m_context->opaqueGraphicsPipelineScaffoldReady;
+  }
+
+  bool VulkanRenderBackend::HasOpaqueDrawExecutionReady() const
+  {
+    return HasOpaqueGraphicsPipelineScaffold() && m_context &&
+           m_context->opaqueGraphicsPipelineExecutable &&
+           m_context->opaqueFallbackIndexBuffer != VK_NULL_HANDLE &&
+           m_context->opaqueMaterialSetLayout != VK_NULL_HANDLE &&
+           !m_context->opaqueMaterialDescriptorSets.empty() &&
+           m_context->opaqueMaterialBufferMapped != nullptr;
   }
 
   bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **outInstance,
@@ -320,6 +546,746 @@ namespace Monolith
 
     m_pendingOverlayRenderCallback = callback;
     m_pendingOverlayRenderUserData = userData;
+  }
+
+  bool VulkanRenderBackend::ReadbackColorBgr8(int width,
+                                              int height,
+                                              std::vector<uint8_t> &outPixels,
+                                              std::string *outError)
+  {
+    if (!m_context || !m_context->supportsColorReadback || m_context->colorReadbackBuffer == VK_NULL_HANDLE)
+    {
+      if (outError)
+        *outError =
+            "Vulkan color readback is unavailable (swapchain transfer-source usage not supported).";
+      return false;
+    }
+    if (m_frameActive)
+    {
+      if (outError)
+        *outError = "Vulkan color readback must be requested outside active BeginFrame/EndFrame scope.";
+      return false;
+    }
+    if (width <= 0 || height <= 0)
+    {
+      if (outError)
+        *outError = "Vulkan color readback requires positive dimensions.";
+      return false;
+    }
+    if (static_cast<uint32_t>(width) != m_context->swapchainExtent.width ||
+        static_cast<uint32_t>(height) != m_context->swapchainExtent.height)
+    {
+      if (outError)
+      {
+        *outError = "Vulkan color readback dimensions must match swapchain extent (" +
+                    std::to_string(m_context->swapchainExtent.width) + "x" +
+                    std::to_string(m_context->swapchainExtent.height) + ").";
+      }
+      return false;
+    }
+    if (!m_context->hasColorReadbackData)
+    {
+      if (outError)
+        *outError =
+            "Vulkan color readback buffer has no captured frame yet. Render at least one frame first.";
+      return false;
+    }
+
+    if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+                 m_lastError,
+                 "vkWaitForFences(colorReadback)"))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    const size_t pixelCount =
+        static_cast<size_t>(m_context->swapchainExtent.width) * m_context->swapchainExtent.height;
+    void *mapped = nullptr;
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             m_context->colorReadbackMemory,
+                             0,
+                             m_context->colorReadbackSize,
+                             0,
+                             &mapped),
+                 m_lastError,
+                 "vkMapMemory(colorReadback)"))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    outPixels.resize(pixelCount * 3u);
+    const auto *src = static_cast<const uint8_t *>(mapped);
+    const bool formatIsBgra = m_context->swapchainFormat == VK_FORMAT_B8G8R8A8_UNORM ||
+                              m_context->swapchainFormat == VK_FORMAT_B8G8R8A8_SRGB;
+    for (uint32_t y = 0; y < m_context->swapchainExtent.height; ++y)
+    {
+      const uint32_t srcY = m_context->swapchainExtent.height - 1u - y;
+      for (uint32_t x = 0; x < m_context->swapchainExtent.width; ++x)
+      {
+        const size_t srcIndex = (static_cast<size_t>(srcY) * m_context->swapchainExtent.width + x) * 4u;
+        const size_t dstIndex = (static_cast<size_t>(y) * m_context->swapchainExtent.width + x) * 3u;
+        if (formatIsBgra)
+        {
+          outPixels[dstIndex + 0] = src[srcIndex + 0];
+          outPixels[dstIndex + 1] = src[srcIndex + 1];
+          outPixels[dstIndex + 2] = src[srcIndex + 2];
+        }
+        else
+        {
+          outPixels[dstIndex + 0] = src[srcIndex + 2];
+          outPixels[dstIndex + 1] = src[srcIndex + 1];
+          outPixels[dstIndex + 2] = src[srcIndex + 0];
+        }
+      }
+    }
+
+    vkUnmapMemory(m_context->device, m_context->colorReadbackMemory);
+    return true;
+  }
+
+  bool VulkanRenderBackend::ReadbackDepth32F(int width,
+                                             int height,
+                                             std::vector<float> &outDepth,
+                                             std::string *outError)
+  {
+    if (!m_context || !m_context->supportsDepthReadback || m_context->depthReadbackBuffer == VK_NULL_HANDLE)
+    {
+      if (outError)
+      {
+        *outError =
+            "Vulkan depth readback is unavailable (depth transfer-source format support not available).";
+      }
+      return false;
+    }
+    if (m_frameActive)
+    {
+      if (outError)
+        *outError = "Vulkan depth readback must be requested outside active BeginFrame/EndFrame scope.";
+      return false;
+    }
+    if (width <= 0 || height <= 0)
+    {
+      if (outError)
+        *outError = "Vulkan depth readback requires positive dimensions.";
+      return false;
+    }
+    if (static_cast<uint32_t>(width) != m_context->swapchainExtent.width ||
+        static_cast<uint32_t>(height) != m_context->swapchainExtent.height)
+    {
+      if (outError)
+      {
+        *outError = "Vulkan depth readback dimensions must match swapchain extent (" +
+                    std::to_string(m_context->swapchainExtent.width) + "x" +
+                    std::to_string(m_context->swapchainExtent.height) + ").";
+      }
+      return false;
+    }
+    if (!m_context->hasDepthReadbackData)
+    {
+      if (outError)
+        *outError =
+            "Vulkan depth readback buffer has no captured frame yet. Render at least one frame first.";
+      return false;
+    }
+
+    if (!CheckVk(vkWaitForFences(m_context->device, 1, &m_context->inFlightFence, VK_TRUE, UINT64_MAX),
+                 m_lastError,
+                 "vkWaitForFences(depthReadback)"))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    const size_t pixelCount =
+        static_cast<size_t>(m_context->swapchainExtent.width) * m_context->swapchainExtent.height;
+    void *mapped = nullptr;
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             m_context->depthReadbackMemory,
+                             0,
+                             m_context->depthReadbackSize,
+                             0,
+                             &mapped),
+                 m_lastError,
+                 "vkMapMemory(depthReadback)"))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    outDepth.resize(pixelCount);
+    const auto *src = static_cast<const float *>(mapped);
+    for (uint32_t y = 0; y < m_context->swapchainExtent.height; ++y)
+    {
+      const uint32_t srcY = m_context->swapchainExtent.height - 1u - y;
+      for (uint32_t x = 0; x < m_context->swapchainExtent.width; ++x)
+      {
+        const size_t srcIndex = static_cast<size_t>(srcY) * m_context->swapchainExtent.width + x;
+        const size_t dstIndex = static_cast<size_t>(y) * m_context->swapchainExtent.width + x;
+        outDepth[dstIndex] = src[srcIndex];
+      }
+    }
+
+    vkUnmapMemory(m_context->device, m_context->depthReadbackMemory);
+    return true;
+  }
+
+  bool VulkanRenderBackend::EnsureEditorViewportRenderTarget(uint32_t width,
+                                                             uint32_t height,
+                                                             std::string *outError)
+  {
+    const bool ok = EnsureOffscreenRenderTarget(kEditorViewportTargetKey, width, height);
+    if (!ok && outError)
+      *outError = m_lastError;
+    return ok;
+  }
+
+  bool VulkanRenderBackend::TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                                   bool needsYFlip,
+                                                                   std::string *outError)
+  {
+    const bool ok = TryGetOffscreenRenderTargetHandle(kEditorViewportTargetKey, outHandle, needsYFlip);
+    if (!ok && outError)
+      *outError = m_lastError;
+    return ok;
+  }
+
+  bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &targetKey,
+                                                        uint32_t width,
+                                                        uint32_t height)
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE || m_context->graphicsQueue == VK_NULL_HANDLE)
+    {
+      m_lastError = "Cannot create Vulkan offscreen target before backend initialization.";
+      return false;
+    }
+    if (targetKey.empty())
+    {
+      m_lastError = "Vulkan offscreen target key cannot be empty.";
+      return false;
+    }
+    if (width == 0 || height == 0)
+    {
+      m_lastError = "Vulkan offscreen target dimensions must be non-zero.";
+      return false;
+    }
+
+    auto it = m_context->offscreenTargets.find(targetKey);
+    if (it != m_context->offscreenTargets.end() &&
+        it->second.width == width &&
+        it->second.height == height &&
+        it->second.readyForSampling)
+    {
+      return true;
+    }
+
+    uint64_t previousGeneration = 0;
+    if (it != m_context->offscreenTargets.end())
+      previousGeneration = it->second.generation;
+
+    DestroyOffscreenRenderTargetResources(targetKey);
+    return CreateOffscreenRenderTargetResources(targetKey, width, height, previousGeneration);
+  }
+
+  bool VulkanRenderBackend::TryGetOffscreenRenderTargetHandle(const std::string &targetKey,
+                                                              RenderTargetHandle *outHandle,
+                                                              bool needsYFlip)
+  {
+    if (!outHandle)
+      return false;
+    *outHandle = {};
+    if (!m_context)
+    {
+      m_lastError = "Vulkan offscreen target handle request requires an initialized backend.";
+      return false;
+    }
+
+    const auto it = m_context->offscreenTargets.find(targetKey);
+    if (it == m_context->offscreenTargets.end())
+    {
+      m_lastError = "Vulkan offscreen target handle request references an unknown target key: " + targetKey;
+      return false;
+    }
+
+    return TryRegisterOffscreenTargetImGuiDescriptor(targetKey, outHandle, needsYFlip);
+  }
+
+  bool VulkanRenderBackend::TryGetOffscreenRenderTargetMetadata(const std::string &targetKey,
+                                                                OffscreenTargetMetadata *outMetadata) const
+  {
+    if (!outMetadata || !m_context)
+      return false;
+
+    const auto it = m_context->offscreenTargets.find(targetKey);
+    if (it == m_context->offscreenTargets.end())
+      return false;
+
+    const Context::OffscreenRenderTarget &target = it->second;
+    outMetadata->width = target.width;
+    outMetadata->height = target.height;
+    outMetadata->generation = target.generation;
+    outMetadata->readyForSampling = target.readyForSampling;
+    outMetadata->hasImGuiDescriptor = target.imguiDescriptorSet != VK_NULL_HANDLE;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOffscreenRenderTarget(const std::string &targetKey)
+  {
+    DestroyOffscreenRenderTargetResources(targetKey);
+  }
+
+  void VulkanRenderBackend::DestroyAllOffscreenRenderTargets()
+  {
+    if (!m_context)
+      return;
+
+    std::vector<std::string> keys;
+    keys.reserve(m_context->offscreenTargets.size());
+    for (const auto &entry : m_context->offscreenTargets)
+      keys.push_back(entry.first);
+
+    for (const std::string &key : keys)
+      DestroyOffscreenRenderTargetResources(key);
+  }
+
+  bool VulkanRenderBackend::EnsureOffscreenRenderPass()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return false;
+    if (m_context->offscreenRenderPass != VK_NULL_HANDLE)
+      return true;
+
+    const VkAttachmentDescription colorAttachment{
+        .flags = 0,
+        .format = kOffscreenTargetFormat,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+        .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+        .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
+    const VkAttachmentReference colorAttachmentRef{
+        .attachment = 0,
+        .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+    };
+    const VkSubpassDescription subpass{
+        .flags = 0,
+        .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+        .inputAttachmentCount = 0,
+        .pInputAttachments = nullptr,
+        .colorAttachmentCount = 1,
+        .pColorAttachments = &colorAttachmentRef,
+        .pResolveAttachments = nullptr,
+        .pDepthStencilAttachment = nullptr,
+        .preserveAttachmentCount = 0,
+        .pPreserveAttachments = nullptr,
+    };
+    const std::array<VkSubpassDependency, 2> dependencies = {
+        VkSubpassDependency{
+            .srcSubpass = VK_SUBPASS_EXTERNAL,
+            .dstSubpass = 0,
+            .srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+            .srcAccessMask = 0,
+            .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            .dependencyFlags = 0,
+        },
+        VkSubpassDependency{
+            .srcSubpass = 0,
+            .dstSubpass = VK_SUBPASS_EXTERNAL,
+            .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+            .dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+            .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+            .dependencyFlags = 0,
+        }};
+
+    const VkRenderPassCreateInfo renderPassInfo{
+        .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .attachmentCount = 1,
+        .pAttachments = &colorAttachment,
+        .subpassCount = 1,
+        .pSubpasses = &subpass,
+        .dependencyCount = static_cast<uint32_t>(dependencies.size()),
+        .pDependencies = dependencies.data(),
+    };
+    return CheckVk(vkCreateRenderPass(m_context->device,
+                                      &renderPassInfo,
+                                      nullptr,
+                                      &m_context->offscreenRenderPass),
+                   m_lastError,
+                   "vkCreateRenderPass(offscreen)");
+  }
+
+  void VulkanRenderBackend::DestroyOffscreenRenderPass()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+    if (m_context->offscreenRenderPass != VK_NULL_HANDLE)
+    {
+      vkDestroyRenderPass(m_context->device, m_context->offscreenRenderPass, nullptr);
+      m_context->offscreenRenderPass = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOffscreenRenderTargetResources(const std::string &targetKey,
+                                                                 uint32_t width,
+                                                                 uint32_t height,
+                                                                 uint64_t previousGeneration)
+  {
+    if (!EnsureOffscreenRenderPass())
+      return false;
+
+    Context::OffscreenRenderTarget target;
+    target.width = width;
+    target.height = height;
+    target.generation = previousGeneration + 1;
+
+    const VkImageCreateInfo imageInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = kOffscreenTargetFormat,
+        .extent = {width, height, 1},
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                 VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    if (!CheckVk(vkCreateImage(m_context->device, &imageInfo, nullptr, &target.image),
+                 m_lastError,
+                 "vkCreateImage(offscreen)"))
+    {
+      return false;
+    }
+
+    VkMemoryRequirements imageRequirements{};
+    vkGetImageMemoryRequirements(m_context->device, target.image, &imageRequirements);
+    const uint32_t memoryTypeIndex =
+        FindMemoryTypeIndex(m_context->physicalDevice,
+                            imageRequirements.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (memoryTypeIndex == kInvalidQueueFamily)
+    {
+      m_lastError = "No Vulkan device-local memory type available for offscreen render target.";
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkMemoryAllocateInfo memoryInfo{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .allocationSize = imageRequirements.size,
+        .memoryTypeIndex = memoryTypeIndex,
+    };
+    if (!CheckVk(vkAllocateMemory(m_context->device, &memoryInfo, nullptr, &target.memory),
+                 m_lastError,
+                 "vkAllocateMemory(offscreen)"))
+    {
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+    if (!CheckVk(vkBindImageMemory(m_context->device, target.image, target.memory, 0),
+                 m_lastError,
+                 "vkBindImageMemory(offscreen)"))
+    {
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkImageViewCreateInfo imageViewInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = target.image,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = kOffscreenTargetFormat,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+    };
+    if (!CheckVk(vkCreateImageView(m_context->device, &imageViewInfo, nullptr, &target.imageView),
+                 m_lastError,
+                 "vkCreateImageView(offscreen)"))
+    {
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkSamplerCreateInfo samplerInfo{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .magFilter = VK_FILTER_LINEAR,
+        .minFilter = VK_FILTER_LINEAR,
+        .mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .mipLodBias = 0.0f,
+        .anisotropyEnable = VK_FALSE,
+        .maxAnisotropy = 1.0f,
+        .compareEnable = VK_FALSE,
+        .compareOp = VK_COMPARE_OP_ALWAYS,
+        .minLod = 0.0f,
+        .maxLod = 0.0f,
+        .borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
+        .unnormalizedCoordinates = VK_FALSE,
+    };
+    if (!CheckVk(vkCreateSampler(m_context->device, &samplerInfo, nullptr, &target.sampler),
+                 m_lastError,
+                 "vkCreateSampler(offscreen)"))
+    {
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkImageView framebufferAttachment = target.imageView;
+    const VkFramebufferCreateInfo framebufferInfo{
+        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .renderPass = m_context->offscreenRenderPass,
+        .attachmentCount = 1,
+        .pAttachments = &framebufferAttachment,
+        .width = width,
+        .height = height,
+        .layers = 1,
+    };
+    if (!CheckVk(vkCreateFramebuffer(m_context->device, &framebufferInfo, nullptr, &target.framebuffer),
+                 m_lastError,
+                 "vkCreateFramebuffer(offscreen)"))
+    {
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    VkCommandBuffer commandBuffer = VK_NULL_HANDLE;
+    const VkCommandBufferAllocateInfo commandBufferInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .commandPool = m_context->commandPool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = 1,
+    };
+    if (!CheckVk(vkAllocateCommandBuffers(m_context->device, &commandBufferInfo, &commandBuffer),
+                 m_lastError,
+                 "vkAllocateCommandBuffers(offscreen)"))
+    {
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkCommandBufferBeginInfo beginInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .pNext = nullptr,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+        .pInheritanceInfo = nullptr,
+    };
+    if (!CheckVk(vkBeginCommandBuffer(commandBuffer, &beginInfo),
+                 m_lastError,
+                 "vkBeginCommandBuffer(offscreen)"))
+    {
+      vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkClearValue clearValue{
+        .color = {{0.14f, 0.14f, 0.14f, 1.0f}},
+    };
+    const VkRenderPassBeginInfo renderPassInfo{
+        .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
+        .pNext = nullptr,
+        .renderPass = m_context->offscreenRenderPass,
+        .framebuffer = target.framebuffer,
+        .renderArea = {{0, 0}, {width, height}},
+        .clearValueCount = 1,
+        .pClearValues = &clearValue,
+    };
+    vkCmdBeginRenderPass(commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdEndRenderPass(commandBuffer);
+
+    if (!CheckVk(vkEndCommandBuffer(commandBuffer), m_lastError, "vkEndCommandBuffer(offscreen)"))
+    {
+      vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    VkFence fence = VK_NULL_HANDLE;
+    const VkFenceCreateInfo fenceInfo{
+        .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+    };
+    if (!CheckVk(vkCreateFence(m_context->device, &fenceInfo, nullptr, &fence),
+                 m_lastError,
+                 "vkCreateFence(offscreen)"))
+    {
+      vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+
+    const VkSubmitInfo submitInfo{
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext = nullptr,
+        .waitSemaphoreCount = 0,
+        .pWaitSemaphores = nullptr,
+        .pWaitDstStageMask = nullptr,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &commandBuffer,
+        .signalSemaphoreCount = 0,
+        .pSignalSemaphores = nullptr,
+    };
+    if (!CheckVk(vkQueueSubmit(m_context->graphicsQueue, 1, &submitInfo, fence),
+                 m_lastError,
+                 "vkQueueSubmit(offscreen)"))
+    {
+      vkDestroyFence(m_context->device, fence, nullptr);
+      vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+    if (!CheckVk(vkWaitForFences(m_context->device, 1, &fence, VK_TRUE, UINT64_MAX),
+                 m_lastError,
+                 "vkWaitForFences(offscreen)"))
+    {
+      vkDestroyFence(m_context->device, fence, nullptr);
+      vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+      vkDestroyImage(m_context->device, target.image, nullptr);
+      return false;
+    }
+    vkDestroyFence(m_context->device, fence, nullptr);
+    vkFreeCommandBuffers(m_context->device, m_context->commandPool, 1, &commandBuffer);
+
+    target.readyForSampling = true;
+    target.currentLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    m_context->offscreenTargets[targetKey] = target;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOffscreenRenderTargetResources(const std::string &targetKey)
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    const auto it = m_context->offscreenTargets.find(targetKey);
+    if (it == m_context->offscreenTargets.end())
+      return;
+
+    Context::OffscreenRenderTarget &target = it->second;
+
+    if (target.imguiDescriptorSet != VK_NULL_HANDLE && IsImGuiVulkanTextureApiReady())
+    {
+      ImGui_ImplVulkan_RemoveTexture(target.imguiDescriptorSet);
+      target.imguiDescriptorSet = VK_NULL_HANDLE;
+    }
+
+    if (target.framebuffer != VK_NULL_HANDLE)
+      vkDestroyFramebuffer(m_context->device, target.framebuffer, nullptr);
+    if (target.sampler != VK_NULL_HANDLE)
+      vkDestroySampler(m_context->device, target.sampler, nullptr);
+    if (target.imageView != VK_NULL_HANDLE)
+      vkDestroyImageView(m_context->device, target.imageView, nullptr);
+    if (target.image != VK_NULL_HANDLE)
+      vkDestroyImage(m_context->device, target.image, nullptr);
+    if (target.memory != VK_NULL_HANDLE)
+      vkFreeMemory(m_context->device, target.memory, nullptr);
+
+    m_context->offscreenTargets.erase(it);
+  }
+
+  bool VulkanRenderBackend::TryRegisterOffscreenTargetImGuiDescriptor(const std::string &targetKey,
+                                                                      RenderTargetHandle *outHandle,
+                                                                      bool needsYFlip)
+  {
+    if (!m_context || !outHandle)
+      return false;
+
+    const auto it = m_context->offscreenTargets.find(targetKey);
+    if (it == m_context->offscreenTargets.end())
+      return false;
+
+    Context::OffscreenRenderTarget &target = it->second;
+    if (!target.readyForSampling || target.imageView == VK_NULL_HANDLE || target.sampler == VK_NULL_HANDLE)
+    {
+      m_lastError = "Vulkan offscreen target is not ready for sampling: " + targetKey;
+      return false;
+    }
+
+    if (target.imguiDescriptorSet == VK_NULL_HANDLE)
+    {
+      if (!IsImGuiVulkanTextureApiReady())
+      {
+        m_lastError = "ImGui Vulkan texture registration is not ready for offscreen target: " + targetKey;
+        return false;
+      }
+      target.imguiDescriptorSet =
+          ImGui_ImplVulkan_AddTexture(target.sampler, target.imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+      if (target.imguiDescriptorSet == VK_NULL_HANDLE)
+      {
+        m_lastError = "Failed to register Vulkan offscreen target with ImGui texture API: " + targetKey;
+        return false;
+      }
+    }
+
+    *outHandle = RenderTargetHandle::VulkanDescriptorSet(reinterpret_cast<void *>(target.imguiDescriptorSet),
+                                                         needsYFlip,
+                                                         target.width,
+                                                         target.height,
+                                                         target.generation);
+    return true;
   }
 
   bool VulkanRenderBackend::Initialize(void *nativeWindowHandle)
@@ -564,12 +1530,19 @@ namespace Monolith
       return false;
     }
 
+    if (!CreateOpaqueMaterialBindingScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    const VkDescriptorSetLayout setLayouts[] = {m_context->opaqueMaterialSetLayout};
     const VkPipelineLayoutCreateInfo pipelineLayoutInfo{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .setLayoutCount = 0,
-        .pSetLayouts = nullptr,
+        .setLayoutCount = 1,
+        .pSetLayouts = setLayouts,
         .pushConstantRangeCount = 0,
         .pPushConstantRanges = nullptr,
     };
@@ -585,6 +1558,12 @@ namespace Monolith
     }
 
     if (!CreateOpaquePipelineCreationScaffold())
+    {
+      Shutdown();
+      return false;
+    }
+
+    if (!CreateOpaqueDrawIndexBuffer())
     {
       Shutdown();
       return false;
@@ -613,10 +1592,16 @@ namespace Monolith
     if (m_context->device != VK_NULL_HANDLE)
       vkDeviceWaitIdle(m_context->device);
 
+    DestroyAllOffscreenRenderTargets();
+    DestroyOffscreenRenderPass();
+
     DestroyOpaqueGraphicsPipelineScaffold();
     DestroySwapchain();
 
     DestroyOpaqueShaderPipelineScaffold();
+    DestroyOpaqueDrawIndexBuffer();
+    DestroyOpaqueMeshGpuBuffers();
+    DestroyOpaqueMaterialBindingScaffold();
     DestroyOpaquePipelineCreationScaffold();
 
     if (m_context->opaquePipelineLayout != VK_NULL_HANDLE)
@@ -648,6 +1633,8 @@ namespace Monolith
       return;
 
     DestroyOpaqueRasterScaffold();
+    DestroyReadbackBuffers();
+    DestroyDepthResources();
 
     if (!m_context->commandBuffers.empty())
     {
@@ -671,8 +1658,230 @@ namespace Monolith
     }
   }
 
+  bool VulkanRenderBackend::CreateDepthResources()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE || m_context->physicalDevice == VK_NULL_HANDLE)
+      return false;
+
+    VkFormat depthFormat = VK_FORMAT_UNDEFINED;
+    if (!FindSupportedDepthFormat(m_context->physicalDevice, false, &depthFormat))
+    {
+      m_lastError = "Failed to find a Vulkan depth format with depth-stencil attachment support.";
+      return false;
+    }
+    const bool depthTransferSrcSupported =
+        HasFormatFeature(m_context->physicalDevice, depthFormat, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    VkImageUsageFlags depthUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    if (depthTransferSrcSupported)
+      depthUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+    const VkImageCreateInfo depthImageInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = depthFormat,
+        .extent = {m_context->swapchainExtent.width, m_context->swapchainExtent.height, 1},
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = depthUsage,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    if (!CheckVk(vkCreateImage(m_context->device, &depthImageInfo, nullptr, &m_context->depthImage),
+                 m_lastError,
+                 "vkCreateImage(depth)"))
+    {
+      return false;
+    }
+
+    VkMemoryRequirements memoryRequirements{};
+    vkGetImageMemoryRequirements(m_context->device, m_context->depthImage, &memoryRequirements);
+    const uint32_t memoryTypeIndex =
+        FindMemoryTypeIndex(m_context->physicalDevice,
+                            memoryRequirements.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (memoryTypeIndex == kInvalidQueueFamily)
+    {
+      m_lastError = "Failed to find Vulkan device-local memory for depth image allocation.";
+      return false;
+    }
+
+    const VkMemoryAllocateInfo allocInfo{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .allocationSize = memoryRequirements.size,
+        .memoryTypeIndex = memoryTypeIndex,
+    };
+    if (!CheckVk(vkAllocateMemory(m_context->device, &allocInfo, nullptr, &m_context->depthImageMemory),
+                 m_lastError,
+                 "vkAllocateMemory(depth)"))
+    {
+      return false;
+    }
+
+    if (!CheckVk(vkBindImageMemory(m_context->device, m_context->depthImage, m_context->depthImageMemory, 0),
+                 m_lastError,
+                 "vkBindImageMemory(depth)"))
+    {
+      return false;
+    }
+
+    const VkImageAspectFlags depthAspect =
+        depthFormat == VK_FORMAT_D32_SFLOAT ? VK_IMAGE_ASPECT_DEPTH_BIT
+                                            : static_cast<VkImageAspectFlags>(VK_IMAGE_ASPECT_DEPTH_BIT);
+    const VkImageViewCreateInfo depthViewInfo{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .image = m_context->depthImage,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = depthFormat,
+        .components = {VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY,
+                       VK_COMPONENT_SWIZZLE_IDENTITY},
+        .subresourceRange = {depthAspect, 0, 1, 0, 1},
+    };
+    if (!CheckVk(vkCreateImageView(m_context->device, &depthViewInfo, nullptr, &m_context->depthImageView),
+                 m_lastError,
+                 "vkCreateImageView(depth)"))
+    {
+      return false;
+    }
+
+    m_context->depthFormat = depthFormat;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyDepthResources()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->depthImageView != VK_NULL_HANDLE)
+    {
+      vkDestroyImageView(m_context->device, m_context->depthImageView, nullptr);
+      m_context->depthImageView = VK_NULL_HANDLE;
+    }
+    if (m_context->depthImage != VK_NULL_HANDLE)
+    {
+      vkDestroyImage(m_context->device, m_context->depthImage, nullptr);
+      m_context->depthImage = VK_NULL_HANDLE;
+    }
+    if (m_context->depthImageMemory != VK_NULL_HANDLE)
+    {
+      vkFreeMemory(m_context->device, m_context->depthImageMemory, nullptr);
+      m_context->depthImageMemory = VK_NULL_HANDLE;
+    }
+    m_context->depthFormat = VK_FORMAT_UNDEFINED;
+  }
+
+  bool VulkanRenderBackend::EnsureReadbackBuffers()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return false;
+
+    DestroyReadbackBuffers();
+
+    const VkDeviceSize colorBytes =
+        static_cast<VkDeviceSize>(m_context->swapchainExtent.width) * m_context->swapchainExtent.height *
+        4u;
+    if (m_context->supportsColorReadback)
+    {
+      if (!CreateHostVisibleBuffer(m_context->physicalDevice,
+                                   m_context->device,
+                                   colorBytes,
+                                   VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                   &m_context->colorReadbackBuffer,
+                                   &m_context->colorReadbackMemory,
+                                   m_lastError,
+                                   "vkCreateBuffer(colorReadback)"))
+      {
+        m_context->supportsColorReadback = false;
+      }
+      else
+      {
+        m_context->colorReadbackSize = colorBytes;
+      }
+    }
+
+    if (m_context->supportsDepthReadback)
+    {
+      const VkDeviceSize depthBytes =
+          static_cast<VkDeviceSize>(m_context->swapchainExtent.width) * m_context->swapchainExtent.height *
+          sizeof(float);
+      if (!CreateHostVisibleBuffer(m_context->physicalDevice,
+                                   m_context->device,
+                                   depthBytes,
+                                   VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                   &m_context->depthReadbackBuffer,
+                                   &m_context->depthReadbackMemory,
+                                   m_lastError,
+                                   "vkCreateBuffer(depthReadback)"))
+      {
+        m_context->supportsDepthReadback = false;
+      }
+      else
+      {
+        m_context->depthReadbackSize = depthBytes;
+      }
+    }
+
+    m_context->hasColorReadbackData = false;
+    m_context->hasDepthReadbackData = false;
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyReadbackBuffers()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->colorReadbackBuffer != VK_NULL_HANDLE)
+    {
+      vkDestroyBuffer(m_context->device, m_context->colorReadbackBuffer, nullptr);
+      m_context->colorReadbackBuffer = VK_NULL_HANDLE;
+    }
+    if (m_context->colorReadbackMemory != VK_NULL_HANDLE)
+    {
+      vkFreeMemory(m_context->device, m_context->colorReadbackMemory, nullptr);
+      m_context->colorReadbackMemory = VK_NULL_HANDLE;
+    }
+    if (m_context->depthReadbackBuffer != VK_NULL_HANDLE)
+    {
+      vkDestroyBuffer(m_context->device, m_context->depthReadbackBuffer, nullptr);
+      m_context->depthReadbackBuffer = VK_NULL_HANDLE;
+    }
+    if (m_context->depthReadbackMemory != VK_NULL_HANDLE)
+    {
+      vkFreeMemory(m_context->device, m_context->depthReadbackMemory, nullptr);
+      m_context->depthReadbackMemory = VK_NULL_HANDLE;
+    }
+
+    m_context->colorReadbackSize = 0;
+    m_context->depthReadbackSize = 0;
+    m_context->hasColorReadbackData = false;
+    m_context->hasDepthReadbackData = false;
+  }
+
   bool VulkanRenderBackend::CreateOpaqueRasterScaffold()
   {
+    const VkAttachmentDescription depthAttachment{
+        .flags = 0,
+        .format = m_context->depthFormat,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+        .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+        .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    };
     const VkAttachmentDescription colorAttachment{
         .flags = 0,
         .format = m_context->swapchainFormat,
@@ -684,7 +1893,9 @@ namespace Monolith
         .initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
         .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
     };
+    const std::array<VkAttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
     const VkAttachmentReference colorAttachmentRef{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
+    const VkAttachmentReference depthAttachmentRef{1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
     const VkSubpassDescription subpass{
         .flags = 0,
         .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -693,25 +1904,28 @@ namespace Monolith
         .colorAttachmentCount = 1,
         .pColorAttachments = &colorAttachmentRef,
         .pResolveAttachments = nullptr,
-        .pDepthStencilAttachment = nullptr,
+        .pDepthStencilAttachment = &depthAttachmentRef,
         .preserveAttachmentCount = 0,
         .pPreserveAttachments = nullptr,
     };
     const VkSubpassDependency dependency{
         .srcSubpass = VK_SUBPASS_EXTERNAL,
         .dstSubpass = 0,
-        .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-        .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                        VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+        .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                        VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
         .srcAccessMask = 0,
-        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                         VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
         .dependencyFlags = 0,
     };
     const VkRenderPassCreateInfo renderPassInfo{
         .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .attachmentCount = 1,
-        .pAttachments = &colorAttachment,
+        .attachmentCount = static_cast<uint32_t>(attachments.size()),
+        .pAttachments = attachments.data(),
         .subpassCount = 1,
         .pSubpasses = &subpass,
         .dependencyCount = 1,
@@ -730,14 +1944,17 @@ namespace Monolith
     m_context->opaqueFramebuffers.resize(m_context->swapchainImageViews.size());
     for (size_t i = 0; i < m_context->swapchainImageViews.size(); ++i)
     {
-      const VkImageView attachment = m_context->swapchainImageViews[i];
+      const std::array<VkImageView, 2> framebufferAttachments = {
+          m_context->swapchainImageViews[i],
+          m_context->depthImageView,
+      };
       const VkFramebufferCreateInfo framebufferInfo{
           .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
           .pNext = nullptr,
           .flags = 0,
           .renderPass = m_context->opaqueRenderPass,
-          .attachmentCount = 1,
-          .pAttachments = &attachment,
+          .attachmentCount = static_cast<uint32_t>(framebufferAttachments.size()),
+          .pAttachments = framebufferAttachments.data(),
           .width = m_context->swapchainExtent.width,
           .height = m_context->swapchainExtent.height,
           .layers = 1,
@@ -802,6 +2019,414 @@ namespace Monolith
       vkDestroyPipelineCache(m_context->device, m_context->opaquePipelineCache, nullptr);
       m_context->opaquePipelineCache = VK_NULL_HANDLE;
     }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueMaterialBindingScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return false;
+
+    const VkDescriptorSetLayoutBinding materialBinding{
+        .binding = 0,
+        .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .descriptorCount = 1,
+        .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+        .pImmutableSamplers = nullptr,
+    };
+    const VkDescriptorSetLayoutCreateInfo setLayoutInfo{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .bindingCount = 1,
+        .pBindings = &materialBinding,
+    };
+    if (!CheckVk(vkCreateDescriptorSetLayout(m_context->device,
+                                             &setLayoutInfo,
+                                             nullptr,
+                                             &m_context->opaqueMaterialSetLayout),
+                 m_lastError,
+                 "vkCreateDescriptorSetLayout(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    const VkDescriptorPoolSize poolSize{
+        .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .descriptorCount = kOpaqueMaterialDescriptorCapacity,
+    };
+    const VkDescriptorPoolCreateInfo poolInfo{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .maxSets = kOpaqueMaterialDescriptorCapacity,
+        .poolSizeCount = 1,
+        .pPoolSizes = &poolSize,
+    };
+    if (!CheckVk(vkCreateDescriptorPool(m_context->device,
+                                        &poolInfo,
+                                        nullptr,
+                                        &m_context->opaqueMaterialDescriptorPool),
+                 m_lastError,
+                 "vkCreateDescriptorPool(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    const VkDeviceSize materialBufferSize =
+        static_cast<VkDeviceSize>(sizeof(OpaqueMaterialGpuData) * kOpaqueMaterialDescriptorCapacity);
+    const VkBufferCreateInfo materialBufferInfo{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = materialBufferSize,
+        .usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    if (!CheckVk(vkCreateBuffer(m_context->device,
+                                &materialBufferInfo,
+                                nullptr,
+                                &m_context->opaqueMaterialBuffer),
+                 m_lastError,
+                 "vkCreateBuffer(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    VkMemoryRequirements materialMemoryRequirements{};
+    vkGetBufferMemoryRequirements(m_context->device,
+                                  m_context->opaqueMaterialBuffer,
+                                  &materialMemoryRequirements);
+    const uint32_t memoryTypeIndex =
+        FindMemoryTypeIndex(m_context->physicalDevice,
+                            materialMemoryRequirements.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (memoryTypeIndex == kInvalidQueueFamily)
+    {
+      m_lastError = "No host-visible Vulkan memory type supports opaque material uniform buffer.";
+      return false;
+    }
+
+    const VkMemoryAllocateInfo materialMemoryAlloc{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .allocationSize = materialMemoryRequirements.size,
+        .memoryTypeIndex = memoryTypeIndex,
+    };
+    if (!CheckVk(vkAllocateMemory(m_context->device,
+                                  &materialMemoryAlloc,
+                                  nullptr,
+                                  &m_context->opaqueMaterialBufferMemory),
+                 m_lastError,
+                 "vkAllocateMemory(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    if (!CheckVk(vkBindBufferMemory(m_context->device,
+                                    m_context->opaqueMaterialBuffer,
+                                    m_context->opaqueMaterialBufferMemory,
+                                    0),
+                 m_lastError,
+                 "vkBindBufferMemory(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             m_context->opaqueMaterialBufferMemory,
+                             0,
+                             materialBufferSize,
+                             0,
+                             &m_context->opaqueMaterialBufferMapped),
+                 m_lastError,
+                 "vkMapMemory(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    std::vector<VkDescriptorSetLayout> setLayouts(kOpaqueMaterialDescriptorCapacity,
+                                                  m_context->opaqueMaterialSetLayout);
+    m_context->opaqueMaterialDescriptorSets.resize(kOpaqueMaterialDescriptorCapacity);
+    const VkDescriptorSetAllocateInfo allocateInfo{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .descriptorPool = m_context->opaqueMaterialDescriptorPool,
+        .descriptorSetCount = kOpaqueMaterialDescriptorCapacity,
+        .pSetLayouts = setLayouts.data(),
+    };
+    if (!CheckVk(vkAllocateDescriptorSets(m_context->device,
+                                          &allocateInfo,
+                                          m_context->opaqueMaterialDescriptorSets.data()),
+                 m_lastError,
+                 "vkAllocateDescriptorSets(opaqueMaterial)"))
+    {
+      return false;
+    }
+
+    for (uint32_t i = 0; i < kOpaqueMaterialDescriptorCapacity; ++i)
+    {
+      const VkDescriptorBufferInfo bufferInfo{
+          .buffer = m_context->opaqueMaterialBuffer,
+          .offset = static_cast<VkDeviceSize>(i * sizeof(OpaqueMaterialGpuData)),
+          .range = sizeof(OpaqueMaterialGpuData),
+      };
+      const VkWriteDescriptorSet write{
+          .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+          .pNext = nullptr,
+          .dstSet = m_context->opaqueMaterialDescriptorSets[i],
+          .dstBinding = 0,
+          .dstArrayElement = 0,
+          .descriptorCount = 1,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .pImageInfo = nullptr,
+          .pBufferInfo = &bufferInfo,
+          .pTexelBufferView = nullptr,
+      };
+      vkUpdateDescriptorSets(m_context->device, 1, &write, 0, nullptr);
+    }
+
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueMaterialBindingScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    m_context->opaqueMaterialDescriptorSets.clear();
+    if (m_context->opaqueMaterialBufferMapped)
+    {
+      vkUnmapMemory(m_context->device, m_context->opaqueMaterialBufferMemory);
+      m_context->opaqueMaterialBufferMapped = nullptr;
+    }
+    if (m_context->opaqueMaterialBuffer != VK_NULL_HANDLE)
+    {
+      vkDestroyBuffer(m_context->device, m_context->opaqueMaterialBuffer, nullptr);
+      m_context->opaqueMaterialBuffer = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueMaterialBufferMemory != VK_NULL_HANDLE)
+    {
+      vkFreeMemory(m_context->device, m_context->opaqueMaterialBufferMemory, nullptr);
+      m_context->opaqueMaterialBufferMemory = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueMaterialDescriptorPool != VK_NULL_HANDLE)
+    {
+      vkDestroyDescriptorPool(m_context->device, m_context->opaqueMaterialDescriptorPool, nullptr);
+      m_context->opaqueMaterialDescriptorPool = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueMaterialSetLayout != VK_NULL_HANDLE)
+    {
+      vkDestroyDescriptorSetLayout(m_context->device, m_context->opaqueMaterialSetLayout, nullptr);
+      m_context->opaqueMaterialSetLayout = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::CreateOpaqueDrawIndexBuffer()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return false;
+
+    const VkBufferCreateInfo bufferInfo{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = sizeof(kFallbackOpaqueIndices),
+        .usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
+    if (!CheckVk(vkCreateBuffer(m_context->device,
+                                &bufferInfo,
+                                nullptr,
+                                &m_context->opaqueFallbackIndexBuffer),
+                 m_lastError,
+                 "vkCreateBuffer(opaqueIndex)"))
+    {
+      return false;
+    }
+
+    VkMemoryRequirements indexMemoryRequirements{};
+    vkGetBufferMemoryRequirements(m_context->device,
+                                  m_context->opaqueFallbackIndexBuffer,
+                                  &indexMemoryRequirements);
+    const uint32_t memoryTypeIndex =
+        FindMemoryTypeIndex(m_context->physicalDevice,
+                            indexMemoryRequirements.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (memoryTypeIndex == kInvalidQueueFamily)
+    {
+      m_lastError = "No host-visible Vulkan memory type supports opaque fallback index buffer.";
+      return false;
+    }
+
+    const VkMemoryAllocateInfo memoryAllocInfo{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .allocationSize = indexMemoryRequirements.size,
+        .memoryTypeIndex = memoryTypeIndex,
+    };
+    if (!CheckVk(vkAllocateMemory(m_context->device,
+                                  &memoryAllocInfo,
+                                  nullptr,
+                                  &m_context->opaqueFallbackIndexBufferMemory),
+                 m_lastError,
+                 "vkAllocateMemory(opaqueIndex)"))
+    {
+      return false;
+    }
+    if (!CheckVk(vkBindBufferMemory(m_context->device,
+                                    m_context->opaqueFallbackIndexBuffer,
+                                    m_context->opaqueFallbackIndexBufferMemory,
+                                    0),
+                 m_lastError,
+                 "vkBindBufferMemory(opaqueIndex)"))
+    {
+      return false;
+    }
+
+    void *mapped = nullptr;
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             m_context->opaqueFallbackIndexBufferMemory,
+                             0,
+                             sizeof(kFallbackOpaqueIndices),
+                             0,
+                             &mapped),
+                 m_lastError,
+                 "vkMapMemory(opaqueIndex)"))
+    {
+      return false;
+    }
+    std::memcpy(mapped, kFallbackOpaqueIndices.data(), sizeof(kFallbackOpaqueIndices));
+    vkUnmapMemory(m_context->device, m_context->opaqueFallbackIndexBufferMemory);
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueDrawIndexBuffer()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    if (m_context->opaqueFallbackIndexBuffer != VK_NULL_HANDLE)
+    {
+      vkDestroyBuffer(m_context->device, m_context->opaqueFallbackIndexBuffer, nullptr);
+      m_context->opaqueFallbackIndexBuffer = VK_NULL_HANDLE;
+    }
+    if (m_context->opaqueFallbackIndexBufferMemory != VK_NULL_HANDLE)
+    {
+      vkFreeMemory(m_context->device, m_context->opaqueFallbackIndexBufferMemory, nullptr);
+      m_context->opaqueFallbackIndexBufferMemory = VK_NULL_HANDLE;
+    }
+  }
+
+  bool VulkanRenderBackend::EnsureOpaqueMeshGpuBuffers(const Mesh &mesh)
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return false;
+
+    if (m_context->opaqueMeshGpuBuffers.find(&mesh) != m_context->opaqueMeshGpuBuffers.end())
+      return true;
+
+    const std::vector<Vertex> &vertices = mesh.GetVertices();
+    const std::vector<uint32_t> &indices = mesh.GetIndices();
+    if (vertices.empty() || indices.empty())
+      return false;
+
+    Context::MeshGpuBuffers gpuBuffers;
+    const VkDeviceSize vertexBufferSize = static_cast<VkDeviceSize>(vertices.size() * sizeof(Vertex));
+    const VkDeviceSize indexBufferSize = static_cast<VkDeviceSize>(indices.size() * sizeof(uint32_t));
+
+    if (!CreateHostVisibleBuffer(m_context->physicalDevice,
+                                 m_context->device,
+                                 vertexBufferSize,
+                                 VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                                 &gpuBuffers.vertexBuffer,
+                                 &gpuBuffers.vertexMemory,
+                                 m_lastError,
+                                 "CreateHostVisibleBuffer(vertex)"))
+    {
+      return false;
+    }
+
+    if (!CreateHostVisibleBuffer(m_context->physicalDevice,
+                                 m_context->device,
+                                 indexBufferSize,
+                                 VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+                                 &gpuBuffers.indexBuffer,
+                                 &gpuBuffers.indexMemory,
+                                 m_lastError,
+                                 "CreateHostVisibleBuffer(index)"))
+    {
+      vkDestroyBuffer(m_context->device, gpuBuffers.vertexBuffer, nullptr);
+      vkFreeMemory(m_context->device, gpuBuffers.vertexMemory, nullptr);
+      return false;
+    }
+
+    void *vertexMapped = nullptr;
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             gpuBuffers.vertexMemory,
+                             0,
+                             vertexBufferSize,
+                             0,
+                             &vertexMapped),
+                 m_lastError,
+                 "vkMapMemory(meshVertex)"))
+    {
+      vkDestroyBuffer(m_context->device, gpuBuffers.indexBuffer, nullptr);
+      vkFreeMemory(m_context->device, gpuBuffers.indexMemory, nullptr);
+      vkDestroyBuffer(m_context->device, gpuBuffers.vertexBuffer, nullptr);
+      vkFreeMemory(m_context->device, gpuBuffers.vertexMemory, nullptr);
+      return false;
+    }
+    std::memcpy(vertexMapped, vertices.data(), static_cast<size_t>(vertexBufferSize));
+    vkUnmapMemory(m_context->device, gpuBuffers.vertexMemory);
+
+    void *indexMapped = nullptr;
+    if (!CheckVk(vkMapMemory(m_context->device,
+                             gpuBuffers.indexMemory,
+                             0,
+                             indexBufferSize,
+                             0,
+                             &indexMapped),
+                 m_lastError,
+                 "vkMapMemory(meshIndex)"))
+    {
+      vkDestroyBuffer(m_context->device, gpuBuffers.indexBuffer, nullptr);
+      vkFreeMemory(m_context->device, gpuBuffers.indexMemory, nullptr);
+      vkDestroyBuffer(m_context->device, gpuBuffers.vertexBuffer, nullptr);
+      vkFreeMemory(m_context->device, gpuBuffers.vertexMemory, nullptr);
+      return false;
+    }
+    std::memcpy(indexMapped, indices.data(), static_cast<size_t>(indexBufferSize));
+    vkUnmapMemory(m_context->device, gpuBuffers.indexMemory);
+
+    gpuBuffers.indexCount = static_cast<uint32_t>(indices.size());
+    m_context->opaqueMeshGpuBuffers.emplace(&mesh, gpuBuffers);
+    return true;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueMeshGpuBuffers()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    for (auto &entry : m_context->opaqueMeshGpuBuffers)
+    {
+      Context::MeshGpuBuffers &gpuBuffers = entry.second;
+      if (gpuBuffers.indexBuffer != VK_NULL_HANDLE)
+        vkDestroyBuffer(m_context->device, gpuBuffers.indexBuffer, nullptr);
+      if (gpuBuffers.indexMemory != VK_NULL_HANDLE)
+        vkFreeMemory(m_context->device, gpuBuffers.indexMemory, nullptr);
+      if (gpuBuffers.vertexBuffer != VK_NULL_HANDLE)
+        vkDestroyBuffer(m_context->device, gpuBuffers.vertexBuffer, nullptr);
+      if (gpuBuffers.vertexMemory != VK_NULL_HANDLE)
+        vkFreeMemory(m_context->device, gpuBuffers.vertexMemory, nullptr);
+    }
+    m_context->opaqueMeshGpuBuffers.clear();
   }
 
   bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold()
@@ -892,11 +2517,17 @@ namespace Monolith
 
   bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold()
   {
-    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
+    const VkPipeline previousPrimaryPipeline = m_context->opaqueGraphicsPipeline;
+    for (auto &entry : m_context->opaquePipelineCacheByKey)
     {
-      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
-      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+      const VkPipeline cachedPipeline = entry.second;
+      if (cachedPipeline != VK_NULL_HANDLE && cachedPipeline != previousPrimaryPipeline)
+        vkDestroyPipeline(m_context->device, cachedPipeline, nullptr);
     }
+    if (previousPrimaryPipeline != VK_NULL_HANDLE)
+      vkDestroyPipeline(m_context->device, previousPrimaryPipeline, nullptr);
+    m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    m_context->opaquePipelineCacheByKey.clear();
 
     m_context->opaqueGraphicsPipelineScaffoldReady =
         m_context->opaqueShaderPipelineScaffoldReady && m_context->opaqueRenderPass != VK_NULL_HANDLE;
@@ -910,17 +2541,94 @@ namespace Monolith
     if (m_context->opaqueShaderStages[0].module == VK_NULL_HANDLE ||
         m_context->opaqueShaderStages[1].module == VK_NULL_HANDLE)
     {
+      m_lastError =
+          "Vulkan opaque graphics pipeline cannot execute draws because shader modules are unavailable.";
       return true;
     }
 
+    void *pipelineHandle = nullptr;
+    if (!GetOrCreateOpaquePipeline({}, &pipelineHandle))
+      return false;
+
+    m_context->opaqueGraphicsPipeline = reinterpret_cast<VkPipeline>(pipelineHandle);
+    m_context->opaqueGraphicsPipelineExecutable = m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
+    return m_context->opaqueGraphicsPipelineExecutable;
+  }
+
+  void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold()
+  {
+    if (!m_context || m_context->device == VK_NULL_HANDLE)
+      return;
+
+    const VkPipeline primaryPipeline = m_context->opaqueGraphicsPipeline;
+    for (auto &entry : m_context->opaquePipelineCacheByKey)
+    {
+      const VkPipeline pipeline = entry.second;
+      if (pipeline != VK_NULL_HANDLE && pipeline != primaryPipeline)
+        vkDestroyPipeline(m_context->device, pipeline, nullptr);
+    }
+    if (primaryPipeline != VK_NULL_HANDLE)
+      vkDestroyPipeline(m_context->device, primaryPipeline, nullptr);
+    m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
+    m_context->opaquePipelineCacheByKey.clear();
+
+    m_context->opaqueGraphicsPipelineExecutable = false;
+    m_context->opaqueGraphicsPipelineScaffoldReady = false;
+  }
+
+  bool VulkanRenderBackend::GetOrCreateOpaquePipeline(const OpaquePipelineKey &key, void **outPipelineHandle)
+  {
+    if (!outPipelineHandle || !m_context)
+      return false;
+    *outPipelineHandle = nullptr;
+
+    const uint8_t packedKey = PackOpaquePipelineKey(key);
+    const auto it = m_context->opaquePipelineCacheByKey.find(packedKey);
+    if (it != m_context->opaquePipelineCacheByKey.end() && it->second != VK_NULL_HANDLE)
+    {
+      *outPipelineHandle = reinterpret_cast<void *>(it->second);
+      return true;
+    }
+
+    if (m_context->opaqueShaderStages[0].module == VK_NULL_HANDLE ||
+        m_context->opaqueShaderStages[1].module == VK_NULL_HANDLE)
+    {
+      m_lastError = "Cannot build opaque Vulkan pipeline for key: shader modules are unavailable.";
+      return false;
+    }
+
+    const VkVertexInputBindingDescription vertexBinding{
+        .binding = 0,
+        .stride = static_cast<uint32_t>(sizeof(Vertex)),
+        .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
+    };
+    const std::array<VkVertexInputAttributeDescription, 3> vertexAttributes = {
+        VkVertexInputAttributeDescription{
+            .location = 0,
+            .binding = 0,
+            .format = VK_FORMAT_R32G32B32_SFLOAT,
+            .offset = static_cast<uint32_t>(offsetof(Vertex, position)),
+        },
+        VkVertexInputAttributeDescription{
+            .location = 1,
+            .binding = 0,
+            .format = VK_FORMAT_R32G32B32_SFLOAT,
+            .offset = static_cast<uint32_t>(offsetof(Vertex, normal)),
+        },
+        VkVertexInputAttributeDescription{
+            .location = 2,
+            .binding = 0,
+            .format = VK_FORMAT_R32G32_SFLOAT,
+            .offset = static_cast<uint32_t>(offsetof(Vertex, uv)),
+        }};
     const VkPipelineVertexInputStateCreateInfo vertexInputState{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .vertexBindingDescriptionCount = 0,
-        .pVertexBindingDescriptions = nullptr,
-        .vertexAttributeDescriptionCount = 0,
-        .pVertexAttributeDescriptions = nullptr,
+        .vertexBindingDescriptionCount = 1,
+        .pVertexBindingDescriptions = &vertexBinding,
+        .vertexAttributeDescriptionCount = static_cast<uint32_t>(vertexAttributes.size()),
+        .pVertexAttributeDescriptions = vertexAttributes.data(),
     };
     const VkPipelineInputAssemblyStateCreateInfo inputAssemblyState{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
@@ -945,7 +2653,8 @@ namespace Monolith
         .depthClampEnable = VK_FALSE,
         .rasterizerDiscardEnable = VK_FALSE,
         .polygonMode = VK_POLYGON_MODE_FILL,
-        .cullMode = VK_CULL_MODE_NONE,
+        .cullMode = key.usesAlbedoMap ? static_cast<VkCullModeFlags>(VK_CULL_MODE_BACK_BIT)
+                                      : static_cast<VkCullModeFlags>(VK_CULL_MODE_NONE),
         .frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE,
         .depthBiasEnable = VK_FALSE,
         .depthBiasConstantFactor = 0.0f,
@@ -994,6 +2703,20 @@ namespace Monolith
         .dynamicStateCount = static_cast<uint32_t>(dynamicStates.size()),
         .pDynamicStates = dynamicStates.data(),
     };
+    const VkPipelineDepthStencilStateCreateInfo depthStencilState{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .depthTestEnable = key.depthTestEnabled ? VK_TRUE : VK_FALSE,
+        .depthWriteEnable = key.writesDepth ? VK_TRUE : VK_FALSE,
+        .depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL,
+        .depthBoundsTestEnable = VK_FALSE,
+        .stencilTestEnable = VK_FALSE,
+        .front = {},
+        .back = {},
+        .minDepthBounds = 0.0f,
+        .maxDepthBounds = 1.0f,
+    };
     const VkGraphicsPipelineCreateInfo pipelineInfo{
         .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
         .pNext = nullptr,
@@ -1006,7 +2729,7 @@ namespace Monolith
         .pViewportState = &viewportState,
         .pRasterizationState = &rasterizationState,
         .pMultisampleState = &multisampleState,
-        .pDepthStencilState = nullptr,
+        .pDepthStencilState = &depthStencilState,
         .pColorBlendState = &colorBlendState,
         .pDynamicState = &dynamicState,
         .layout = m_context->opaquePipelineLayout,
@@ -1015,35 +2738,25 @@ namespace Monolith
         .basePipelineHandle = VK_NULL_HANDLE,
         .basePipelineIndex = -1,
     };
+
+    VkPipeline newPipeline = VK_NULL_HANDLE;
     if (!CheckVk(vkCreateGraphicsPipelines(m_context->device,
                                            m_context->opaquePipelineCache,
                                            1,
                                            &pipelineInfo,
                                            nullptr,
-                                           &m_context->opaqueGraphicsPipeline),
+                                           &newPipeline),
                  m_lastError,
-                 "vkCreateGraphicsPipelines(opaque)"))
+                 "vkCreateGraphicsPipelines(opaque-keyed)"))
     {
       return false;
     }
 
-    m_context->opaqueGraphicsPipelineExecutable = true;
+    m_context->opaquePipelineCacheByKey.emplace(packedKey, newPipeline);
+    if (m_context->opaqueGraphicsPipeline == VK_NULL_HANDLE)
+      m_context->opaqueGraphicsPipeline = newPipeline;
+    *outPipelineHandle = reinterpret_cast<void *>(newPipeline);
     return true;
-  }
-
-  void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold()
-  {
-    if (!m_context || m_context->device == VK_NULL_HANDLE)
-      return;
-
-    if (m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE)
-    {
-      vkDestroyPipeline(m_context->device, m_context->opaqueGraphicsPipeline, nullptr);
-      m_context->opaqueGraphicsPipeline = VK_NULL_HANDLE;
-    }
-
-    m_context->opaqueGraphicsPipelineExecutable = false;
-    m_context->opaqueGraphicsPipelineScaffoldReady = false;
   }
 
   bool VulkanRenderBackend::RecreateSwapchain()
@@ -1132,6 +2845,12 @@ namespace Monolith
     const bool usesSeparatePresentQueue =
         m_context->graphicsQueueFamily != m_context->presentQueueFamily;
 
+    const bool surfaceSupportsTransferSrc =
+        (surfaceCapabilities.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) != 0;
+    VkImageUsageFlags swapchainUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (surfaceSupportsTransferSrc)
+      swapchainUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
     const VkSwapchainCreateInfoKHR swapchainInfo{
         .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
         .pNext = nullptr,
@@ -1142,7 +2861,7 @@ namespace Monolith
         .imageColorSpace = chosenFormat.colorSpace,
         .imageExtent = m_context->swapchainExtent,
         .imageArrayLayers = 1,
-        .imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .imageUsage = swapchainUsage,
         .imageSharingMode = usesSeparatePresentQueue ? VK_SHARING_MODE_CONCURRENT
                                                      : VK_SHARING_MODE_EXCLUSIVE,
         .queueFamilyIndexCount = usesSeparatePresentQueue ? 2u : 0u,
@@ -1214,6 +2933,18 @@ namespace Monolith
       return false;
     }
 
+    if (!CreateDepthResources())
+      return false;
+
+    m_context->supportsColorReadback = (swapchainUsage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) != 0;
+    m_context->supportsDepthReadback =
+        m_context->depthFormat == VK_FORMAT_D32_SFLOAT &&
+        HasFormatFeature(m_context->physicalDevice,
+                         m_context->depthFormat,
+                         VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    if (!EnsureReadbackBuffers())
+      return false;
+
     if (!CreateOpaqueRasterScaffold())
       return false;
 
@@ -1243,9 +2974,7 @@ namespace Monolith
 
     const bool hasQueuedOpaqueDraws = !m_pendingOpaqueDraws.empty();
     const bool hasQueuedOverlayRender = m_pendingOverlayRenderCallback != nullptr;
-    const bool hasExecutableOpaquePipeline =
-        m_context->opaqueGraphicsPipelineExecutable &&
-        m_context->opaqueGraphicsPipeline != VK_NULL_HANDLE;
+    const bool hasExecutableOpaquePipeline = HasOpaqueDrawExecutionReady();
     if (hasQueuedOpaqueDraws && !hasExecutableOpaquePipeline)
     {
       m_lastError =
@@ -1254,6 +2983,9 @@ namespace Monolith
           std::to_string(m_pendingOpaqueDraws.size());
     }
 
+    bool colorLayoutIsPresent = false;
+    bool colorLayoutIsTransferSrc = false;
+    bool colorLayoutIsTransferDst = false;
     if (hasQueuedOpaqueDraws || hasQueuedOverlayRender)
     {
       const VkImageMemoryBarrier toColorAttachment{
@@ -1281,16 +3013,18 @@ namespace Monolith
                            1,
                            &toColorAttachment);
 
-      const VkClearValue clearValue = {
-          .color = {{frame.clearColor.x, frame.clearColor.y, frame.clearColor.z, frame.clearColor.w}}};
+      const std::array<VkClearValue, 2> clearValues = {
+          VkClearValue{.color = {{frame.clearColor.x, frame.clearColor.y, frame.clearColor.z, frame.clearColor.w}}},
+          VkClearValue{.depthStencil = {1.0f, 0u}},
+      };
       const VkRenderPassBeginInfo renderPassBeginInfo{
           .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
           .pNext = nullptr,
           .renderPass = m_context->opaqueRenderPass,
           .framebuffer = m_context->opaqueFramebuffers[m_context->activeImageIndex],
           .renderArea = {{0, 0}, m_context->swapchainExtent},
-          .clearValueCount = 1,
-          .pClearValues = &clearValue,
+          .clearValueCount = static_cast<uint32_t>(clearValues.size()),
+          .pClearValues = clearValues.data(),
       };
       vkCmdBeginRenderPass(commandBuffer, &renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
@@ -1307,15 +3041,70 @@ namespace Monolith
       vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
       if (hasQueuedOpaqueDraws && hasExecutableOpaquePipeline)
       {
-        vkCmdBindPipeline(commandBuffer,
-                          VK_PIPELINE_BIND_POINT_GRAPHICS,
-                          m_context->opaqueGraphicsPipeline);
-
-        for (const PendingOpaqueDraw &draw : m_pendingOpaqueDraws)
+        for (size_t drawIndex = 0; drawIndex < m_pendingOpaqueDraws.size(); ++drawIndex)
         {
-          if (draw.indexCount <= 0)
+          const PendingOpaqueDraw &draw = m_pendingOpaqueDraws[drawIndex];
+          if (!draw.mesh || draw.indexCount <= 0)
             continue;
-          vkCmdDraw(commandBuffer, 3u, 1u, 0u, 0u);
+
+          if (!EnsureOpaqueMeshGpuBuffers(*draw.mesh))
+          {
+            if (m_lastError.empty())
+            {
+              m_lastError = "Vulkan opaque draw execution skipped because mesh GPU buffers are unavailable.";
+            }
+            continue;
+          }
+
+          const auto meshGpuIt = m_context->opaqueMeshGpuBuffers.find(draw.mesh);
+          if (meshGpuIt == m_context->opaqueMeshGpuBuffers.end())
+            continue;
+          const Context::MeshGpuBuffers &meshGpu = meshGpuIt->second;
+          if (meshGpu.indexBuffer == VK_NULL_HANDLE || meshGpu.vertexBuffer == VK_NULL_HANDLE ||
+              meshGpu.indexCount == 0)
+            continue;
+
+          void *pipelineHandle = nullptr;
+          if (!GetOrCreateOpaquePipeline(draw.pipelineKey, &pipelineHandle))
+            continue;
+          VkPipeline pipeline = reinterpret_cast<VkPipeline>(pipelineHandle);
+
+          if (pipeline == VK_NULL_HANDLE)
+            continue;
+
+          const VkBuffer vertexBuffers[] = {meshGpu.vertexBuffer};
+          const VkDeviceSize vertexOffsets[] = {0};
+          vkCmdBindVertexBuffers(commandBuffer, 0, 1, vertexBuffers, vertexOffsets);
+          vkCmdBindIndexBuffer(commandBuffer, meshGpu.indexBuffer, 0, VK_INDEX_TYPE_UINT32);
+
+          const uint32_t materialSlot =
+              static_cast<uint32_t>(drawIndex % m_context->opaqueMaterialDescriptorSets.size());
+          auto *materialStorage = reinterpret_cast<OpaqueMaterialGpuData *>(m_context->opaqueMaterialBufferMapped);
+          OpaqueMaterialGpuData &materialGpu = materialStorage[materialSlot];
+          materialGpu.baseColor[0] = draw.material.baseColor.x;
+          materialGpu.baseColor[1] = draw.material.baseColor.y;
+          materialGpu.baseColor[2] = draw.material.baseColor.z;
+          materialGpu.baseColor[3] = draw.material.baseColor.w;
+          materialGpu.roughness = draw.material.roughness;
+          materialGpu.metallic = draw.material.metallic;
+          materialGpu.uvScale = draw.material.uvScale;
+
+          vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+          vkCmdBindDescriptorSets(commandBuffer,
+                                  VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                  m_context->opaquePipelineLayout,
+                                  0,
+                                  1,
+                                  &m_context->opaqueMaterialDescriptorSets[materialSlot],
+                                  0,
+                                  nullptr);
+
+          const uint32_t submittedIndexCount = static_cast<uint32_t>(draw.indexCount);
+          const uint32_t drawIndexCount = std::min(submittedIndexCount, meshGpu.indexCount);
+          if (drawIndexCount == 0)
+            continue;
+          vkCmdDrawIndexed(commandBuffer, drawIndexCount, 1u, 0u, 0, 0u);
+          ++m_executedOpaqueIndexedDraws;
         }
       }
 
@@ -1326,6 +3115,181 @@ namespace Monolith
       }
 
       vkCmdEndRenderPass(commandBuffer);
+      colorLayoutIsPresent = true;
+
+      auto viewportTargetIt = m_context->offscreenTargets.find(kEditorViewportTargetKey);
+      if (viewportTargetIt != m_context->offscreenTargets.end())
+      {
+        Context::OffscreenRenderTarget &viewportTarget = viewportTargetIt->second;
+        if (viewportTarget.readyForSampling && viewportTarget.image != VK_NULL_HANDLE)
+        {
+          const VkImageMemoryBarrier sourceToTransfer{
+              .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+              .pNext = nullptr,
+              .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+              .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+              .oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+              .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+              .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .image = m_context->swapchainImages[m_context->activeImageIndex],
+              .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+          };
+          vkCmdPipelineBarrier(commandBuffer,
+                               VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               0,
+                               0,
+                               nullptr,
+                               0,
+                               nullptr,
+                               1,
+                               &sourceToTransfer);
+
+          const VkImageLayout destinationOldLayout =
+              viewportTarget.currentLayout == VK_IMAGE_LAYOUT_UNDEFINED ? VK_IMAGE_LAYOUT_UNDEFINED
+                                                                        : viewportTarget.currentLayout;
+          const VkImageMemoryBarrier targetToTransfer{
+              .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+              .pNext = nullptr,
+              .srcAccessMask = destinationOldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                   ? static_cast<VkAccessFlags>(VK_ACCESS_SHADER_READ_BIT)
+                                   : 0u,
+              .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+              .oldLayout = destinationOldLayout,
+              .newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+              .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .image = viewportTarget.image,
+              .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+          };
+          vkCmdPipelineBarrier(commandBuffer,
+                               destinationOldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                   ? VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                                   : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               0,
+                               0,
+                               nullptr,
+                               0,
+                               nullptr,
+                               1,
+                               &targetToTransfer);
+
+          VkImageBlit blitRegion{};
+          blitRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+          blitRegion.srcOffsets[0] = {0, 0, 0};
+          blitRegion.srcOffsets[1] = {static_cast<int32_t>(m_context->swapchainExtent.width),
+                                      static_cast<int32_t>(m_context->swapchainExtent.height),
+                                      1};
+          blitRegion.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+          blitRegion.dstOffsets[0] = {0, 0, 0};
+          blitRegion.dstOffsets[1] = {static_cast<int32_t>(viewportTarget.width),
+                                      static_cast<int32_t>(viewportTarget.height),
+                                      1};
+          vkCmdBlitImage(commandBuffer,
+                         m_context->swapchainImages[m_context->activeImageIndex],
+                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                         viewportTarget.image,
+                         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                         1,
+                         &blitRegion,
+                         VK_FILTER_LINEAR);
+
+          const VkImageMemoryBarrier targetToSample{
+              .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+              .pNext = nullptr,
+              .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+              .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+              .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+              .newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+              .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+              .image = viewportTarget.image,
+              .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+          };
+          vkCmdPipelineBarrier(commandBuffer,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                               0,
+                               0,
+                               nullptr,
+                               0,
+                               nullptr,
+                               1,
+                               &targetToSample);
+          viewportTarget.currentLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+          colorLayoutIsPresent = false;
+          colorLayoutIsTransferSrc = true;
+        }
+      }
+
+      if (m_context->supportsDepthReadback && m_context->depthReadbackBuffer != VK_NULL_HANDLE &&
+          m_context->depthFormat == VK_FORMAT_D32_SFLOAT)
+      {
+        const VkImageMemoryBarrier depthToTransfer{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+            .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = m_context->depthImage,
+            .subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1},
+        };
+        vkCmdPipelineBarrier(commandBuffer,
+                             VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0,
+                             0,
+                             nullptr,
+                             0,
+                             nullptr,
+                             1,
+                             &depthToTransfer);
+
+        const VkBufferImageCopy depthCopyRegion{
+            .bufferOffset = 0,
+            .bufferRowLength = 0,
+            .bufferImageHeight = 0,
+            .imageSubresource = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1},
+            .imageOffset = {0, 0, 0},
+            .imageExtent = {m_context->swapchainExtent.width, m_context->swapchainExtent.height, 1},
+        };
+        vkCmdCopyImageToBuffer(commandBuffer,
+                               m_context->depthImage,
+                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               m_context->depthReadbackBuffer,
+                               1,
+                               &depthCopyRegion);
+
+        const VkImageMemoryBarrier depthToAttachment{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            .dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+            .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = m_context->depthImage,
+            .subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1},
+        };
+        vkCmdPipelineBarrier(commandBuffer,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+                             0,
+                             0,
+                             nullptr,
+                             0,
+                             nullptr,
+                             1,
+                             &depthToAttachment);
+        m_context->hasDepthReadbackData = true;
+      }
     }
     else if (frame.clearColorBuffer)
     {
@@ -1365,7 +3329,108 @@ namespace Monolith
                            &clearColor,
                            1,
                            &clearRange);
+      colorLayoutIsTransferDst = true;
+    }
 
+    if (m_context->supportsColorReadback && m_context->colorReadbackBuffer != VK_NULL_HANDLE &&
+        (colorLayoutIsPresent || colorLayoutIsTransferSrc || colorLayoutIsTransferDst))
+    {
+      if (!colorLayoutIsTransferSrc)
+      {
+        const VkImageMemoryBarrier toTransferSource{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .pNext = nullptr,
+            .srcAccessMask = colorLayoutIsPresent
+                                 ? static_cast<VkAccessFlags>(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
+                                 : static_cast<VkAccessFlags>(VK_ACCESS_TRANSFER_WRITE_BIT),
+            .dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+            .oldLayout = colorLayoutIsPresent ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+                                              : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = m_context->swapchainImages[m_context->activeImageIndex],
+            .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+        };
+        vkCmdPipelineBarrier(commandBuffer,
+                             colorLayoutIsPresent ? VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                                                  : VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0,
+                             0,
+                             nullptr,
+                             0,
+                             nullptr,
+                             1,
+                             &toTransferSource);
+      }
+
+      const VkBufferImageCopy colorCopyRegion{
+          .bufferOffset = 0,
+          .bufferRowLength = 0,
+          .bufferImageHeight = 0,
+          .imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+          .imageOffset = {0, 0, 0},
+          .imageExtent = {m_context->swapchainExtent.width, m_context->swapchainExtent.height, 1},
+      };
+      vkCmdCopyImageToBuffer(commandBuffer,
+                             m_context->swapchainImages[m_context->activeImageIndex],
+                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                             m_context->colorReadbackBuffer,
+                             1,
+                             &colorCopyRegion);
+
+      const VkImageMemoryBarrier toPresent{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+          .dstAccessMask = 0,
+          .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+          .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toPresent);
+      m_context->hasColorReadbackData = true;
+    }
+    else if (colorLayoutIsTransferSrc)
+    {
+      const VkImageMemoryBarrier toPresent{
+          .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+          .pNext = nullptr,
+          .srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT,
+          .dstAccessMask = 0,
+          .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+          .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .image = m_context->swapchainImages[m_context->activeImageIndex],
+          .subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1},
+      };
+      vkCmdPipelineBarrier(commandBuffer,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                           0,
+                           0,
+                           nullptr,
+                           0,
+                           nullptr,
+                           1,
+                           &toPresent);
+    }
+    else if (colorLayoutIsTransferDst)
+    {
       const VkImageMemoryBarrier toPresent{
           .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
           .pNext = nullptr,
@@ -1427,20 +3492,30 @@ namespace Monolith
                                             UINT64_MAX,
                                             m_context->imageAvailableSemaphore,
                                             VK_NULL_HANDLE,
-                                            &m_context->activeImageIndex);
+                                             &m_context->activeImageIndex);
     }
-    MONOLITH_ASSERT(acquireResult == VK_SUCCESS, "vkAcquireNextImageKHR failed for Vulkan backend");
+    if (acquireResult != VK_SUCCESS)
+    {
+      m_lastError = "vkAcquireNextImageKHR failed during BeginFrame: " +
+                    std::string(VkResultName(acquireResult));
+      return;
+    }
 
-    MONOLITH_ASSERT(CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
-                            m_lastError,
-                            "vkResetFences"),
-                    m_lastError.c_str());
+    if (!CheckVk(vkResetFences(m_context->device, 1, &m_context->inFlightFence),
+                 m_lastError,
+                 "vkResetFences"))
+    {
+      return;
+    }
 
     m_activeFrame = frame;
     m_activeView = {};
+    if (m_pendingOpaqueDraws.capacity() < 256)
+      m_pendingOpaqueDraws.reserve(256);
     m_pendingOpaqueDraws.clear();
     m_context->frameCommandsRecorded = false;
     m_drawCalls = 0;
+    m_executedOpaqueIndexedDraws = 0;
     m_frameActive = true;
   }
 
@@ -1472,13 +3547,16 @@ namespace Monolith
           .signalSemaphoreCount = 1,
           .pSignalSemaphores = &m_context->renderFinishedSemaphore,
       };
-      MONOLITH_ASSERT(CheckVk(vkQueueSubmit(m_context->graphicsQueue,
-                                            1,
-                                            &submitInfo,
-                                            m_context->inFlightFence),
-                              m_lastError,
-                              "vkQueueSubmit"),
-                      m_lastError.c_str());
+      if (!CheckVk(vkQueueSubmit(m_context->graphicsQueue,
+                                 1,
+                                 &submitInfo,
+                                 m_context->inFlightFence),
+                   m_lastError,
+                   "vkQueueSubmit"))
+      {
+        m_frameActive = false;
+        return;
+      }
 
       const VkPresentInfoKHR presentInfo{
           .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
@@ -1495,9 +3573,12 @@ namespace Monolith
       {
         MONOLITH_ASSERT(RecreateSwapchain(), m_lastError.c_str());
       }
-      else
+      else if (presentResult != VK_SUCCESS)
       {
-        MONOLITH_ASSERT(presentResult == VK_SUCCESS, "vkQueuePresentKHR failed for Vulkan backend");
+        m_lastError = "vkQueuePresentKHR failed during EndFrame: " +
+                      std::string(VkResultName(presentResult));
+        m_frameActive = false;
+        return;
       }
 
       m_context->imageWasPresented[m_context->activeImageIndex] = true;
@@ -1536,7 +3617,8 @@ namespace Monolith
       return;
 
     m_pendingOpaqueDraws.push_back(
-        PendingOpaqueDraw{ResolveIndexCount(*command.mesh),
+        PendingOpaqueDraw{command.mesh,
+                          ResolveIndexCount(*command.mesh),
                           command.modelMatrix,
                           TranslateMaterialState(*command.material),
                           {}});
@@ -1571,6 +3653,12 @@ namespace Monolith
     return false;
   }
 
+  bool VulkanRenderBackend::HasOpaqueRasterScaffold() const { return false; }
+  bool VulkanRenderBackend::HasOpaquePipelineCreationScaffold() const { return false; }
+  bool VulkanRenderBackend::HasOpaqueShaderPipelineScaffold() const { return false; }
+  bool VulkanRenderBackend::HasOpaqueGraphicsPipelineScaffold() const { return false; }
+  bool VulkanRenderBackend::HasOpaqueDrawExecutionReady() const { return false; }
+
   bool VulkanRenderBackend::TryGetImGuiVulkanInitData(void **,
                                                       void **,
                                                       void **,
@@ -1588,6 +3676,38 @@ namespace Monolith
   }
 
   void VulkanRenderBackend::QueueOverlayRenderCallback(OverlayRenderCallback, void *) {}
+  bool VulkanRenderBackend::ReadbackColorBgr8(int, int, std::vector<uint8_t> &, std::string *)
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::ReadbackDepth32F(int, int, std::vector<float> &, std::string *)
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::EnsureEditorViewportRenderTarget(uint32_t, uint32_t, std::string *)
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *,
+                                                                   bool,
+                                                                   std::string *)
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &, uint32_t, uint32_t) { return false; }
+  bool VulkanRenderBackend::TryGetOffscreenRenderTargetHandle(const std::string &,
+                                                              RenderTargetHandle *,
+                                                              bool)
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetOffscreenRenderTargetMetadata(const std::string &,
+                                                                OffscreenTargetMetadata *) const
+  {
+    return false;
+  }
+  void VulkanRenderBackend::DestroyOffscreenRenderTarget(const std::string &) {}
+  void VulkanRenderBackend::DestroyAllOffscreenRenderTargets() {}
 
   bool VulkanRenderBackend::Initialize(void *)
   {
@@ -1597,7 +3717,42 @@ namespace Monolith
   void VulkanRenderBackend::Shutdown() {}
   bool VulkanRenderBackend::RecreateSwapchain() { return false; }
   void VulkanRenderBackend::DestroySwapchain() {}
+  bool VulkanRenderBackend::CreateOpaqueRasterScaffold() { return false; }
+  void VulkanRenderBackend::DestroyOpaqueRasterScaffold() {}
+  bool VulkanRenderBackend::CreateOpaquePipelineCreationScaffold() { return false; }
+  void VulkanRenderBackend::DestroyOpaquePipelineCreationScaffold() {}
+  bool VulkanRenderBackend::CreateDepthResources() { return false; }
+  void VulkanRenderBackend::DestroyDepthResources() {}
+  bool VulkanRenderBackend::EnsureReadbackBuffers() { return false; }
+  void VulkanRenderBackend::DestroyReadbackBuffers() {}
+  bool VulkanRenderBackend::CreateOpaqueMaterialBindingScaffold() { return false; }
+  void VulkanRenderBackend::DestroyOpaqueMaterialBindingScaffold() {}
+  bool VulkanRenderBackend::CreateOpaqueDrawIndexBuffer() { return false; }
+  void VulkanRenderBackend::DestroyOpaqueDrawIndexBuffer() {}
+  bool VulkanRenderBackend::EnsureOpaqueMeshGpuBuffers(const Mesh &) { return false; }
+  void VulkanRenderBackend::DestroyOpaqueMeshGpuBuffers() {}
+  bool VulkanRenderBackend::CreateOpaqueShaderPipelineScaffold() { return false; }
+  void VulkanRenderBackend::DestroyOpaqueShaderPipelineScaffold() {}
+  bool VulkanRenderBackend::GetOrCreateOpaquePipeline(const OpaquePipelineKey &, void **) { return false; }
+  bool VulkanRenderBackend::CreateOpaqueGraphicsPipelineScaffold() { return false; }
+  void VulkanRenderBackend::DestroyOpaqueGraphicsPipelineScaffold() {}
   bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig &) { return false; }
+  bool VulkanRenderBackend::EnsureOffscreenRenderPass() { return false; }
+  void VulkanRenderBackend::DestroyOffscreenRenderPass() {}
+  bool VulkanRenderBackend::CreateOffscreenRenderTargetResources(const std::string &,
+                                                                 uint32_t,
+                                                                 uint32_t,
+                                                                 uint64_t)
+  {
+    return false;
+  }
+  void VulkanRenderBackend::DestroyOffscreenRenderTargetResources(const std::string &) {}
+  bool VulkanRenderBackend::TryRegisterOffscreenTargetImGuiDescriptor(const std::string &,
+                                                                      RenderTargetHandle *,
+                                                                      bool)
+  {
+    return false;
+  }
   void VulkanRenderBackend::BeginFrame(const RenderFrameConfig &) {}
   void VulkanRenderBackend::EndFrame() {}
   void VulkanRenderBackend::BeginPass(const RenderPassConfig &) {}

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <optional>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -91,6 +92,14 @@ struct VulkanRenderBackend::Context {
   uint32_t activeImageIndex = 0;
   bool frameCommandsRecorded = false;
 };
+
+namespace {
+
+constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId) {
+  return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+}
+
+}  // namespace
 
 VulkanRenderBackend::VulkanRenderBackend(void* nativeWindowHandle) {
   Initialize(nativeWindowHandle);
@@ -576,6 +585,13 @@ bool VulkanRenderBackend::RecordFrameCommands(const RenderFrameConfig& frame) {
   }
 
   if (frame.clearColorBuffer) {
+    if (!m_pendingOpaqueDraws.empty()) {
+      // Placeholder for the first opaque-scene submission slice: keep the current
+      // clear/present bootstrap, but make frame recording aware that opaque scene
+      // work was queued through the backend seam.
+      m_lastError.clear();
+    }
+
     const VkImageMemoryBarrier toTransfer{
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .pNext = nullptr,
@@ -677,8 +693,11 @@ void VulkanRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
                           m_lastError,
                           "vkResetFences"),
                   m_lastError.c_str());
-  MONOLITH_ASSERT(RecordFrameCommands(frame), m_lastError.c_str());
 
+  m_activeFrame = frame;
+  m_activeView = {};
+  m_pendingOpaqueDraws.clear();
+  m_context->frameCommandsRecorded = false;
   m_drawCalls = 0;
   m_frameActive = true;
 }
@@ -690,6 +709,10 @@ void VulkanRenderBackend::EndFrame() {
 
   if (m_passActive)
     EndPass();
+
+  if (!m_context->frameCommandsRecorded) {
+    MONOLITH_ASSERT(RecordFrameCommands(m_activeFrame), m_lastError.c_str());
+  }
 
   if (m_context->frameCommandsRecorded) {
     const VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_TRANSFER_BIT};
@@ -734,6 +757,7 @@ void VulkanRenderBackend::EndFrame() {
   }
 
   m_frameActive = false;
+  m_pendingOpaqueDraws.clear();
 }
 
 void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
@@ -743,6 +767,7 @@ void VulkanRenderBackend::BeginPass(const RenderPassConfig& pass) {
     return;
 
   m_activePassId = pass.id;
+  m_activeView = pass.view;
   m_passActive = true;
 }
 
@@ -753,7 +778,13 @@ void VulkanRenderBackend::EndPass() {
   m_passActive = false;
 }
 
-void VulkanRenderBackend::DrawMesh(const MeshDrawCommand&) {}
+void VulkanRenderBackend::DrawMesh(const MeshDrawCommand& command) {
+  if (!m_passActive || !IsSupportedVulkanScenePass(m_activePassId) || !command.mesh || !command.material)
+    return;
+
+  m_pendingOpaqueDraws.push_back(PendingOpaqueDraw{command.mesh, command.material, command.modelMatrix});
+  ++m_drawCalls;
+}
 
 void VulkanRenderBackend::DrawSkinnedMesh(const SkinnedMeshDrawCommand&) {}
 

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -33,6 +33,7 @@ class VulkanRenderBackend : public IRenderBackend {
 
   bool IsInitialized() const;
   bool HasOpaqueRasterScaffold() const;
+  bool HasOpaquePipelineCreationScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -64,6 +65,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroySwapchain();
   bool CreateOpaqueRasterScaffold();
   void DestroyOpaqueRasterScaffold();
+  bool CreateOpaquePipelineCreationScaffold();
+  void DestroyOpaquePipelineCreationScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -34,6 +34,18 @@ class VulkanRenderBackend : public IRenderBackend {
   bool IsInitialized() const;
   const std::string& GetLastError() const { return m_lastError; }
 
+  struct TranslatedMaterialState {
+    Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
+    float roughness = 0.5f;
+    float metallic = 0.0f;
+    float uvScale = 1.0f;
+    bool usesAlbedoMap = false;
+    bool usesCustomShader = false;
+  };
+
+  static TranslatedMaterialState TranslateMaterialState(const Material& material);
+  static int ResolveIndexCount(const Mesh& mesh);
+
  private:
   struct Context;
 
@@ -44,9 +56,9 @@ class VulkanRenderBackend : public IRenderBackend {
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {
-    const Mesh* mesh = nullptr;
-    const Material* material = nullptr;
+    int indexCount = 0;
     Mat4 modelMatrix = Mat4::Identity();
+    TranslatedMaterialState material;
   };
 
   std::unique_ptr<Context> m_context;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -6,104 +6,109 @@
 
 #include "renderer/IRenderBackend.h"
 
-namespace Monolith {
+namespace Monolith
+{
 
-class VulkanRenderBackend : public IRenderBackend {
- public:
-  using OverlayRenderCallback = void (*)(void* userData, void* commandBufferHandle);
+  class VulkanRenderBackend : public IRenderBackend
+  {
+  public:
+    using OverlayRenderCallback = void (*)(void *userData, void *commandBufferHandle);
 
-  explicit VulkanRenderBackend(void* nativeWindowHandle);
-  ~VulkanRenderBackend() override;
+    explicit VulkanRenderBackend(void *nativeWindowHandle);
+    ~VulkanRenderBackend() override;
 
-  VulkanRenderBackend(const VulkanRenderBackend&) = delete;
-  VulkanRenderBackend& operator=(const VulkanRenderBackend&) = delete;
-  VulkanRenderBackend(VulkanRenderBackend&&) = delete;
-  VulkanRenderBackend& operator=(VulkanRenderBackend&&) = delete;
+    VulkanRenderBackend(const VulkanRenderBackend &) = delete;
+    VulkanRenderBackend &operator=(const VulkanRenderBackend &) = delete;
+    VulkanRenderBackend(VulkanRenderBackend &&) = delete;
+    VulkanRenderBackend &operator=(VulkanRenderBackend &&) = delete;
 
-  void BeginFrame(const RenderFrameConfig& frame) override;
-  void EndFrame() override;
-  void BeginPass(const RenderPassConfig& pass) override;
-  void EndPass() override;
+    void BeginFrame(const RenderFrameConfig &frame) override;
+    void EndFrame() override;
+    void BeginPass(const RenderPassConfig &pass) override;
+    void EndPass() override;
 
-  void DrawMesh(const MeshDrawCommand& command) override;
-  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override;
-  void DrawWireframe(const WireframeDrawCommand& command) override;
+    void DrawMesh(const MeshDrawCommand &command) override;
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &command) override;
+    void DrawWireframe(const WireframeDrawCommand &command) override;
 
-  RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
-  RenderBackendCapabilities GetCapabilities() const override;
-  int GetDrawCallCount() const override { return m_drawCalls; }
+    RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
+    RenderBackendCapabilities GetCapabilities() const override;
+    int GetDrawCallCount() const override { return m_drawCalls; }
 
-  bool IsInitialized() const;
-  bool HasOpaqueRasterScaffold() const;
-  bool HasOpaquePipelineCreationScaffold() const;
-  bool HasOpaqueShaderPipelineScaffold() const;
-  bool HasOpaqueGraphicsPipelineScaffold() const;
-  bool TryGetImGuiVulkanInitData(void** outInstance,
-                                 void** outPhysicalDevice,
-                                 void** outDevice,
-                                 uint32_t* outQueueFamily,
-                                 void** outQueue,
-                                 void** outRenderPass,
-                                 uint32_t* outImageCount) const;
-  void* GetActiveCommandBufferHandle() const;
-  void QueueOverlayRenderCallback(OverlayRenderCallback callback, void* userData);
-  const std::string& GetLastError() const { return m_lastError; }
+    bool IsInitialized() const;
+    bool HasOpaqueRasterScaffold() const;
+    bool HasOpaquePipelineCreationScaffold() const;
+    bool HasOpaqueShaderPipelineScaffold() const;
+    bool HasOpaqueGraphicsPipelineScaffold() const;
+    bool TryGetImGuiVulkanInitData(void **outInstance,
+                                   void **outPhysicalDevice,
+                                   void **outDevice,
+                                   uint32_t *outQueueFamily,
+                                   void **outQueue,
+                                   void **outRenderPass,
+                                   uint32_t *outImageCount) const;
+    void *GetActiveCommandBufferHandle() const;
+    void QueueOverlayRenderCallback(OverlayRenderCallback callback, void *userData);
+    const std::string &GetLastError() const { return m_lastError; }
 
-  struct TranslatedMaterialState {
-    Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
-    float roughness = 0.5f;
-    float metallic = 0.0f;
-    float uvScale = 1.0f;
-    bool usesAlbedoMap = false;
-    bool usesCustomShader = false;
+    struct TranslatedMaterialState
+    {
+      Vec4 baseColor = {1.0f, 1.0f, 1.0f, 1.0f};
+      float roughness = 0.5f;
+      float metallic = 0.0f;
+      float uvScale = 1.0f;
+      bool usesAlbedoMap = false;
+      bool usesCustomShader = false;
+    };
+
+    struct OpaquePipelineKey
+    {
+      bool usesAlbedoMap = false;
+      bool usesCustomShader = false;
+      bool writesDepth = true;
+      bool depthTestEnabled = true;
+    };
+
+    static TranslatedMaterialState TranslateMaterialState(const Material &material);
+    static int ResolveIndexCount(const Mesh &mesh);
+    static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState &materialState);
+
+  private:
+    struct Context;
+
+    bool Initialize(void *nativeWindowHandle);
+    void Shutdown();
+    bool RecreateSwapchain();
+    void DestroySwapchain();
+    bool CreateOpaqueRasterScaffold();
+    void DestroyOpaqueRasterScaffold();
+    bool CreateOpaquePipelineCreationScaffold();
+    void DestroyOpaquePipelineCreationScaffold();
+    bool CreateOpaqueShaderPipelineScaffold();
+    void DestroyOpaqueShaderPipelineScaffold();
+    bool CreateOpaqueGraphicsPipelineScaffold();
+    void DestroyOpaqueGraphicsPipelineScaffold();
+    bool RecordFrameCommands(const RenderFrameConfig &frame);
+
+    struct PendingOpaqueDraw
+    {
+      int indexCount = 0;
+      Mat4 modelMatrix = Mat4::Identity();
+      TranslatedMaterialState material;
+      OpaquePipelineKey pipelineKey;
+    };
+
+    std::unique_ptr<Context> m_context;
+    RenderFrameConfig m_activeFrame;
+    RenderView m_activeView;
+    std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
+    OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
+    void *m_pendingOverlayRenderUserData = nullptr;
+    std::string m_lastError;
+    RenderPassId m_activePassId = RenderPassId::OpaqueScene;
+    int m_drawCalls = 0;
+    bool m_frameActive = false;
+    bool m_passActive = false;
   };
 
-  struct OpaquePipelineKey {
-    bool usesAlbedoMap = false;
-    bool usesCustomShader = false;
-    bool writesDepth = true;
-    bool depthTestEnabled = true;
-  };
-
-  static TranslatedMaterialState TranslateMaterialState(const Material& material);
-  static int ResolveIndexCount(const Mesh& mesh);
-  static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState& materialState);
-
- private:
-  struct Context;
-
-  bool Initialize(void* nativeWindowHandle);
-  void Shutdown();
-  bool RecreateSwapchain();
-  void DestroySwapchain();
-  bool CreateOpaqueRasterScaffold();
-  void DestroyOpaqueRasterScaffold();
-  bool CreateOpaquePipelineCreationScaffold();
-  void DestroyOpaquePipelineCreationScaffold();
-  bool CreateOpaqueShaderPipelineScaffold();
-  void DestroyOpaqueShaderPipelineScaffold();
-  bool CreateOpaqueGraphicsPipelineScaffold();
-  void DestroyOpaqueGraphicsPipelineScaffold();
-  bool RecordFrameCommands(const RenderFrameConfig& frame);
-
-  struct PendingOpaqueDraw {
-    int indexCount = 0;
-    Mat4 modelMatrix = Mat4::Identity();
-    TranslatedMaterialState material;
-    OpaquePipelineKey pipelineKey;
-  };
-
-  std::unique_ptr<Context> m_context;
-  RenderFrameConfig m_activeFrame;
-  RenderView m_activeView;
-  std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
-  OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
-  void* m_pendingOverlayRenderUserData = nullptr;
-  std::string m_lastError;
-  RenderPassId m_activePassId = RenderPassId::OpaqueScene;
-  int m_drawCalls = 0;
-  bool m_frameActive = false;
-  bool m_passActive = false;
-};
-
-}  // namespace Monolith
+} // namespace Monolith

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -10,6 +10,8 @@ namespace Monolith {
 
 class VulkanRenderBackend : public IRenderBackend {
  public:
+  using OverlayRenderCallback = void (*)(void* userData, void* commandBufferHandle);
+
   explicit VulkanRenderBackend(void* nativeWindowHandle);
   ~VulkanRenderBackend() override;
 
@@ -44,6 +46,7 @@ class VulkanRenderBackend : public IRenderBackend {
                                  void** outRenderPass,
                                  uint32_t* outImageCount) const;
   void* GetActiveCommandBufferHandle() const;
+  void QueueOverlayRenderCallback(OverlayRenderCallback callback, void* userData);
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -94,6 +97,8 @@ class VulkanRenderBackend : public IRenderBackend {
   RenderFrameConfig m_activeFrame;
   RenderView m_activeView;
   std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
+  OverlayRenderCallback m_pendingOverlayRenderCallback = nullptr;
+  void* m_pendingOverlayRenderUserData = nullptr;
   std::string m_lastError;
   RenderPassId m_activePassId = RenderPassId::OpaqueScene;
   int m_drawCalls = 0;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "renderer/IRenderBackend.h"
+#include "renderer/RenderTargetHandle.h"
 
 namespace Monolith
 {
@@ -30,6 +32,20 @@ namespace Monolith
     void DrawMesh(const MeshDrawCommand &command) override;
     void DrawSkinnedMesh(const SkinnedMeshDrawCommand &command) override;
     void DrawWireframe(const WireframeDrawCommand &command) override;
+    bool ReadbackColorBgr8(int width,
+                           int height,
+                           std::vector<uint8_t> &outPixels,
+                           std::string *outError) override;
+    bool ReadbackDepth32F(int width,
+                          int height,
+                          std::vector<float> &outDepth,
+                          std::string *outError) override;
+    bool EnsureEditorViewportRenderTarget(uint32_t width,
+                                          uint32_t height,
+                                          std::string *outError) override;
+    bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                bool needsYFlip,
+                                                std::string *outError) override;
 
     RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
     RenderBackendCapabilities GetCapabilities() const override;
@@ -40,6 +56,7 @@ namespace Monolith
     bool HasOpaquePipelineCreationScaffold() const;
     bool HasOpaqueShaderPipelineScaffold() const;
     bool HasOpaqueGraphicsPipelineScaffold() const;
+    bool HasOpaqueDrawExecutionReady() const;
     bool TryGetImGuiVulkanInitData(void **outInstance,
                                    void **outPhysicalDevice,
                                    void **outDevice,
@@ -50,6 +67,25 @@ namespace Monolith
     void *GetActiveCommandBufferHandle() const;
     void QueueOverlayRenderCallback(OverlayRenderCallback callback, void *userData);
     const std::string &GetLastError() const { return m_lastError; }
+    int GetExecutedOpaqueIndexedDrawCount() const { return m_executedOpaqueIndexedDraws; }
+
+    struct OffscreenTargetMetadata
+    {
+      uint32_t width = 0;
+      uint32_t height = 0;
+      uint64_t generation = 0;
+      bool readyForSampling = false;
+      bool hasImGuiDescriptor = false;
+    };
+
+    bool EnsureOffscreenRenderTarget(const std::string &targetKey, uint32_t width, uint32_t height);
+    bool TryGetOffscreenRenderTargetHandle(const std::string &targetKey,
+                                           RenderTargetHandle *outHandle,
+                                           bool needsYFlip = false);
+    bool TryGetOffscreenRenderTargetMetadata(const std::string &targetKey,
+                                             OffscreenTargetMetadata *outMetadata) const;
+    void DestroyOffscreenRenderTarget(const std::string &targetKey);
+    void DestroyAllOffscreenRenderTargets();
 
     struct TranslatedMaterialState
     {
@@ -84,14 +120,36 @@ namespace Monolith
     void DestroyOpaqueRasterScaffold();
     bool CreateOpaquePipelineCreationScaffold();
     void DestroyOpaquePipelineCreationScaffold();
+    bool CreateDepthResources();
+    void DestroyDepthResources();
+    bool EnsureReadbackBuffers();
+    void DestroyReadbackBuffers();
+    bool CreateOpaqueMaterialBindingScaffold();
+    void DestroyOpaqueMaterialBindingScaffold();
+    bool CreateOpaqueDrawIndexBuffer();
+    void DestroyOpaqueDrawIndexBuffer();
+    bool EnsureOpaqueMeshGpuBuffers(const Mesh &mesh);
+    void DestroyOpaqueMeshGpuBuffers();
+    bool GetOrCreateOpaquePipeline(const OpaquePipelineKey &key, void **outPipelineHandle);
     bool CreateOpaqueShaderPipelineScaffold();
     void DestroyOpaqueShaderPipelineScaffold();
     bool CreateOpaqueGraphicsPipelineScaffold();
     void DestroyOpaqueGraphicsPipelineScaffold();
     bool RecordFrameCommands(const RenderFrameConfig &frame);
+    bool EnsureOffscreenRenderPass();
+    void DestroyOffscreenRenderPass();
+    bool CreateOffscreenRenderTargetResources(const std::string &targetKey,
+                                              uint32_t width,
+                                              uint32_t height,
+                                              uint64_t previousGeneration);
+    void DestroyOffscreenRenderTargetResources(const std::string &targetKey);
+    bool TryRegisterOffscreenTargetImGuiDescriptor(const std::string &targetKey,
+                                                   RenderTargetHandle *outHandle,
+                                                   bool needsYFlip);
 
     struct PendingOpaqueDraw
     {
+      const Mesh *mesh = nullptr;
       int indexCount = 0;
       Mat4 modelMatrix = Mat4::Identity();
       TranslatedMaterialState material;
@@ -107,6 +165,7 @@ namespace Monolith
     std::string m_lastError;
     RenderPassId m_activePassId = RenderPassId::OpaqueScene;
     int m_drawCalls = 0;
+    int m_executedOpaqueIndexedDraws = 0;
     bool m_frameActive = false;
     bool m_passActive = false;
   };

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -43,8 +43,16 @@ class VulkanRenderBackend : public IRenderBackend {
     bool usesCustomShader = false;
   };
 
+  struct OpaquePipelineKey {
+    bool usesAlbedoMap = false;
+    bool usesCustomShader = false;
+    bool writesDepth = true;
+    bool depthTestEnabled = true;
+  };
+
   static TranslatedMaterialState TranslateMaterialState(const Material& material);
   static int ResolveIndexCount(const Mesh& mesh);
+  static OpaquePipelineKey BuildOpaquePipelineKey(const TranslatedMaterialState& materialState);
 
  private:
   struct Context;
@@ -59,6 +67,7 @@ class VulkanRenderBackend : public IRenderBackend {
     int indexCount = 0;
     Mat4 modelMatrix = Mat4::Identity();
     TranslatedMaterialState material;
+    OpaquePipelineKey pipelineKey;
   };
 
   std::unique_ptr<Context> m_context;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -32,6 +32,7 @@ class VulkanRenderBackend : public IRenderBackend {
   int GetDrawCallCount() const override { return m_drawCalls; }
 
   bool IsInitialized() const;
+  bool HasOpaqueRasterScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -61,6 +62,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void Shutdown();
   bool RecreateSwapchain();
   void DestroySwapchain();
+  bool CreateOpaqueRasterScaffold();
+  void DestroyOpaqueRasterScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "renderer/IRenderBackend.h"
 
@@ -42,7 +43,16 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroySwapchain();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
+  struct PendingOpaqueDraw {
+    const Mesh* mesh = nullptr;
+    const Material* material = nullptr;
+    Mat4 modelMatrix = Mat4::Identity();
+  };
+
   std::unique_ptr<Context> m_context;
+  RenderFrameConfig m_activeFrame;
+  RenderView m_activeView;
+  std::vector<PendingOpaqueDraw> m_pendingOpaqueDraws;
   std::string m_lastError;
   RenderPassId m_activePassId = RenderPassId::OpaqueScene;
   int m_drawCalls = 0;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -36,6 +36,14 @@ class VulkanRenderBackend : public IRenderBackend {
   bool HasOpaquePipelineCreationScaffold() const;
   bool HasOpaqueShaderPipelineScaffold() const;
   bool HasOpaqueGraphicsPipelineScaffold() const;
+  bool TryGetImGuiVulkanInitData(void** outInstance,
+                                 void** outPhysicalDevice,
+                                 void** outDevice,
+                                 uint32_t* outQueueFamily,
+                                 void** outQueue,
+                                 void** outRenderPass,
+                                 uint32_t* outImageCount) const;
+  void* GetActiveCommandBufferHandle() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -35,6 +35,7 @@ class VulkanRenderBackend : public IRenderBackend {
   bool HasOpaqueRasterScaffold() const;
   bool HasOpaquePipelineCreationScaffold() const;
   bool HasOpaqueShaderPipelineScaffold() const;
+  bool HasOpaqueGraphicsPipelineScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -70,6 +71,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroyOpaquePipelineCreationScaffold();
   bool CreateOpaqueShaderPipelineScaffold();
   void DestroyOpaqueShaderPipelineScaffold();
+  bool CreateOpaqueGraphicsPipelineScaffold();
+  void DestroyOpaqueGraphicsPipelineScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -34,6 +34,7 @@ class VulkanRenderBackend : public IRenderBackend {
   bool IsInitialized() const;
   bool HasOpaqueRasterScaffold() const;
   bool HasOpaquePipelineCreationScaffold() const;
+  bool HasOpaqueShaderPipelineScaffold() const;
   const std::string& GetLastError() const { return m_lastError; }
 
   struct TranslatedMaterialState {
@@ -67,6 +68,8 @@ class VulkanRenderBackend : public IRenderBackend {
   void DestroyOpaqueRasterScaffold();
   bool CreateOpaquePipelineCreationScaffold();
   void DestroyOpaquePipelineCreationScaffold();
+  bool CreateOpaqueShaderPipelineScaffold();
+  void DestroyOpaqueShaderPipelineScaffold();
   bool RecordFrameCommands(const RenderFrameConfig& frame);
 
   struct PendingOpaqueDraw {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "renderer/IRenderBackend.h"
+
+namespace Monolith {
+
+class VulkanRenderBackend : public IRenderBackend {
+ public:
+  explicit VulkanRenderBackend(void* nativeWindowHandle);
+  ~VulkanRenderBackend() override;
+
+  VulkanRenderBackend(const VulkanRenderBackend&) = delete;
+  VulkanRenderBackend& operator=(const VulkanRenderBackend&) = delete;
+  VulkanRenderBackend(VulkanRenderBackend&&) = delete;
+  VulkanRenderBackend& operator=(VulkanRenderBackend&&) = delete;
+
+  void BeginFrame(const RenderFrameConfig& frame) override;
+  void EndFrame() override;
+  void BeginPass(const RenderPassConfig& pass) override;
+  void EndPass() override;
+
+  void DrawMesh(const MeshDrawCommand& command) override;
+  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override;
+  void DrawWireframe(const WireframeDrawCommand& command) override;
+
+  RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
+  RenderBackendCapabilities GetCapabilities() const override;
+  int GetDrawCallCount() const override { return m_drawCalls; }
+
+  bool IsInitialized() const;
+  const std::string& GetLastError() const { return m_lastError; }
+
+ private:
+  struct Context;
+
+  bool Initialize(void* nativeWindowHandle);
+  void Shutdown();
+  bool RecreateSwapchain();
+  void DestroySwapchain();
+  bool RecordFrameCommands(const RenderFrameConfig& frame);
+
+  std::unique_ptr<Context> m_context;
+  std::string m_lastError;
+  RenderPassId m_activePassId = RenderPassId::OpaqueScene;
+  int m_drawCalls = 0;
+  bool m_frameActive = false;
+  bool m_passActive = false;
+};
+
+}  // namespace Monolith

--- a/scene/STARTER_TEMPLATE.h
+++ b/scene/STARTER_TEMPLATE.h
@@ -25,7 +25,6 @@
 #include "editor/SceneSerializer.h"
 #include "renderer/DebugDraw.h"
 #include "renderer/RenderBackend.h"
-#include "renderer/RenderContext.h"
 #include "renderer/Renderer.h"
 #include "renderer/RenderViewUtils.h"
 #include "scene/Scene.h"
@@ -46,7 +45,6 @@ class MyGameApp : public Monolith::Application {
     if (!backendInit.ok)
       throw std::runtime_error("Failed to initialize renderer backend: " + backendInit.error);
 
-    Monolith::RenderContext::Init();
     Monolith::DebugDraw::Init();
     m_referenceRuntime = std::make_unique<Monolith::SceneReferenceRuntime>(&m_scene);
 
@@ -66,7 +64,6 @@ class MyGameApp : public Monolith::Application {
 
   // STEP 5: Rendering (variable framerate).
   void OnRender(float alpha) override {
-    Monolith::RenderContext::BeginFrame();
     Monolith::Renderer::BeginFrame({{}, "starter-template-frame"});
     Monolith::Renderer::BeginPass({Monolith::RenderPassId::OpaqueScene,
                                    Monolith::BuildRenderView(m_camera),
@@ -74,7 +71,6 @@ class MyGameApp : public Monolith::Application {
     m_scene.RenderSystems(alpha);
     Monolith::Renderer::EndPass();
     Monolith::Renderer::EndFrame();
-    Monolith::RenderContext::EndFrame();
   }
 
   void OnShutdown() override {

--- a/scene/STARTER_TEMPLATE.h
+++ b/scene/STARTER_TEMPLATE.h
@@ -40,8 +40,11 @@ class MyGameApp : public Monolith::Application {
   protected:
   // STEP 2: Setup (called once at startup).
   void OnInit() override {
+    Monolith::RenderBackendSelection backendSelection;
+    backendSelection.requested = Monolith::RenderBackendId::OpenGL;
+    backendSelection.nativeWindowHandle = GetWindow().GetNativeHandle();
     const Monolith::RenderBackendInitResult backendInit =
-        Monolith::Renderer::InitializeBackend({Monolith::RenderBackendId::OpenGL});
+        Monolith::Renderer::InitializeBackend(backendSelection);
     if (!backendInit.ok)
       throw std::runtime_error("Failed to initialize renderer backend: " + backendInit.error);
 

--- a/scene/STARTER_TEMPLATE.h
+++ b/scene/STARTER_TEMPLATE.h
@@ -36,9 +36,7 @@ namespace MyGame {
 // STEP 1: Create a minimal app class.
 class MyGameApp : public Monolith::Application {
  public:
-  MyGameApp() : Application(AppSpec{
-      "My Game", 1280, 720, true, "assets/scenes/level.json"
-  }) {}
+  MyGameApp() : Application(BuildAppSpec()) {}
 
   protected:
   // STEP 2: Setup (called once at startup).
@@ -88,6 +86,17 @@ class MyGameApp : public Monolith::Application {
   Monolith::Scene m_scene;
   std::unique_ptr<Monolith::SceneReferenceRuntime> m_referenceRuntime;
   Monolith::Camera m_camera;
+
+  static Monolith::AppSpec BuildAppSpec() {
+    Monolith::AppSpec spec;
+    spec.name = "My Game";
+    spec.width = 1280;
+    spec.height = 720;
+    spec.vsync = true;
+    spec.graphicsApi = Monolith::WindowGraphicsApi::OpenGL;
+    spec.defaultSceneFile = "assets/scenes/level.json";
+    return spec;
+  }
 
   void LoadSceneFromFile(const std::string& path) {
     const Monolith::Editor::SceneDocument doc = Monolith::Editor::SceneSerializer::LoadFromFile(path);

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -36,6 +36,8 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "renderer-foundation.md"));
   REQUIRE(std::filesystem::is_regular_file(
       docsRoot / "backend-agnostic-rendering-foundation-and-runtime-selection.md"));
+  REQUIRE(std::filesystem::is_regular_file(
+      docsRoot / "vulkan-backend-integration-and-backend-parity.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "ownership-lifecycle.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "error-result-model.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "threading-and-mutation.md"));
@@ -58,6 +60,8 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
   REQUIRE(architectureReadme.find("renderer-foundation.md") != std::string::npos);
   REQUIRE(architectureReadme.find("backend-agnostic-rendering-foundation-and-runtime-selection.md") !=
           std::string::npos);
+  REQUIRE(architectureReadme.find("vulkan-backend-integration-and-backend-parity.md") !=
+          std::string::npos);
 
   RequireFileContains(docsRoot / "renderer-foundation.md", "IRenderBackend");
   RequireFileContains(docsRoot / "renderer-foundation.md", "RenderPassConfig");
@@ -65,6 +69,10 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
   RequireFileContains(docsRoot / "renderer-foundation.md", "OpenGLRenderBackend");
   RequireFileContains(docsRoot / "backend-agnostic-rendering-foundation-and-runtime-selection.md",
                       "runtime backend selection");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "capability-driven parity");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "editor viewport");
 }
 
 TEST_CASE("Renderer foundation isolates backend-specific details from higher-level systems",

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -123,6 +123,15 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
 
   const std::string editorImGuiBackend = ReadTextFile(root / "editor" / "EditorImGuiBackend.cpp");
   REQUIRE(editorImGuiBackend.find("ImGui_ImplOpenGL3_Init") != std::string::npos);
+
+  const std::string debugDraw = ReadTextFile(root / "renderer" / "DebugDraw.cpp");
+  REQUIRE(debugDraw.find("supportsDebugDraw") != std::string::npos);
+
+  const std::string screenshot = ReadTextFile(root / "core" / "Screenshot.cpp");
+  REQUIRE(screenshot.find("supportsReadback") != std::string::npos);
+
+  const std::string debugHud = ReadTextFile(root / "renderer" / "DebugHUD.cpp");
+  REQUIRE(debugHud.find("supportsDepthReadback") != std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -119,6 +119,10 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
 
   const std::string editorLayer = ReadTextFile(root / "editor" / "EditorLayer.cpp");
   REQUIRE(editorLayer.find("GetNativeId(") == std::string::npos);
+  REQUIRE(editorLayer.find("ImGui_ImplOpenGL3_") == std::string::npos);
+
+  const std::string editorImGuiBackend = ReadTextFile(root / "editor" / "EditorImGuiBackend.cpp");
+  REQUIRE(editorImGuiBackend.find("ImGui_ImplOpenGL3_Init") != std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -86,12 +86,20 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string renderer = ReadTextFile(root / "renderer" / "Renderer.cpp");
   REQUIRE(renderer.find("GetProgramID(") == std::string::npos);
 
+  const std::string renderContext = ReadTextFile(root / "renderer" / "RenderContext.cpp");
+  REQUIRE(renderContext.find("glViewport(") == std::string::npos);
+  REQUIRE(renderContext.find("glad/glad.h") == std::string::npos);
+
   const std::string renderSystem = ReadTextFile(root / "scene" / "systems" / "RenderSystem.cpp");
   REQUIRE(renderSystem.find("GetProgramID(") == std::string::npos);
 
   const std::string skinnedRenderSystem =
       ReadTextFile(root / "scene" / "systems" / "SkinnedRenderSystem.cpp");
   REQUIRE(skinnedRenderSystem.find("GetProgramID(") == std::string::npos);
+
+  const std::string starterTemplate = ReadTextFile(root / "scene" / "STARTER_TEMPLATE.h");
+  REQUIRE(starterTemplate.find("RenderContext::BeginFrame") == std::string::npos);
+  REQUIRE(starterTemplate.find("RenderContext::EndFrame") == std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -116,6 +116,9 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string starterTemplate = ReadTextFile(root / "scene" / "STARTER_TEMPLATE.h");
   REQUIRE(starterTemplate.find("RenderContext::BeginFrame") == std::string::npos);
   REQUIRE(starterTemplate.find("RenderContext::EndFrame") == std::string::npos);
+
+  const std::string editorLayer = ReadTextFile(root / "editor" / "EditorLayer.cpp");
+  REQUIRE(editorLayer.find("GetNativeId(") == std::string::npos);
 }
 
 TEST_CASE("McpController lifecycle calls are safe to repeat", "[architecture][lifecycle][mcp]") {

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -77,6 +77,10 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
                       "capability-driven parity");
   RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
                       "editor viewport");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "Current Implemented Foundation State");
+  RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
+                      "backend-parity-validation-matrix.md");
   RequireFileContains(devDocsRoot / "backend-parity-validation-matrix.md", "Vulkan-enabled build");
 }
 

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -29,8 +29,10 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
   const std::filesystem::path root =
       std::filesystem::path(__FILE__).parent_path().parent_path();
   const std::filesystem::path docsRoot = root / "docs" / "architecture";
+  const std::filesystem::path devDocsRoot = root / "docs" / "development";
 
   REQUIRE(std::filesystem::is_directory(docsRoot));
+  REQUIRE(std::filesystem::is_directory(devDocsRoot));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "README.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "module-boundaries.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "renderer-foundation.md"));
@@ -41,9 +43,11 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "ownership-lifecycle.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "error-result-model.md"));
   REQUIRE(std::filesystem::is_regular_file(docsRoot / "threading-and-mutation.md"));
+  REQUIRE(std::filesystem::is_regular_file(devDocsRoot / "backend-parity-validation-matrix.md"));
 
   const std::string readme = ReadTextFile(root / "README.md");
   REQUIRE(readme.find("docs/architecture") != std::string::npos);
+  REQUIRE(readme.find("backend-parity-validation-matrix.md") != std::string::npos);
   REQUIRE(readme.find("new headers are internal by default") != std::string::npos);
 
   const std::string moduleBoundaries = ReadTextFile(docsRoot / "module-boundaries.md");
@@ -73,6 +77,7 @@ TEST_CASE("Architecture docs exist and are discoverable from README", "[architec
                       "capability-driven parity");
   RequireFileContains(docsRoot / "vulkan-backend-integration-and-backend-parity.md",
                       "editor viewport");
+  RequireFileContains(devDocsRoot / "backend-parity-validation-matrix.md", "Vulkan-enabled build");
 }
 
 TEST_CASE("Renderer foundation isolates backend-specific details from higher-level systems",

--- a/tests/test_architecture_docs.cpp
+++ b/tests/test_architecture_docs.cpp
@@ -86,6 +86,22 @@ TEST_CASE("Renderer foundation isolates backend-specific details from higher-lev
   const std::string renderer = ReadTextFile(root / "renderer" / "Renderer.cpp");
   REQUIRE(renderer.find("GetProgramID(") == std::string::npos);
 
+  const std::string meshHeader = ReadTextFile(root / "renderer" / "Mesh.h");
+  REQUIRE(meshHeader.find("m_vao") == std::string::npos);
+  REQUIRE(meshHeader.find("m_vbo") == std::string::npos);
+  REQUIRE(meshHeader.find("m_ebo") == std::string::npos);
+
+  const std::string shaderHeader = ReadTextFile(root / "renderer" / "Shader.h");
+  REQUIRE(shaderHeader.find("unsigned int m_program") == std::string::npos);
+
+  const std::string textureHeader = ReadTextFile(root / "renderer" / "Texture.h");
+  REQUIRE(textureHeader.find("unsigned int m_id") == std::string::npos);
+
+  const std::string skinnedMeshHeader = ReadTextFile(root / "renderer" / "SkinnedMesh.h");
+  REQUIRE(skinnedMeshHeader.find("m_vao") == std::string::npos);
+  REQUIRE(skinnedMeshHeader.find("m_vbo") == std::string::npos);
+  REQUIRE(skinnedMeshHeader.find("m_ebo") == std::string::npos);
+
   const std::string renderContext = ReadTextFile(root / "renderer" / "RenderContext.cpp");
   REQUIRE(renderContext.find("glViewport(") == std::string::npos);
   REQUIRE(renderContext.find("glad/glad.h") == std::string::npos);

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -5,8 +5,10 @@
 #include <cstring>
 #include <filesystem>
 
+#include "core/Application.h"
 #include "core/Logger.h"
 #include "core/ProjectPath.h"
+#include "core/Window.h"
 #include "math/MathUtils.h"
 
 using namespace Monolith;
@@ -67,6 +69,36 @@ TEST_CASE("Logger: mixed formatted arguments are handled", "[logger]") {
 TEST_CASE("ProjectPath: Init accepts empty path", "[core][projectpath]") {
     ProjectPath::Init(std::filesystem::path{});
     REQUIRE(ProjectPath::Root().empty());
+}
+
+TEST_CASE("WindowGraphicsApiTraits: OpenGL keeps window-owned presentation behavior",
+          "[core][window]") {
+    const WindowGraphicsApiTraits traits = GetWindowGraphicsApiTraits(WindowGraphicsApi::OpenGL);
+
+    REQUIRE(traits.createsClientContext);
+    REQUIRE(traits.windowOwnsPresentation);
+    REQUIRE(traits.windowOwnsVSync);
+    REQUIRE(traits.windowOwnsViewportResize);
+    REQUIRE(traits.requestsMsaaSamples);
+}
+
+TEST_CASE("WindowGraphicsApiTraits: Vulkan leaves presentation and resize to the backend",
+          "[core][window]") {
+    const WindowGraphicsApiTraits traits = GetWindowGraphicsApiTraits(WindowGraphicsApi::Vulkan);
+
+    REQUIRE_FALSE(traits.createsClientContext);
+    REQUIRE_FALSE(traits.windowOwnsPresentation);
+    REQUIRE_FALSE(traits.windowOwnsVSync);
+    REQUIRE_FALSE(traits.windowOwnsViewportResize);
+    REQUIRE_FALSE(traits.requestsMsaaSamples);
+}
+
+TEST_CASE("AppSpec: aggregate initialization keeps scene path compatibility", "[core][application]") {
+    const AppSpec spec{"Compat App", 1280, 720, true, "assets/scenes/starter_world.json"};
+
+    REQUIRE(spec.name == "Compat App");
+    REQUIRE(spec.defaultSceneFile == "assets/scenes/starter_world.json");
+    REQUIRE(spec.graphicsApi == WindowGraphicsApi::OpenGL);
 }
 
 // ===========================================================================

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -220,11 +220,16 @@ TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]"
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorImGuiBackend: only OpenGL is supported in the current integration slice",
+TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
           "[editor][imgui][backend]") {
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::OpenGL));
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Auto));
+
+#if defined(MONOLITH_HAS_VULKAN)
+    REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
+#else
     REQUIRE_FALSE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
+#endif
 }
 
 TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -22,6 +22,7 @@
 #include "editor/AssetImporterRegistry.h"
 #include "editor/EditorSchema.h"
 #include "editor/EditorAssetImport.h"
+#include "editor/EditorImGuiBackend.h"
 #include "editor/EditorSearch.h"
 #include "editor/EditorUiLogic.h"
 #include "editor/EditorWorkspaceSettings.h"
@@ -217,6 +218,13 @@ TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]"
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile(TmpPath("schema_bad.json")));
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
+}
+
+TEST_CASE("EditorImGuiBackend: only OpenGL is supported in the current integration slice",
+          "[editor][imgui][backend]") {
+    REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::OpenGL));
+    REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Auto));
+    REQUIRE_FALSE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
 }
 
 TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -36,21 +36,24 @@
 using namespace Monolith;
 using namespace Monolith::Editor;
 
-namespace {
-Monolith::Editor::SceneObject MakeObjectFromAssetForTest(const Monolith::Editor::SceneDocument&, const std::string& assetId) {
-    Monolith::Editor::SceneObject obj;
-    obj.id = "generated";
-    obj.type = Monolith::Editor::SceneObjectType::Prop;
-    obj.assetId = assetId;
-    return obj;
-}
+namespace
+{
+    Monolith::Editor::SceneObject MakeObjectFromAssetForTest(const Monolith::Editor::SceneDocument &, const std::string &assetId)
+    {
+        Monolith::Editor::SceneObject obj;
+        obj.id = "generated";
+        obj.type = Monolith::Editor::SceneObjectType::Prop;
+        obj.assetId = assetId;
+        return obj;
+    }
 
-Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::SceneDocument& doc, const Monolith::Editor::SceneObject& src) {
-    Monolith::Editor::SceneObject clone = src;
-    clone.id = "copy_" + std::to_string(doc.objects.size());
-    clone.props.erase("_eid");
-    return clone;
-}
+    Monolith::Editor::SceneObject DuplicateObjectForTest(const Monolith::Editor::SceneDocument &doc, const Monolith::Editor::SceneObject &src)
+    {
+        Monolith::Editor::SceneObject clone = src;
+        clone.id = "copy_" + std::to_string(doc.objects.size());
+        clone.props.erase("_eid");
+        return clone;
+    }
 
 }
 using Catch::Approx;
@@ -59,20 +62,24 @@ using Catch::Approx;
 // Helpers
 // ---------------------------------------------------------------------------
 
-static std::string TmpPath(const std::string& name) {
+static std::string TmpPath(const std::string &name)
+{
     return (std::filesystem::temp_directory_path() / name).string();
 }
 
-static std::filesystem::path RepoRootFromTestSource() {
+static std::filesystem::path RepoRootFromTestSource()
+{
     return std::filesystem::path(__FILE__).parent_path().parent_path().lexically_normal();
 }
 
-static void WriteFile(const std::string& path, const std::string& content) {
+static void WriteFile(const std::string &path, const std::string &content)
+{
     std::ofstream f(path);
     f << content;
 }
 
-static std::filesystem::path NormalizePathForComparison(const std::filesystem::path& path) {
+static std::filesystem::path NormalizePathForComparison(const std::filesystem::path &path)
+{
     if (path.empty())
         return path;
     std::error_code ec;
@@ -81,7 +88,8 @@ static std::filesystem::path NormalizePathForComparison(const std::filesystem::p
         return normalized;
     ec.clear();
     const std::filesystem::path parent = path.parent_path();
-    if (!parent.empty()) {
+    if (!parent.empty())
+    {
         const std::filesystem::path normalizedParent = std::filesystem::weakly_canonical(parent, ec);
         if (!ec)
             return (normalizedParent / path.filename()).lexically_normal();
@@ -89,30 +97,35 @@ static std::filesystem::path NormalizePathForComparison(const std::filesystem::p
     return path.lexically_normal();
 }
 
-struct ProjectPathGuard {
+struct ProjectPathGuard
+{
     std::filesystem::path previousRoot;
 
-    explicit ProjectPathGuard(const std::filesystem::path& nextRoot)
-        : previousRoot(Monolith::ProjectPath::Root()) {
+    explicit ProjectPathGuard(const std::filesystem::path &nextRoot)
+        : previousRoot(Monolith::ProjectPath::Root())
+    {
         Monolith::ProjectPath::Init(nextRoot);
     }
 
-    ~ProjectPathGuard() {
+    ~ProjectPathGuard()
+    {
         Monolith::ProjectPath::Init(previousRoot);
     }
 };
 
-struct HomeDirGuard {
+struct HomeDirGuard
+{
     std::string previousUserProfile;
     std::string previousHomeDrive;
     std::string previousHomePath;
     std::string previousHome;
 
-    static std::string ReadEnv(const char* name) {
+    static std::string ReadEnv(const char *name)
+    {
         if (!name || !*name)
             return {};
 #ifdef _WIN32
-        char* value = nullptr;
+        char *value = nullptr;
         size_t len = 0;
         if (_dupenv_s(&value, &len, name) != 0 || !value)
             return {};
@@ -120,16 +133,17 @@ struct HomeDirGuard {
         free(value);
         return out;
 #else
-        const char* value = std::getenv(name);
+        const char *value = std::getenv(name);
         return value ? std::string(value) : std::string();
 #endif
     }
 
-    explicit HomeDirGuard(const std::filesystem::path& nextHome)
+    explicit HomeDirGuard(const std::filesystem::path &nextHome)
         : previousUserProfile(ReadEnv("USERPROFILE")),
           previousHomeDrive(ReadEnv("HOMEDRIVE")),
           previousHomePath(ReadEnv("HOMEPATH")),
-          previousHome(ReadEnv("HOME")) {
+          previousHome(ReadEnv("HOME"))
+    {
 #ifdef _WIN32
         _putenv_s("USERPROFILE", nextHome.string().c_str());
         _putenv_s("HOMEDRIVE", "");
@@ -139,7 +153,8 @@ struct HomeDirGuard {
 #endif
     }
 
-    ~HomeDirGuard() {
+    ~HomeDirGuard()
+    {
 #ifdef _WIN32
         _putenv_s("USERPROFILE", previousUserProfile.c_str());
         _putenv_s("HOMEDRIVE", previousHomeDrive.c_str());
@@ -153,12 +168,14 @@ struct HomeDirGuard {
     }
 };
 
-struct ImGuiContextGuard {
-    ImGuiContextGuard() {
+struct ImGuiContextGuard
+{
+    ImGuiContextGuard()
+    {
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
-        ImGuiIO& io = ImGui::GetIO();
-        unsigned char* fontPixels = nullptr;
+        ImGuiIO &io = ImGui::GetIO();
+        unsigned char *fontPixels = nullptr;
         int fontWidth = 0;
         int fontHeight = 0;
         io.Fonts->GetTexDataAsRGBA32(&fontPixels, &fontWidth, &fontHeight);
@@ -168,18 +185,20 @@ struct ImGuiContextGuard {
         io.MouseDown[0] = false;
     }
 
-    ~ImGuiContextGuard() {
+    ~ImGuiContextGuard()
+    {
         ImGui::DestroyContext();
     }
 };
 
-static void SeedExternalAssetDragPayload(const char* assetId) {
+static void SeedExternalAssetDragPayload(const char *assetId)
+{
     REQUIRE(assetId != nullptr);
-    ImGuiContext& g = *ImGui::GetCurrentContext();
-    ImGuiPayload& payload = g.DragDropPayload;
+    ImGuiContext &g = *ImGui::GetCurrentContext();
+    ImGuiPayload &payload = g.DragDropPayload;
     payload.Clear();
     payload.SourceId = 1;
-    payload.Data = const_cast<char*>(assetId);
+    payload.Data = const_cast<char *>(assetId);
     payload.DataSize = static_cast<int>(std::strlen(assetId)) + 1;
     payload.DataFrameCount = g.FrameCount;
     payload.Delivery = false;
@@ -200,20 +219,23 @@ static void SeedExternalAssetDragPayload(const char* assetId) {
 // EditorSchema
 // ===========================================================================
 
-TEST_CASE("EditorSchema: missing file is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: missing file is silently ignored", "[editor][schema]")
+{
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile("/nonexistent/path/schema.json"));
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorSchema: empty JSON is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: empty JSON is silently ignored", "[editor][schema]")
+{
     WriteFile(TmpPath("schema_empty.json"), "{}");
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile(TmpPath("schema_empty.json")));
     REQUIRE(schema.GetSchema(SceneObjectType::Panel) == nullptr);
 }
 
-TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]") {
+TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]")
+{
     WriteFile(TmpPath("schema_bad.json"), "{ this is not valid json !!!}");
     EditorSchema schema;
     REQUIRE_NOTHROW(schema.LoadFromFile(TmpPath("schema_bad.json")));
@@ -221,7 +243,8 @@ TEST_CASE("EditorSchema: malformed JSON is silently ignored", "[editor][schema]"
 }
 
 TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
-          "[editor][imgui][backend]") {
+          "[editor][imgui][backend]")
+{
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::OpenGL));
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Auto));
 
@@ -232,7 +255,8 @@ TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
 #endif
 }
 
-TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -253,7 +277,7 @@ TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
@@ -267,7 +291,8 @@ TEST_CASE("EditorSchema: loads Prop mesh as enum field", "[editor][schema]") {
     REQUIRE(ts->fields[0].options[3] == "pyramid");
 }
 
-TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[editor][schema]") {
+TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -282,7 +307,7 @@ TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[ed
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop_mesh_legacy.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
@@ -290,7 +315,8 @@ TEST_CASE("EditorSchema: normalizes legacy Prop mesh string field to enum", "[ed
     REQUIRE_FALSE(ts->fields[0].options.empty());
 }
 
-TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schema]") {
+TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -306,13 +332,14 @@ TEST_CASE("EditorSchema: ignores deprecated Prop isLight field", "[editor][schem
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_prop_islight_deprecated.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields.size() == 1);
     REQUIRE(ts->fields[0].key == "mesh");
 }
 
-TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Light": {
@@ -327,14 +354,15 @@ TEST_CASE("EditorSchema: loads float field with min/max", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_light.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Light);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Light);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Float);
     REQUIRE(ts->fields[0].minVal == Approx(0.0f));
     REQUIRE(ts->fields[0].maxVal == Approx(10.0f));
 }
 
-TEST_CASE("EditorSchema: loads bool field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads bool field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -349,12 +377,13 @@ TEST_CASE("EditorSchema: loads bool field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_bool.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Prop);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Prop);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Bool);
 }
 
-TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Panel": {
@@ -375,7 +404,7 @@ TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_enum.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Panel);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Panel);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Enum);
     REQUIRE(ts->fields[0].options.size() == 3);
@@ -384,7 +413,8 @@ TEST_CASE("EditorSchema: loads enum field with options", "[editor][schema]") {
     REQUIRE(ts->fields[0].options[2] == "stone");
 }
 
-TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Light": {
@@ -399,12 +429,13 @@ TEST_CASE("EditorSchema: loads color3 field", "[editor][schema]") {
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_color.json"));
 
-    const TypeSchema* ts = schema.GetSchema(SceneObjectType::Light);
+    const TypeSchema *ts = schema.GetSchema(SceneObjectType::Light);
     REQUIRE(ts != nullptr);
     REQUIRE(ts->fields[0].widget == FieldDef::Widget::Color3);
 }
 
-TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[editor][schema]") {
+TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -422,7 +453,8 @@ TEST_CASE("EditorSchema: GetSchema returns nullptr for unregistered type", "[edi
     REQUIRE(schema.GetSchema(SceneObjectType::Panel) == nullptr);
 }
 
-TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -454,7 +486,8 @@ TEST_CASE("EditorSchema: loads multiple types", "[editor][schema]") {
     REQUIRE(schema.GetSchema(SceneObjectType::Panel)->fields.size() == 1);
 }
 
-TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]") {
+TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {}
@@ -468,7 +501,8 @@ TEST_CASE("EditorSchema: type without fields is skipped", "[editor][schema]") {
     REQUIRE(schema.GetSchema(SceneObjectType::Prop) == nullptr);
 }
 
-TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor][schema]") {
+TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor][schema]")
+{
     const std::string json = R"({
         "types": {
             "Prop": {
@@ -509,14 +543,14 @@ TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor]
     EditorSchema schema;
     schema.LoadFromFile(TmpPath("schema_components.json"));
 
-    const TypeSchema* propSchema = schema.GetSchemaByName("Prop");
+    const TypeSchema *propSchema = schema.GetSchemaByName("Prop");
     REQUIRE(propSchema != nullptr);
     REQUIRE(propSchema->name == "Prop");
     REQUIRE(propSchema->label == "Prop");
     REQUIRE(propSchema->appliesTo.size() == 1);
     REQUIRE(propSchema->appliesTo[0] == "Prop");
 
-    const ComponentSchema* lightSchema = schema.GetComponentSchema("light");
+    const ComponentSchema *lightSchema = schema.GetComponentSchema("light");
     REQUIRE(lightSchema != nullptr);
     REQUIRE(lightSchema->name == "light");
     REQUIRE(lightSchema->label == "Light");
@@ -532,14 +566,15 @@ TEST_CASE("EditorSchema: loads component schema metadata and lookups", "[editor]
     REQUIRE(lightSchema->fields[1].options.size() == 2);
 }
 
-TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]") {
+TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "[editor][schema]")
+{
     const std::filesystem::path schemaPath = RepoRootFromTestSource() / "assets" / "editor_schema.json";
     REQUIRE(std::filesystem::exists(schemaPath));
 
     EditorSchema schema;
     schema.LoadFromFile(schemaPath.string());
 
-    const ComponentSchema* rigidbody = schema.GetComponentSchema("rigidbody");
+    const ComponentSchema *rigidbody = schema.GetComponentSchema("rigidbody");
     REQUIRE(rigidbody != nullptr);
     REQUIRE(rigidbody->label == "RigidBody");
     REQUIRE(rigidbody->appliesTo.size() == 1);
@@ -549,7 +584,7 @@ TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "
     REQUIRE(rigidbody->fields[0].hasMin);
     REQUIRE(rigidbody->fields[0].minVal == Approx(0.0f));
 
-    const ComponentSchema* script = schema.GetComponentSchema("script");
+    const ComponentSchema *script = schema.GetComponentSchema("script");
     REQUIRE(script != nullptr);
     REQUIRE(script->fields.size() == 1);
     REQUIRE(script->fields[0].key == "behaviorTag");
@@ -560,20 +595,23 @@ TEST_CASE("EditorSchema: bundled schema exposes shared component definitions", "
 // SceneSerializer
 // ===========================================================================
 
-TEST_CASE("SceneSerializer: LoadFromFile throws on missing file", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: LoadFromFile throws on missing file", "[editor][serializer]")
+{
     REQUIRE_THROWS_AS(
         SceneSerializer::LoadFromFile("/nonexistent/scene.json"),
         std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: LoadFromFile throws on invalid JSON", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: LoadFromFile throws on invalid JSON", "[editor][serializer]")
+{
     WriteFile(TmpPath("bad_scene.json"), "{ not json!!! }");
     REQUIRE_THROWS_AS(
         SceneSerializer::LoadFromFile(TmpPath("bad_scene.json")),
         std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]")
+{
     SceneDocument doc;
     doc.filePath = "test.json";
 
@@ -586,7 +624,8 @@ TEST_CASE("SceneSerializer: round-trip empty scene", "[editor][serializer]") {
     REQUIRE(loaded.assets.empty());
 }
 
-TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -603,7 +642,7 @@ TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serialize
     SceneDocument loaded = SceneSerializer::LoadFromFile(path);
 
     REQUIRE(loaded.objects.size() == 1);
-    const auto& o = loaded.objects[0];
+    const auto &o = loaded.objects[0];
     REQUIRE(o.id == "panel_001");
     REQUIRE(o.type == SceneObjectType::Panel);
     REQUIRE(o.position.x == Approx(1.0f));
@@ -614,7 +653,8 @@ TEST_CASE("SceneSerializer: round-trip single Panel object", "[editor][serialize
     REQUIRE(o.props.at("texture") == "wood.png");
 }
 
-TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject prop;
@@ -635,15 +675,25 @@ TEST_CASE("SceneSerializer: round-trip Prop and Light types", "[editor][serializ
 
     REQUIRE(loaded.objects.size() == 2);
     bool foundProp = false, foundLight = false;
-    for (const auto& o : loaded.objects) {
-        if (o.id == "prop_a") { foundProp = true; REQUIRE(o.type == SceneObjectType::Prop); }
-        if (o.id == "light_1") { foundLight = true; REQUIRE(o.type == SceneObjectType::Light); }
+    for (const auto &o : loaded.objects)
+    {
+        if (o.id == "prop_a")
+        {
+            foundProp = true;
+            REQUIRE(o.type == SceneObjectType::Prop);
+        }
+        if (o.id == "light_1")
+        {
+            foundLight = true;
+            REQUIRE(o.type == SceneObjectType::Light);
+        }
     }
     REQUIRE(foundProp);
     REQUIRE(foundLight);
 }
 
-TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]")
+{
     SceneDocument doc;
 
     AssetDef asset;
@@ -673,7 +723,8 @@ TEST_CASE("SceneSerializer: round-trip asset registry", "[editor][serializer]") 
 }
 
 TEST_CASE("SceneSerializer: legacy asset entries gain guid and display name on load",
-          "[editor][serializer]") {
+          "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_asset_identity_scene.json");
     const std::string json = R"({
       "version": 1,
@@ -695,7 +746,8 @@ TEST_CASE("SceneSerializer: legacy asset entries gain guid and display name on l
 }
 
 TEST_CASE("AssetMetadata: EnsureAssetMetadataForDocument writes sidecar files",
-          "[editor][asset-metadata]") {
+          "[editor][asset-metadata]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_metadata_case";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -723,14 +775,15 @@ TEST_CASE("AssetMetadata: EnsureAssetMetadataForDocument writes sidecar files",
 }
 
 TEST_CASE("AssetImporterRegistry: built-in importers resolve by extension and id",
-          "[editor][asset-import]") {
+          "[editor][asset-import]")
+{
     AssetImporterRegistry registry;
-    const AssetImporter* objImporter = registry.FindByExtension("mesh.OBJ");
+    const AssetImporter *objImporter = registry.FindByExtension("mesh.OBJ");
     REQUIRE(objImporter != nullptr);
     REQUIRE(std::string(objImporter->ImporterId()) == "builtin.obj_mesh");
 
-    const AssetImporter* pngImporter = registry.FindByExtension("albedo.png");
-    const AssetImporter* jpgImporter = registry.FindByExtension("albedo.jpg");
+    const AssetImporter *pngImporter = registry.FindByExtension("albedo.png");
+    const AssetImporter *jpgImporter = registry.FindByExtension("albedo.jpg");
     REQUIRE(pngImporter != nullptr);
     REQUIRE(jpgImporter != nullptr);
     REQUIRE(std::string(pngImporter->ImporterId()) == "builtin.texture_copy");
@@ -741,7 +794,8 @@ TEST_CASE("AssetImporterRegistry: built-in importers resolve by extension and id
 }
 
 TEST_CASE("AssetImportService: imports OBJ and persists importer metadata",
-          "[editor][asset-import]") {
+          "[editor][asset-import]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_import_obj";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -775,7 +829,8 @@ TEST_CASE("AssetImportService: imports OBJ and persists importer metadata",
 }
 
 TEST_CASE("AssetImportService: unsupported source yields structured diagnostics",
-          "[editor][asset-import][diagnostics]") {
+          "[editor][asset-import][diagnostics]")
+{
     AssetImportService service;
     AssetImportResult result =
         service.ImportAssetFromSource("C:/tmp/unsupported.txt", "broken", "guid_broken", "Broken");
@@ -788,7 +843,8 @@ TEST_CASE("AssetImportService: unsupported source yields structured diagnostics"
 }
 
 TEST_CASE("AssetImportService: reimport propagation follows deterministic topological order",
-          "[editor][asset-import][reimport]") {
+          "[editor][asset-import][reimport]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_reimport_graph";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -796,12 +852,15 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
     WriteFile((root / "CMakePresets.json").string(), "{}");
     ProjectPathGuard guard(root);
 
-    auto writeObj = [](const std::filesystem::path& path, float xOffset) {
+    auto writeObj = [](const std::filesystem::path &path, float xOffset)
+    {
         WriteFile(path.string(),
                   "v " + std::to_string(xOffset) + " 0 0\n"
-                  "v " + std::to_string(xOffset) + " 1 0\n"
-                  "v " + std::to_string(xOffset + 1.0f) + " 0 0\n"
-                  "f 1 2 3\n");
+                                                   "v " +
+                      std::to_string(xOffset) + " 1 0\n"
+                                                "v " +
+                      std::to_string(xOffset + 1.0f) + " 0 0\n"
+                                                       "f 1 2 3\n");
     };
 
     writeObj(root / "root.obj", 0.0f);
@@ -811,19 +870,21 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
 
     AssetImportService service;
     SceneDocument doc;
-    for (const auto& spec : std::vector<std::tuple<std::string, std::string, std::string>>{
+    for (const auto &spec : std::vector<std::tuple<std::string, std::string, std::string>>{
              {"root", "guid_root", "root.obj"},
              {"alpha", "guid_alpha", "alpha.obj"},
              {"beta", "guid_beta", "beta.obj"},
              {"gamma", "guid_gamma", "gamma.obj"},
-         }) {
+         })
+    {
         AssetImportResult result = service.ImportAssetFromSource(
             (root / std::get<2>(spec)).string(), std::get<0>(spec), std::get<1>(spec), std::get<0>(spec));
         REQUIRE(result.ok);
         doc.assets[std::get<0>(spec)] = result.asset;
     }
 
-    auto addDependency = [](const std::string& guid, const std::string& dependsOnGuid) {
+    auto addDependency = [](const std::string &guid, const std::string &dependsOnGuid)
+    {
         AssetMetadata metadata;
         std::string error;
         REQUIRE(LoadAssetMetadata(guid, &metadata, &error));
@@ -848,7 +909,8 @@ TEST_CASE("AssetImportService: reimport propagation follows deterministic topolo
 }
 
 TEST_CASE("AssetImportService: cyclic dependencies fail reimport with actionable error",
-          "[editor][asset-import][reimport]") {
+          "[editor][asset-import][reimport]")
+{
     const std::filesystem::path root = std::filesystem::temp_directory_path() / "horo_asset_reimport_cycle";
     std::error_code ec;
     std::filesystem::remove_all(root, ec);
@@ -890,7 +952,8 @@ TEST_CASE("AssetImportService: cyclic dependencies fail reimport with actionable
     REQUIRE(aReloaded.diagnostics[0].code == "asset.reimport.dependency_cycle");
 }
 
-TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "prop.obj";
@@ -911,7 +974,8 @@ TEST_CASE("SceneSerializer: asset albedoMap round-trip", "[editor][serializer]")
     REQUIRE(loaded.assets.at("tex_asset").albedoMap == "assets/models/custom_Albedo.png");
 }
 
-TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][serializer]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "x.obj";
@@ -926,7 +990,8 @@ TEST_CASE("SceneSerializer: empty albedoMap not written to JSON", "[editor][seri
     REQUIRE(saved.find("albedoMap") == std::string::npos);
 }
 
-TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[editor][serializer]")
+{
     SceneDocument doc;
 
     AssetDef asset;
@@ -957,7 +1022,8 @@ TEST_CASE("SceneSerializer: asset-backed objects omit inline props block", "[edi
     REQUIRE(loaded.objects[0].assetId == "crate");
 }
 
-TEST_CASE("SceneSerializer: inline props survive when object has no asset reference", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: inline props survive when object has no asset reference", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -977,7 +1043,8 @@ TEST_CASE("SceneSerializer: inline props survive when object has no asset refere
     REQUIRE(loaded.objects[0].props.at("renderScale") == "1.2500,1.2500,1.2500");
 }
 
-TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][serializer]")
+{
     SceneDocument doc;
 
     SceneObject obj;
@@ -997,7 +1064,8 @@ TEST_CASE("SceneSerializer: prefab instance metadata round-trips", "[editor][ser
     REQUIRE(loaded.objects[0].prefabInstance->sourcePath == "assets/prefabs/crate_prefab.horo");
 }
 
-TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[editor]") {
+TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[editor]")
+{
     SceneDocument doc;
     SceneObject src;
     src.id = "prop_001";
@@ -1014,7 +1082,8 @@ TEST_CASE("Editor helpers: duplicating an object clears runtime entity id", "[ed
     REQUIRE(clone.props.at("mesh") == "crate.obj");
 }
 
-TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[editor]") {
+TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[editor]")
+{
     SceneDocument doc;
     AssetDef asset;
     asset.mesh = "torch.obj";
@@ -1026,7 +1095,8 @@ TEST_CASE("Editor helpers: asset-backed object stores selected asset id", "[edit
     REQUIRE(created.assetId == "torch");
 }
 
-TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]") {
+TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]")
+{
     SceneObject obj;
     obj.id = "prop_007";
     obj.type = SceneObjectType::Prop;
@@ -1038,7 +1108,8 @@ TEST_CASE("Editor helpers: object query matches id and asset id", "[editor]") {
     REQUIRE_FALSE(ObjectMatchesQuickOpenQuery(obj, "torch"));
 }
 
-TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[editor]") {
+TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[editor]")
+{
     ShortcutRow row{"Editor", "Quick open", "Ctrl/Cmd + P"};
     REQUIRE(MatchesShortcutQuery(row, "editor"));
     REQUIRE(MatchesShortcutQuery(row, "quick"));
@@ -1046,7 +1117,8 @@ TEST_CASE("Editor helpers: shortcut query matches category command and keys", "[
     REQUIRE_FALSE(MatchesShortcutQuery(row, "delete"));
 }
 
-TEST_CASE("Editor helpers: command palette query matches command and shortcut", "[editor]") {
+TEST_CASE("Editor helpers: command palette query matches command and shortcut", "[editor]")
+{
     CommandPaletteRow row{"save_scene", "Save Scene", "Toolbar"};
     REQUIRE(MatchesCommandPaletteQuery(row, "save"));
     REQUIRE(MatchesCommandPaletteQuery(row, "toolbar"));
@@ -1054,14 +1126,16 @@ TEST_CASE("Editor helpers: command palette query matches command and shortcut", 
     REQUIRE_FALSE(MatchesCommandPaletteQuery(row, "delete"));
 }
 
-TEST_CASE("Editor helpers: object type labels are stable", "[editor]") {
+TEST_CASE("Editor helpers: object type labels are stable", "[editor]")
+{
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Prop)) == "prop");
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Light)) == "light");
     REQUIRE(std::string(ObjectTypeLabel(SceneObjectType::Panel)) == "board");
     REQUIRE(std::string(ObjectTypeLabel(static_cast<SceneObjectType>(999))) == "unknown");
 }
 
-TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]") {
+TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]")
+{
     ShortcutRow row{"Editor", "Quick open", "Ctrl/Cmd + P"};
     REQUIRE(MatchesShortcutQuery(row, ""));
     REQUIRE(ContainsCaseInsensitive("Any Text", ""));
@@ -1078,7 +1152,8 @@ TEST_CASE("Editor helpers: generic search helpers handle empty query", "[editor]
     REQUIRE(AssetMatchesQuickOpenQuery("crate_asset", asset, ""));
 }
 
-TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor]") {
+TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor]")
+{
     AssetDef asset;
     asset.mesh = "assets/models/torch.obj";
     REQUIRE(AssetMatchesQuickOpenQuery("torch_asset", asset, "torch"));
@@ -1086,21 +1161,23 @@ TEST_CASE("Editor helpers: asset quick-open query matches id and mesh", "[editor
     REQUIRE_FALSE(AssetMatchesQuickOpenQuery("torch_asset", asset, "barrel"));
 }
 
-TEST_CASE("Editor helpers: filtered list state handles empty and no-match cases", "[editor]") {
+TEST_CASE("Editor helpers: filtered list state handles empty and no-match cases", "[editor]")
+{
     REQUIRE(EvaluateFilteredListState(3, 1, "") == FilteredListState::None);
     REQUIRE(EvaluateFilteredListState(0, 0, "") == FilteredListState::EmptyData);
     REQUIRE(EvaluateFilteredListState(4, 0, "torch") == FilteredListState::NoMatches);
     REQUIRE(EvaluateFilteredListState(4, 0, "") == FilteredListState::None);
 }
 
-TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]") {
+TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]")
+{
     const auto rows = GetEditorShortcuts();
     REQUIRE_FALSE(rows.empty());
 
-    auto hasCommandWithKeys = [&](const char* command, const char* keys) {
-        return std::any_of(rows.begin(), rows.end(), [&](const ShortcutRow& row) {
-            return std::string(row.command) == command && std::string(row.keys) == keys;
-        });
+    auto hasCommandWithKeys = [&](const char *command, const char *keys)
+    {
+        return std::any_of(rows.begin(), rows.end(), [&](const ShortcutRow &row)
+                           { return std::string(row.command) == command && std::string(row.keys) == keys; });
     };
 
     REQUIRE(hasCommandWithKeys("Run or stop game in viewport", "Toolbar: Play / Stop"));
@@ -1111,24 +1188,28 @@ TEST_CASE("Editor helpers: shortcut table includes required entries", "[editor]"
     REQUIRE(hasCommandWithKeys("Redo last scene change", "Ctrl/Cmd + Shift + Z / Ctrl+Y"));
 }
 
-TEST_CASE("Editor helpers: shortcut table commands are unique", "[editor]") {
+TEST_CASE("Editor helpers: shortcut table commands are unique", "[editor]")
+{
     const auto rows = GetEditorShortcuts();
     std::unordered_set<std::string> commandSet;
 
-    for (const auto& row : rows) {
+    for (const auto &row : rows)
+    {
         const auto [_, inserted] = commandSet.insert(row.command);
         REQUIRE(inserted);
     }
 }
 
-TEST_CASE("Editor asset import: validates obj extension case-insensitively", "[editor]") {
+TEST_CASE("Editor asset import: validates obj extension case-insensitively", "[editor]")
+{
     REQUIRE(IsObjFilePath("/tmp/mesh.obj"));
     REQUIRE(IsObjFilePath("/tmp/MESH.OBJ"));
     REQUIRE_FALSE(IsObjFilePath("/tmp/mesh.fbx"));
     REQUIRE_FALSE(IsObjFilePath(""));
 }
 
-TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[editor]") {
+TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[editor]")
+{
     const std::string path = "/Users/bodur/Downloads/torch_model.obj";
     REQUIRE(AssetIdFromImportedPath(path) == "torch_model");
     REQUIRE(MeshTagFromImportedPath(path) == "assets/models/torch_model.obj");
@@ -1137,7 +1218,8 @@ TEST_CASE("Editor asset import: derives asset id and mesh tag from path", "[edit
     REQUIRE(MeshTagFromImportedPath("").empty());
 }
 
-TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[editor][mcp][filesystem]") {
+TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[editor][mcp][filesystem]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_delete_asset_managed";
@@ -1171,7 +1253,8 @@ TEST_CASE("Editor MCP delete_asset removes managed imported asset folders", "[ed
 }
 
 TEST_CASE("Editor MCP delete_asset keeps manual asset files and removes only registry entry",
-          "[editor][mcp][filesystem]") {
+          "[editor][mcp][filesystem]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_delete_asset_manual";
@@ -1195,7 +1278,8 @@ TEST_CASE("Editor MCP delete_asset keeps manual asset files and removes only reg
     REQUIRE(fs::exists(projectRoot / "assets" / "models" / "crate.obj"));
 }
 
-TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "[editor][mcp][assets]") {
+TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "[editor][mcp][assets]")
+{
     SceneDocument doc;
     doc.assets["crate"] = AssetDef{"assets/models/crate/crate.obj", "1.0000,2.0000,3.0000", ""};
 
@@ -1226,7 +1310,7 @@ TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "
     REQUIRE(rootResult.data["created"]["position"][1].get<float>() == Approx(5.0f));
     REQUIRE(rootResult.data["created"]["position"][2].get<float>() == Approx(6.0f));
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 3);
     REQUIRE(updated.objects[1].props.at("parentId") == "parent_panel");
     REQUIRE(updated.objects[2].position.x == Approx(4.0f));
@@ -1234,7 +1318,8 @@ TEST_CASE("Editor create_object_from_asset shares parent-aware creation path", "
     REQUIRE(updated.objects[2].position.z == Approx(6.0f));
 }
 
-TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor][mcp][selection]") {
+TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor][mcp][selection]")
+{
     SceneDocument doc;
 
     SceneObject first;
@@ -1265,18 +1350,18 @@ TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor]
     REQUIRE(result.data["duplicates"].is_array());
     REQUIRE(result.data["duplicates"].size() == 2);
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 5);
     REQUIRE(updated.dirty);
 
-    const SceneObject& panelClone = updated.objects[3];
+    const SceneObject &panelClone = updated.objects[3];
     REQUIRE(panelClone.id != "panel_a");
     REQUIRE(panelClone.type == SceneObjectType::Panel);
     REQUIRE(panelClone.position.x == Approx(2.0f));
     REQUIRE(panelClone.position.y == Approx(0.0f));
     REQUIRE(panelClone.position.z == Approx(3.0f));
 
-    const SceneObject& lightClone = updated.objects[4];
+    const SceneObject &lightClone = updated.objects[4];
     REQUIRE(lightClone.id != "light_c");
     REQUIRE(lightClone.type == SceneObjectType::Light);
     REQUIRE(lightClone.position.x == Approx(6.0f));
@@ -1289,7 +1374,8 @@ TEST_CASE("Editor MCP duplicate duplicates each selected object once", "[editor]
     REQUIRE(selectedIds[1] == lightClone.id);
 }
 
-TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[editor][mcp][selection]") {
+TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[editor][mcp][selection]")
+{
     SceneDocument doc;
 
     SceneObject source;
@@ -1307,11 +1393,12 @@ TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[edito
     REQUIRE(result.ok);
     REQUIRE(result.data["duplicates"].size() == 3);
 
-    const SceneDocument& updated = editor.GetDocument();
+    const SceneDocument &updated = editor.GetDocument();
     REQUIRE(updated.objects.size() == 4);
 
-    for (size_t i = 1; i < updated.objects.size(); ++i) {
-        const SceneObject& clone = updated.objects[i];
+    for (size_t i = 1; i < updated.objects.size(); ++i)
+    {
+        const SceneObject &clone = updated.objects[i];
         const float expectedOffset = static_cast<float>(i);
         REQUIRE(clone.id != "camera_main");
         REQUIRE(clone.position.x == Approx(10.0f + expectedOffset));
@@ -1326,7 +1413,8 @@ TEST_CASE("Editor MCP duplicate preserves single-object count behavior", "[edito
     REQUIRE(selectedIds[2] == updated.objects[3].id);
 }
 
-TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor][mcp][history]")
+{
     EditorLayer editor;
     editor.LoadDocument(SceneDocument{});
 
@@ -1354,7 +1442,8 @@ TEST_CASE("Editor MCP undo and redo restore created object selection", "[editor]
     REQUIRE(editor.GetSelectedObjectIds() == std::vector<std::string>{"panel_created"});
 }
 
-TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state", "[editor][mcp][history]")
+{
     SceneDocument doc;
 
     SceneObject first;
@@ -1392,7 +1481,8 @@ TEST_CASE("Editor MCP undo and redo restore duplicate selection and dirty state"
     REQUIRE(editor.GetSelectedObjectIds() == duplicatedSelection);
 }
 
-TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][mcp][history]")
+{
     SceneDocument doc;
     doc.sceneId = "forest";
     doc.sceneName = "Forest";
@@ -1422,7 +1512,8 @@ TEST_CASE("Editor MCP undo restores previous scene after new_scene", "[editor][m
     REQUIRE_FALSE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][mcp][history]") {
+TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][mcp][history]")
+{
     SceneDocument doc;
     doc.assets["crate"] = AssetDef{"assets/models/crate.obj", "1,1,1", ""};
 
@@ -1446,7 +1537,8 @@ TEST_CASE("Editor MCP undo restores asset edits and selected asset", "[editor][m
     REQUIRE_FALSE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instance", "[editor][mcp][prefab]") {
+TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instance", "[editor][mcp][prefab]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_editor_create_prefab";
@@ -1480,14 +1572,15 @@ TEST_CASE("Editor MCP create_prefab writes prefab file and links selected instan
     REQUIRE(prefabDoc.objects[0].id == "crate_prop");
     REQUIRE_FALSE(prefabDoc.objects[0].prefabInstance.has_value());
 
-    const SceneObject& updated = editor.GetDocument().objects[0];
+    const SceneObject &updated = editor.GetDocument().objects[0];
     REQUIRE(updated.prefabInstance.has_value());
     REQUIRE(updated.prefabInstance->sourcePath == result.data["prefabPath"].get<std::string>());
     REQUIRE(updated.prefabInstance->prefabId == prefabPath.stem().string());
     REQUIRE(editor.GetDocument().dirty);
 }
 
-TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "[editor][prefab][runtime]") {
+TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "[editor][prefab][runtime]")
+{
     namespace fs = std::filesystem;
 
     const fs::path projectRoot = fs::temp_directory_path() / "horo_runtime_prefab_instance";
@@ -1529,7 +1622,7 @@ TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "
     REQUIRE(runtime.definition.rooms.size() == 1);
     REQUIRE(runtime.definition.rooms[0].props.size() == 1);
 
-    const RuntimeSceneProp& prop = runtime.definition.rooms[0].props[0];
+    const RuntimeSceneProp &prop = runtime.definition.rooms[0].props[0];
     REQUIRE(prop.id == "crate_instance");
     REQUIRE(prop.meshTag == "assets/models/crate.obj");
     REQUIRE(prop.position.x == Approx(8.0f));
@@ -1539,14 +1632,16 @@ TEST_CASE("Runtime bridge resolves linked prefab instances to concrete props", "
     REQUIRE(prop.scale.z == Approx(4.0f));
 }
 
-TEST_CASE("Editor UI logic: hotkey popup triggers only on valid rising edge", "[editor]") {
+TEST_CASE("Editor UI logic: hotkey popup triggers only on valid rising edge", "[editor]")
+{
     REQUIRE(ShouldToggleHelpPopup(true, false, false, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, true, false, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, true, false));
     REQUIRE_FALSE(ShouldToggleHelpPopup(true, false, false, true));
 }
 
-TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "[editor]") {
+TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "[editor]")
+{
     REQUIRE(ShouldOpenQuickOpen(true, false, false, false, false));
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, true, false, false));
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, false, false, true, false));
@@ -1554,14 +1649,15 @@ TEST_CASE("Editor UI logic: quick open is blocked in fly mode and text input", "
     REQUIRE_FALSE(ShouldOpenQuickOpen(true, true, false, false, false));
 }
 
-TEST_CASE("Editor helpers: command palette table includes scene actions", "[editor]") {
+TEST_CASE("Editor helpers: command palette table includes scene actions", "[editor]")
+{
     const auto rows = GetEditorCommands();
     REQUIRE_FALSE(rows.empty());
 
-    auto hasCommand = [&](const char* id, const char* command) {
-        return std::any_of(rows.begin(), rows.end(), [&](const CommandPaletteRow& row) {
-            return std::string(row.id) == id && std::string(row.command) == command;
-        });
+    auto hasCommand = [&](const char *id, const char *command)
+    {
+        return std::any_of(rows.begin(), rows.end(), [&](const CommandPaletteRow &row)
+                           { return std::string(row.id) == id && std::string(row.command) == command; });
     };
 
     REQUIRE(hasCommand("new_scene", "New Scene"));
@@ -1572,14 +1668,16 @@ TEST_CASE("Editor helpers: command palette table includes scene actions", "[edit
     REQUIRE(hasCommand("redo", "Redo"));
 }
 
-TEST_CASE("Editor UI logic: command palette shares quick-open gating", "[editor]") {
+TEST_CASE("Editor UI logic: command palette shares quick-open gating", "[editor]")
+{
     REQUIRE(ShouldOpenCommandPalette(true, false, false, false, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, false, true, false, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, false, false, true, false));
     REQUIRE_FALSE(ShouldOpenCommandPalette(true, true, false, false, false));
 }
 
-TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]") {
+TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]")
+{
     REQUIRE(ShouldCopySelectionRef(true, false, false, false, true));
     REQUIRE_FALSE(ShouldCopySelectionRef(true, false, false, false, false));
     REQUIRE_FALSE(ShouldCopySelectionRef(true, true, false, false, true));
@@ -1588,7 +1686,8 @@ TEST_CASE("Editor UI logic: copy and delete actions gate correctly", "[editor]")
     REQUIRE_FALSE(ShouldRequestDeleteSelection(true, false, false));
 }
 
-TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[editor]") {
+TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[editor]")
+{
     REQUIRE(ShouldHandleEditorEscape(true, false, false, false, false));
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, true, false, false, false));
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, false, true, false, false));
@@ -1596,18 +1695,21 @@ TEST_CASE("Editor UI logic: escape handling respects modal and input gates", "[e
     REQUIRE_FALSE(ShouldHandleEditorEscape(true, false, false, false, true));
 }
 
-TEST_CASE("Editor UI logic: exit decision reflects unsaved state", "[editor]") {
+TEST_CASE("Editor UI logic: exit decision reflects unsaved state", "[editor]")
+{
     REQUIRE(ResolveEditorExitDecision(false) == EditorExitDecision::ExitImmediately);
     REQUIRE(ResolveEditorExitDecision(true) == EditorExitDecision::PromptUnsavedConfirm);
 }
 
-TEST_CASE("Editor UI logic: close finalization waits for pending reload", "[editor]") {
+TEST_CASE("Editor UI logic: close finalization waits for pending reload", "[editor]")
+{
     REQUIRE_FALSE(ShouldFinalizeEditorClose(false, false));
     REQUIRE_FALSE(ShouldFinalizeEditorClose(true, true));
     REQUIRE(ShouldFinalizeEditorClose(true, false));
 }
 
-TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[editor]") {
+TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[editor]")
+{
     EditorStatusText status = BuildEditorStatusText(EditorStatusSnapshot{-2, true, false, true});
     REQUIRE(status.selectionCount == 0);
     REQUIRE(std::string(status.dirtyText) == "yes");
@@ -1621,7 +1723,8 @@ TEST_CASE("Editor UI logic: status text is stable and clamps selection", "[edito
     REQUIRE(std::string(status.reloadText) == "idle");
 }
 
-TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", "[editor]") {
+TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", "[editor]")
+{
     REQUIRE(CanEditSingleSelection(1, 0, 1));
     REQUIRE(CanEditSingleSelection(1, 2, 5));
 
@@ -1631,12 +1734,13 @@ TEST_CASE("Editor UI logic: edit menu enables only for single valid selection", 
     REQUIRE_FALSE(CanEditSingleSelection(1, 5, 5));
 }
 
-TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer]")
+{
     SceneDocument doc;
     SceneObject obj;
     obj.id = "obj1";
     obj.type = SceneObjectType::Panel;
-    obj.props["_eid"] = "42";  // runtime-only, should not be persisted
+    obj.props["_eid"] = "42"; // runtime-only, should not be persisted
     obj.props["visible"] = "true";
     doc.objects.push_back(obj);
 
@@ -1649,7 +1753,8 @@ TEST_CASE("SceneSerializer: _eid prop is stripped on save", "[editor][serializer
     REQUIRE(loaded.objects[0].props.count("visible") == 1);
 }
 
-TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_islight_true.json");
     const std::string json = R"({
       "version": 1,
@@ -1674,7 +1779,8 @@ TEST_CASE("SceneSerializer: legacy isLight=true migrates to light component", "[
     REQUIRE(loaded.objects[0].components[0].type == "light");
 }
 
-TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted", "[editor][serializer]")
+{
     const std::string path = TmpPath("legacy_islight_false.json");
     const std::string json = R"({
       "version": 1,
@@ -1704,7 +1810,8 @@ TEST_CASE("SceneSerializer: legacy isLight=false is tolerated but not persisted"
     REQUIRE(roundTrip.objects[0].props.count("isLight") == 0);
 }
 
-TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][serializer]")
+{
     SceneDocument doc;
     // Unix: true root path — mkdir/open fail without privileges.
     // Windows: a leading "/" is *not* filesystem root; it resolves under the current drive
@@ -1718,7 +1825,8 @@ TEST_CASE("SceneSerializer: SaveToFile throws on unwriteable path", "[editor][se
     REQUIRE_THROWS_AS(SceneSerializer::SaveToFile(doc, badPath), std::runtime_error);
 }
 
-TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]")
+{
     SceneDocument doc;
     const std::string path = TmpPath("filepath_test.json");
     SceneSerializer::SaveToFile(doc, path);
@@ -1727,7 +1835,8 @@ TEST_CASE("SceneSerializer: filePath is set after load", "[editor][serializer]")
     REQUIRE(loaded.filePath == path);
 }
 
-TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]") {
+TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]")
+{
     SceneDocument doc;
     SceneObject obj;
     obj.id = "multi_prop";
@@ -1750,102 +1859,110 @@ TEST_CASE("SceneSerializer: multiple props round-trip", "[editor][serializer]") 
 // Raycaster — RayVsAABB
 // ===========================================================================
 
-TEST_CASE("RayVsAABB: direct hit along +X axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: direct hit along +X axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 0.0f, 0.0f};
+    ray.origin = {-5.0f, 0.0f, 0.0f};
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
-    REQUIRE(t == Approx(4.0f).epsilon(1e-4f));  // ray travels 4 units before hitting near face
+    REQUIRE(t == Approx(4.0f).epsilon(1e-4f)); // ray travels 4 units before hitting near face
 }
 
-TEST_CASE("RayVsAABB: miss — ray passes above the box", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: miss — ray passes above the box", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 3.0f, 0.0f};  // y=3, above a box with half=1
+    ray.origin = {-5.0f, 3.0f, 0.0f}; // y=3, above a box with half=1
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: ray origin inside box returns 0", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: ray origin inside box returns 0", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, 0.0f, 0.0f};  // inside the box
+    ray.origin = {0.0f, 0.0f, 0.0f}; // inside the box
     ray.direction = {1.0f, 0.0f, 0.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(0.0f).margin(1e-5f));
 }
 
-TEST_CASE("RayVsAABB: parallel ray outside slab misses", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: parallel ray outside slab misses", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {5.0f, 5.0f, 0.0f};   // outside x-slab of box centered at origin
-    ray.direction = {0.0f, 0.0f, 1.0f};   // moves in Z only — parallel to Y slab
+    ray.origin = {5.0f, 5.0f, 0.0f};    // outside x-slab of box centered at origin
+    ray.direction = {0.0f, 0.0f, 1.0f}; // moves in Z only — parallel to Y slab
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: parallel ray inside slab hits", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: parallel ray inside slab hits", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {-5.0f, 0.0f, 0.0f};
-    ray.direction = {0.0f, 0.0f, 1.0f};   // moves in Z, inside x and y slabs
+    ray.origin = {-5.0f, 0.0f, 0.0f};
+    ray.direction = {0.0f, 0.0f, 1.0f}; // moves in Z, inside x and y slabs
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     // parallel x-axis: origin.x=-5 is outside [-1,1] → should miss
     REQUIRE(t < 0.0f);
 }
 
-TEST_CASE("RayVsAABB: hit along -Z axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: hit along -Z axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, 0.0f, 10.0f};
+    ray.origin = {0.0f, 0.0f, 10.0f};
     ray.direction = {0.0f, 0.0f, -1.0f};
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {0.5f, 0.5f, 0.5f};
+    Vec3 half = {0.5f, 0.5f, 0.5f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(9.5f).epsilon(1e-4f));
 }
 
-TEST_CASE("RayVsAABB: hit along +Y axis", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: hit along +Y axis", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {0.0f, -5.0f, 0.0f};
+    ray.origin = {0.0f, -5.0f, 0.0f};
     ray.direction = {0.0f, 1.0f, 0.0f};
 
     Vec3 center = {0.0f, 2.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t >= 0.0f);
     REQUIRE(t == Approx(6.0f).epsilon(1e-4f));
 }
 
-TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]") {
+TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]")
+{
     Ray ray;
-    ray.origin    = {10.0f, 0.0f, 0.0f};
-    ray.direction = {1.0f, 0.0f, 0.0f};  // pointing away from origin box
+    ray.origin = {10.0f, 0.0f, 0.0f};
+    ray.direction = {1.0f, 0.0f, 0.0f}; // pointing away from origin box
 
     Vec3 center = {0.0f, 0.0f, 0.0f};
-    Vec3 half   = {1.0f, 1.0f, 1.0f};
+    Vec3 half = {1.0f, 1.0f, 1.0f};
 
     float t = RayVsAABB(ray, center, half);
     REQUIRE(t < 0.0f);
@@ -1855,52 +1972,55 @@ TEST_CASE("RayVsAABB: ray pointing away from box misses", "[editor][raycaster]")
 // Raycaster — ScreenToRay
 // ===========================================================================
 
-TEST_CASE("ScreenToRay: center of screen produces ray through view center", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: center of screen produces ray through view center", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {0.0f, 0.0f, 5.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 1.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 1.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     int W = 800, H = 800;
     Ray ray = ScreenToRay(W / 2.0f, H / 2.0f, W, H, cam);
 
     REQUIRE(ray.direction.x == Approx(0.0f).margin(1e-3f));
     REQUIRE(ray.direction.y == Approx(0.0f).margin(1e-3f));
-    REQUIRE(ray.direction.z < 0.0f);  // pointing toward -Z (into the scene)
+    REQUIRE(ray.direction.z < 0.0f); // pointing toward -Z (into the scene)
 }
 
-TEST_CASE("ScreenToRay: direction is normalized", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: direction is normalized", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {0.0f, 0.0f, 5.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 16.0f / 9.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 16.0f / 9.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     // Test multiple screen positions
-    for (auto [mx, my] : std::initializer_list<std::pair<float,float>>{
-        {0.0f, 0.0f}, {200.0f, 150.0f}, {400.0f, 300.0f}, {799.0f, 449.0f}
-    }) {
+    for (auto [mx, my] : std::initializer_list<std::pair<float, float>>{
+             {0.0f, 0.0f}, {200.0f, 150.0f}, {400.0f, 300.0f}, {799.0f, 449.0f}})
+    {
         Ray r = ScreenToRay(mx, my, 800, 450, cam);
         REQUIRE(r.direction.Length() == Approx(1.0f).epsilon(1e-4f));
     }
 }
 
-TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]") {
+TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]")
+{
     Camera cam;
     cam.position = {3.0f, 2.0f, 7.0f};
-    cam.target   = {0.0f, 0.0f, 0.0f};
-    cam.up       = Vec3::Up();
-    cam.fovY     = 60.0f;
-    cam.aspect   = 1.0f;
-    cam.zNear    = 0.1f;
-    cam.zFar     = 100.0f;
+    cam.target = {0.0f, 0.0f, 0.0f};
+    cam.up = Vec3::Up();
+    cam.fovY = 60.0f;
+    cam.aspect = 1.0f;
+    cam.zNear = 0.1f;
+    cam.zFar = 100.0f;
 
     Ray ray = ScreenToRay(400.0f, 300.0f, 800, 600, cam);
 
@@ -1914,28 +2034,35 @@ TEST_CASE("ScreenToRay: origin is at/near camera position", "[editor][raycaster]
 // ===========================================================================
 
 // Mirror of the selection logic in EditorLayer::DrawObjectsTree.
-static void ApplyHierarchyClick(std::vector<int>& sel, int& lastIdx,
-                                 int clicked, bool shift, bool ctrl) {
-    if (shift && lastIdx >= 0) {
+static void ApplyHierarchyClick(std::vector<int> &sel, int &lastIdx,
+                                int clicked, bool shift, bool ctrl)
+{
+    if (shift && lastIdx >= 0)
+    {
         const int lo = std::min(lastIdx, clicked);
         const int hi = std::max(lastIdx, clicked);
         sel.clear();
         for (int i = lo; i <= hi; ++i)
             sel.push_back(i);
-    } else if (ctrl) {
+    }
+    else if (ctrl)
+    {
         auto it = std::find(sel.begin(), sel.end(), clicked);
         if (it != sel.end())
             sel.erase(it);
         else
             sel.push_back(clicked);
         lastIdx = clicked;
-    } else {
+    }
+    else
+    {
         sel = {clicked};
         lastIdx = clicked;
     }
 }
 
-TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1950,7 +2077,8 @@ TEST_CASE("Hierarchy plain click replaces selection", "[editor][hierarchy]") {
     REQUIRE(last == 7);
 }
 
-TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1971,7 +2099,8 @@ TEST_CASE("Hierarchy range select fills contiguous range", "[editor][hierarchy]"
     REQUIRE(sel[2] == 2);
 }
 
-TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single select", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single select", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
@@ -1983,16 +2112,17 @@ TEST_CASE("Hierarchy shift-click with no prior anchor falls back to single selec
     REQUIRE(last == 4);
 }
 
-TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]") {
+TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]")
+{
     std::vector<int> sel;
     int last = -1;
 
     ApplyHierarchyClick(sel, last, 1, false, false);
-    ApplyHierarchyClick(sel, last, 3, false, true);  // ctrl-add 3
-    ApplyHierarchyClick(sel, last, 5, false, true);  // ctrl-add 5
+    ApplyHierarchyClick(sel, last, 3, false, true); // ctrl-add 3
+    ApplyHierarchyClick(sel, last, 5, false, true); // ctrl-add 5
     REQUIRE(sel.size() == 3);
 
-    ApplyHierarchyClick(sel, last, 3, false, true);  // ctrl-remove 3
+    ApplyHierarchyClick(sel, last, 3, false, true); // ctrl-remove 3
     REQUIRE(sel.size() == 2);
     REQUIRE(std::find(sel.begin(), sel.end(), 3) == sel.end());
 }
@@ -2001,13 +2131,14 @@ TEST_CASE("Hierarchy ctrl-click toggles individual items", "[editor][hierarchy]"
 // Drag-drop ray-floor intersection math
 // ===========================================================================
 
-TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]") {
+TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]")
+{
     // Ray from above looking straight down
     Ray r;
-    r.origin    = {0.0f, 5.0f, 0.0f};
+    r.origin = {0.0f, 5.0f, 0.0f};
     r.direction = {0.0f, -1.0f, 0.0f};
 
-    const float t = -r.origin.y / r.direction.y;  // = 5
+    const float t = -r.origin.y / r.direction.y; // = 5
     const Vec3 hit = {r.origin.x + r.direction.x * t,
                       r.origin.y + r.direction.y * t,
                       r.origin.z + r.direction.z * t};
@@ -2023,10 +2154,11 @@ TEST_CASE("Drop ray hits y=0 plane correctly", "[editor][dragdrop]") {
     REQUIRE(helperHit.z == Approx(0.0f));
 }
 
-TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]") {
+TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]")
+{
     // Ray from (3, 4, 1) pointing down-forward
     Ray r;
-    r.origin    = {3.0f, 4.0f, 1.0f};
+    r.origin = {3.0f, 4.0f, 1.0f};
     // Direction: slightly forward (+z) and mostly down
     const float len = std::sqrt(1.0f + 16.0f);
     r.direction = {0.0f, -4.0f / len, 1.0f / len};
@@ -2037,10 +2169,11 @@ TEST_CASE("Drop ray hits y=0 plane at correct XZ", "[editor][dragdrop]") {
                       r.origin.z + r.direction.z * t};
 
     REQUIRE(hit.y == Approx(0.0f).margin(1e-4f));
-    REQUIRE(hit.x == Approx(3.0f).margin(1e-4f));  // no x-component in direction
+    REQUIRE(hit.x == Approx(3.0f).margin(1e-4f)); // no x-component in direction
 }
 
-TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]") {
+TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]")
+{
     Ray r;
     r.origin = {2.0f, 3.0f, 4.0f};
     r.direction = {1.0f, 0.0f, 0.0f};
@@ -2049,7 +2182,8 @@ TEST_CASE("Drop ray parallel to ground plane is rejected", "[editor][dragdrop]")
     REQUIRE_FALSE(TryIntersectGroundPlane(r, &hit));
 }
 
-TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdrop]") {
+TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdrop]")
+{
     Ray ray;
     ray.origin = {0.0f, 5.0f, 0.0f};
     ray.direction = {0.0f, -1.0f, 0.0f};
@@ -2065,7 +2199,8 @@ TEST_CASE("RayVsAABBHit reports top-face hit point and normal", "[editor][dragdr
     REQUIRE(hit.normal.z == Approx(0.0f));
 }
 
-TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragdrop]") {
+TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragdrop]")
+{
     Ray ray;
     ray.origin = {-5.0f, 0.25f, 0.0f};
     ray.direction = {1.0f, 0.0f, 0.0f};
@@ -2081,7 +2216,8 @@ TEST_CASE("RayVsAABBHit reports side-face hit point and normal", "[editor][dragd
     REQUIRE(hit.normal.z == Approx(0.0f));
 }
 
-TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]") {
+TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]")
+{
     const EditorViewportRect rect =
         BuildEditorViewportRect(1600.0f, 900.0f, 36.0f, 24.0f, 200.0f, 308.0f, 280.0f);
 
@@ -2095,7 +2231,8 @@ TEST_CASE("Editor viewport rect excludes docks and panels", "[editor][ui]") {
     REQUIRE_FALSE(rect.Contains(600.0f, 800.0f));
 }
 
-TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect", "[editor][ui]") {
+TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect", "[editor][ui]")
+{
     const EditorViewportRect viewport =
         BuildEditorViewportRect(1600.0f, 900.0f, 36.0f, 24.0f, 200.0f, 308.0f, 280.0f);
     const EditorViewGimbalLayout layout =
@@ -2112,7 +2249,8 @@ TEST_CASE("Editor view gimbal layout reserves wire button and combined pick rect
     REQUIRE(layout.pickRect.Contains(layout.gimbalRect.maxX - 4.0f, layout.gimbalRect.maxY - 4.0f));
 }
 
-TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[editor][ui]") {
+TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[editor][ui]")
+{
     REQUIRE(ComputeEditorLeftDockWidth(1200.0f) == Approx(220.0f));
     REQUIRE(ComputeEditorLeftDockWidth(2400.0f) == Approx(320.0f));
 
@@ -2123,11 +2261,12 @@ TEST_CASE("Editor layout helpers clamp dock widths and workspace height", "[edit
     REQUIRE(ComputeEditorBottomDockHeight(1440.0f) == Approx(259.2f));
 }
 
-TEST_CASE("Editor viewport asset drop target matches active asset payload inline", "[editor][ui][dragdrop]") {
+TEST_CASE("Editor viewport asset drop target matches active asset payload inline", "[editor][ui][dragdrop]")
+{
     ImGuiContextGuard imgui;
     bool callbackInvoked = false;
 
-    ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO &io = ImGui::GetIO();
     io.MousePos = ImVec2(48.0f, 48.0f);
 
     ImGui::NewFrame();
@@ -2135,7 +2274,7 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
     ImGui::SetNextWindowSize(ImVec2(320.0f, 240.0f), ImGuiCond_Always);
     ImGui::Begin("ViewportTest");
 
-    ImGuiContext& g = *ImGui::GetCurrentContext();
+    ImGuiContext &g = *ImGui::GetCurrentContext();
     g.HoveredWindow = ImGui::GetCurrentWindow();
     g.HoveredWindowUnderMovingWindow = ImGui::GetCurrentWindow();
     SeedExternalAssetDragPayload("crate");
@@ -2145,8 +2284,9 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
         220.0f,
         140.0f,
         &callbackInvoked,
-        [](void* userData, const char* assetId) {
-            auto* invoked = static_cast<bool*>(userData);
+        [](void *userData, const char *assetId)
+        {
+            auto *invoked = static_cast<bool *>(userData);
             *invoked = true;
             return assetId && std::string(assetId) == "crate";
         });
@@ -2161,11 +2301,12 @@ TEST_CASE("Editor viewport asset drop target matches active asset payload inline
     REQUIRE_FALSE(callbackInvoked);
 }
 
-TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "[editor][ui][dragdrop]") {
+TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "[editor][ui][dragdrop]")
+{
     ImGuiContextGuard imgui;
     bool callbackInvoked = false;
 
-    ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO &io = ImGui::GetIO();
     io.MousePos = ImVec2(48.0f, 48.0f);
 
     ImGui::NewFrame();
@@ -2173,7 +2314,7 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
     ImGui::SetNextWindowSize(ImVec2(320.0f, 240.0f), ImGuiCond_Always);
     ImGui::Begin("ViewportPlayModeTest");
 
-    ImGuiContext& g = *ImGui::GetCurrentContext();
+    ImGuiContext &g = *ImGui::GetCurrentContext();
     g.HoveredWindow = ImGui::GetCurrentWindow();
     g.HoveredWindowUnderMovingWindow = ImGui::GetCurrentWindow();
     SeedExternalAssetDragPayload("crate");
@@ -2183,8 +2324,9 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
         220.0f,
         140.0f,
         &callbackInvoked,
-        [](void* userData, const char*) {
-            auto* invoked = static_cast<bool*>(userData);
+        [](void *userData, const char *)
+        {
+            auto *invoked = static_cast<bool *>(userData);
             *invoked = true;
             return true;
         });
@@ -2199,7 +2341,8 @@ TEST_CASE("Editor viewport asset drop target stays inactive during play mode", "
     REQUIRE_FALSE(callbackInvoked);
 }
 
-TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_missing";
     fs::remove_all(tempHome);
@@ -2217,7 +2360,8 @@ TEST_CASE("Editor workspace settings: missing file falls back to defaults", "[ed
     REQUIRE(ResolveEditorWorkspacePath() == tempHome / ".horo" / "editor_workspace.json");
 }
 
-TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_invalid";
     fs::remove_all(tempHome);
@@ -2232,7 +2376,8 @@ TEST_CASE("Editor workspace settings: invalid JSON reports parse fallback", "[ed
     REQUIRE(loaded.state.consoleShowInfo);
 }
 
-TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[editor][workspace]") {
+TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[editor][workspace]")
+{
     namespace fs = std::filesystem;
     const fs::path tempHome = fs::temp_directory_path() / "horo_editor_workspace_roundtrip";
     fs::remove_all(tempHome);
@@ -2259,7 +2404,8 @@ TEST_CASE("Editor workspace settings: round-trip console filters and cwd", "[edi
     REQUIRE(loaded.state.projectBrowserCwd == "C:/project/assets");
 }
 
-TEST_CASE("Vec3 CSV parser accepts render scale triples", "[editor][ui]") {
+TEST_CASE("Vec3 CSV parser accepts render scale triples", "[editor][ui]")
+{
     Vec3 parsed = Vec3::Zero();
     REQUIRE(TryParseVec3Csv("1.5000, 2.0000,0.7500", &parsed));
     REQUIRE(parsed.x == Approx(1.5f));

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -230,6 +230,21 @@ TEST_CASE("Vulkan material translation snapshots backend-relevant material state
   REQUIRE_FALSE(translated.usesCustomShader);
 }
 
+TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
+          "[renderer][foundation][vulkan][pipeline]") {
+  VulkanRenderBackend::TranslatedMaterialState materialState;
+  materialState.usesAlbedoMap = true;
+  materialState.usesCustomShader = false;
+
+  const VulkanRenderBackend::OpaquePipelineKey key =
+      VulkanRenderBackend::BuildOpaquePipelineKey(materialState);
+
+  REQUIRE(key.usesAlbedoMap);
+  REQUIRE_FALSE(key.usesCustomShader);
+  REQUIRE(key.writesDepth);
+  REQUIRE(key.depthTestEnabled);
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -135,10 +135,12 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
   REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
 
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
+  REQUIRE(caps.supportsDebugDraw);
   REQUIRE(caps.supportsWireframeOverlay);
   REQUIRE(caps.supportsOffscreenTargets);
   REQUIRE(caps.supportsNativeTextureHandles);
   REQUIRE(caps.supportsReadback);
+  REQUIRE(caps.supportsDepthReadback);
   REQUIRE(caps.supportsDebugHud);
   REQUIRE_FALSE(caps.supportsComputePasses);
 }
@@ -158,10 +160,12 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 
   const RenderBackendCapabilities vulkanCaps =
       GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  REQUIRE_FALSE(vulkanCaps.supportsDebugDraw);
   REQUIRE_FALSE(vulkanCaps.supportsWireframeOverlay);
   REQUIRE_FALSE(vulkanCaps.supportsOffscreenTargets);
   REQUIRE_FALSE(vulkanCaps.supportsNativeTextureHandles);
   REQUIRE_FALSE(vulkanCaps.supportsReadback);
+  REQUIRE_FALSE(vulkanCaps.supportsDepthReadback);
   REQUIRE_FALSE(vulkanCaps.supportsDebugHud);
 #else
   REQUIRE_FALSE(init.ok);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+#if defined(MONOLITH_HAS_VULKAN)
+#include <GLFW/glfw3.h>
+#endif
+
 #include "math/Mat4.h"
 #include "renderer/IRenderBackend.h"
 #include "renderer/Material.h"
@@ -167,6 +171,55 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
   REQUIRE_FALSE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
 #endif
 }
+
+#if defined(MONOLITH_HAS_VULKAN)
+TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
+          "[renderer][foundation][vulkan][opaque]") {
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported()) {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
+  if (!window) {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan backend test");
+  }
+
+  RenderBackendSelection selection;
+  selection.requested = RenderBackendId::Vulkan;
+  selection.nativeWindowHandle = window;
+  const RenderBackendInitResult init = Renderer::InitializeBackend(selection);
+
+  if (!init.ok) {
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    FAIL(init.error);
+  }
+
+  Mesh mesh;
+  Material material;
+  Camera camera;
+
+  Renderer::BeginFrame({{}, "vulkan-opaque-scene"});
+  Renderer::BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-opaque-pass"});
+  Renderer::Submit(mesh, Mat4::Identity(), material);
+  Renderer::EndPass();
+  Renderer::EndFrame();
+
+  REQUIRE(Renderer::GetBackendId() == RenderBackendId::Vulkan);
+  REQUIRE(Renderer::GetDrawCallCount() == 1);
+
+  Renderer::ResetBackend();
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+#endif
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",
           "[renderer][foundation]") {

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -80,7 +80,52 @@ namespace
       return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
     }
     int GetDrawCallCount() const override { return drawCalls; }
-
+    bool ReadbackColorBgr8(int width,
+                           int height,
+                           std::vector<uint8_t> &outPixels,
+                           std::string *outError) override
+    {
+      if (width <= 0 || height <= 0)
+      {
+        if (outError)
+          *outError = "invalid color readback dimensions";
+        return false;
+      }
+      outPixels.assign(static_cast<size_t>(width * height * 3), 0u);
+      return true;
+    }
+    bool ReadbackDepth32F(int width,
+                          int height,
+                          std::vector<float> &outDepth,
+                          std::string *outError) override
+    {
+      if (width <= 0 || height <= 0)
+      {
+        if (outError)
+          *outError = "invalid depth readback dimensions";
+        return false;
+      }
+      outDepth.assign(static_cast<size_t>(width * height), 1.0f);
+      return true;
+    }
+    bool EnsureEditorViewportRenderTarget(uint32_t,
+                                          uint32_t,
+                                          std::string *outError) override
+    {
+      if (outError)
+        *outError = "fake backend has no viewport targets";
+      return false;
+    }
+    bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                bool,
+                                                std::string *outError) override
+    {
+      if (outHandle)
+        *outHandle = {};
+      if (outError)
+        *outError = "fake backend has no viewport target handle";
+      return false;
+    }
     std::vector<std::string> events;
     RenderFrameConfig lastFrame;
     RenderPassConfig lastPass;
@@ -133,6 +178,19 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
   REQUIRE(backend.lastMesh.mesh == &mesh);
   REQUIRE(backend.lastMesh.material == &material);
   REQUIRE(Renderer::GetDrawCallCount() == 1);
+  std::vector<uint8_t> colorReadback;
+  std::vector<float> depthReadback;
+  std::string readbackError;
+  REQUIRE(Renderer::ReadbackColorBgr8(2, 2, colorReadback, &readbackError));
+  REQUIRE(colorReadback.size() == 12u);
+  REQUIRE(Renderer::ReadbackDepth32F(2, 2, depthReadback, &readbackError));
+  REQUIRE(depthReadback.size() == 4u);
+  RenderTargetHandle viewportHandle;
+  REQUIRE_FALSE(Renderer::EnsureEditorViewportRenderTarget(320u, 180u, &readbackError));
+  REQUIRE(readbackError.find("no viewport targets") != std::string::npos);
+  REQUIRE_FALSE(Renderer::TryGetEditorViewportRenderTargetHandle(&viewportHandle, false, &readbackError));
+  REQUIRE(readbackError.find("no viewport target handle") != std::string::npos);
+  REQUIRE_FALSE(viewportHandle.IsValid());
 
   Renderer::ResetBackend();
 }
@@ -195,8 +253,8 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
       GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   REQUIRE_FALSE(vulkanCaps.supportsDebugDraw);
   REQUIRE_FALSE(vulkanCaps.supportsWireframeOverlay);
-  REQUIRE_FALSE(vulkanCaps.supportsOffscreenTargets);
-  REQUIRE_FALSE(vulkanCaps.supportsNativeTextureHandles);
+  REQUIRE(vulkanCaps.supportsOffscreenTargets);
+  REQUIRE(vulkanCaps.supportsNativeTextureHandles);
   REQUIRE_FALSE(vulkanCaps.supportsReadback);
   REQUIRE_FALSE(vulkanCaps.supportsDepthReadback);
   REQUIRE_FALSE(vulkanCaps.supportsDebugHud);
@@ -235,8 +293,8 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   const RenderBackendCapabilities vkCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   REQUIRE_FALSE(vkCaps.supportsDebugDraw);
   REQUIRE_FALSE(vkCaps.supportsWireframeOverlay);
-  REQUIRE_FALSE(vkCaps.supportsOffscreenTargets);
-  REQUIRE_FALSE(vkCaps.supportsNativeTextureHandles);
+  REQUIRE(vkCaps.supportsOffscreenTargets);
+  REQUIRE(vkCaps.supportsNativeTextureHandles);
   REQUIRE_FALSE(vkCaps.supportsReadback);
   REQUIRE_FALSE(vkCaps.supportsDepthReadback);
   REQUIRE_FALSE(vkCaps.supportsDebugHud);
@@ -250,6 +308,9 @@ TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
   REQUIRE(glHandle.backendId == RenderBackendId::OpenGL);
   REQUIRE(glHandle.nativeType == RenderNativeHandleType::OpenGLTexture2D);
   REQUIRE(glHandle.nativeHandle == 42u);
+  REQUIRE(glHandle.width == 0u);
+  REQUIRE(glHandle.height == 0u);
+  REQUIRE(glHandle.generation == 0u);
   REQUIRE(glHandle.needsYFlip);
 
   void *fakeDescriptorSet = reinterpret_cast<void *>(0x1234);
@@ -259,6 +320,9 @@ TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
   REQUIRE(vkHandle.backendId == RenderBackendId::Vulkan);
   REQUIRE(vkHandle.nativeType == RenderNativeHandleType::VulkanImGuiDescriptorSet);
   REQUIRE(vkHandle.nativeHandle == static_cast<uint64_t>(0x1234));
+  REQUIRE(vkHandle.width == 0u);
+  REQUIRE(vkHandle.height == 0u);
+  REQUIRE(vkHandle.generation == 0u);
   REQUIRE_FALSE(vkHandle.needsYFlip);
 }
 
@@ -324,10 +388,19 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
 
   VulkanRenderBackend backend(window);
   REQUIRE(backend.IsInitialized());
+  int framebufferWidth = 0;
+  int framebufferHeight = 0;
+  glfwGetFramebufferSize(window, &framebufferWidth, &framebufferHeight);
+  framebufferWidth = std::max(framebufferWidth, 1);
+  framebufferHeight = std::max(framebufferHeight, 1);
   REQUIRE(backend.HasOpaqueRasterScaffold());
   REQUIRE(backend.HasOpaquePipelineCreationScaffold());
   REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
   REQUIRE(backend.HasOpaqueGraphicsPipelineScaffold());
+  if (!backend.HasOpaqueDrawExecutionReady())
+  {
+    REQUIRE(backend.GetLastError().find("shader modules") != std::string::npos);
+  }
 
   void *instanceHandle = nullptr;
   void *physicalDeviceHandle = nullptr;
@@ -405,8 +478,8 @@ TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with
   glfwTerminate();
 }
 
-TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaque draw execution",
-          "[renderer][foundation][vulkan][opaque][diagnostics]")
+TEST_CASE("Vulkan backend executes opaque indexed draws when shader pipeline is ready",
+          "[renderer][foundation][vulkan][opaque][draw-indexed]")
 {
   if (!glfwInit())
     SKIP("GLFW initialization failed on this machine");
@@ -429,7 +502,7 @@ TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaqu
   VulkanRenderBackend backend(window);
   REQUIRE(backend.IsInitialized());
 
-  Mesh mesh;
+  Mesh mesh = Mesh::CreateQuad();
   Material material;
   Camera camera;
 
@@ -440,8 +513,16 @@ TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaqu
   backend.EndFrame();
 
   REQUIRE(backend.GetDrawCallCount() == 1);
-  REQUIRE(backend.GetLastError().find("draw submissions are queued") != std::string::npos);
-  REQUIRE(backend.GetLastError().find("Pending draws: 1") != std::string::npos);
+  if (!backend.HasOpaqueDrawExecutionReady())
+  {
+    REQUIRE(backend.GetLastError().find("shader modules") != std::string::npos);
+    REQUIRE(backend.GetExecutedOpaqueIndexedDrawCount() == 0);
+  }
+  else
+  {
+    REQUIRE(backend.GetExecutedOpaqueIndexedDrawCount() >= 1);
+    REQUIRE(backend.GetLastError().find("draw submissions are queued") == std::string::npos);
+  }
 
   glfwDestroyWindow(window);
   glfwTerminate();
@@ -484,6 +565,331 @@ TEST_CASE("Vulkan backend executes queued overlay callbacks while recording fram
 
   REQUIRE(overlayProbe.invoked);
   REQUIRE(overlayProbe.commandBufferHandle != nullptr);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan backend manages offscreen render-target lifecycle and resize metadata",
+          "[renderer][foundation][vulkan][offscreen]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-offscreen-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan offscreen target test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+  const RenderBackendCapabilities caps = backend.GetCapabilities();
+  REQUIRE(caps.supportsOffscreenTargets);
+  REQUIRE(caps.supportsNativeTextureHandles);
+
+  const std::string targetKey = "editor-thumb:mesh-a";
+  REQUIRE_FALSE(backend.EnsureOffscreenRenderTarget(targetKey, 0, 128));
+  REQUIRE(backend.GetLastError().find("non-zero") != std::string::npos);
+
+  REQUIRE(backend.EnsureOffscreenRenderTarget(targetKey, 128, 128));
+  VulkanRenderBackend::OffscreenTargetMetadata metadata{};
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata(targetKey, &metadata));
+  REQUIRE(metadata.width == 128u);
+  REQUIRE(metadata.height == 128u);
+  REQUIRE(metadata.generation == 1u);
+  REQUIRE(metadata.readyForSampling);
+  REQUIRE_FALSE(metadata.hasImGuiDescriptor);
+
+  RenderTargetHandle initialHandle{};
+  const bool initialHandleOk = backend.TryGetOffscreenRenderTargetHandle(targetKey, &initialHandle, false);
+  if (initialHandleOk)
+  {
+    REQUIRE(initialHandle.IsValid());
+    REQUIRE(initialHandle.backendId == RenderBackendId::Vulkan);
+    REQUIRE(initialHandle.nativeType == RenderNativeHandleType::VulkanImGuiDescriptorSet);
+    REQUIRE(initialHandle.width == 128u);
+    REQUIRE(initialHandle.height == 128u);
+    REQUIRE(initialHandle.generation == metadata.generation);
+    REQUIRE_FALSE(initialHandle.needsYFlip);
+
+    RenderTargetHandle flippedHandle{};
+    REQUIRE(backend.TryGetOffscreenRenderTargetHandle(targetKey, &flippedHandle, true));
+    REQUIRE(flippedHandle.IsValid());
+    REQUIRE(flippedHandle.nativeHandle == initialHandle.nativeHandle);
+    REQUIRE(flippedHandle.width == initialHandle.width);
+    REQUIRE(flippedHandle.height == initialHandle.height);
+    REQUIRE(flippedHandle.generation == initialHandle.generation);
+    REQUIRE(flippedHandle.needsYFlip);
+  }
+  else
+  {
+    REQUIRE(backend.GetLastError().find("ImGui Vulkan texture registration is not ready") != std::string::npos);
+  }
+
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata(targetKey, &metadata));
+  REQUIRE(metadata.hasImGuiDescriptor == initialHandleOk);
+
+  REQUIRE(backend.EnsureOffscreenRenderTarget(targetKey, 256, 128));
+  VulkanRenderBackend::OffscreenTargetMetadata resizedMetadata{};
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata(targetKey, &resizedMetadata));
+  REQUIRE(resizedMetadata.width == 256u);
+  REQUIRE(resizedMetadata.height == 128u);
+  REQUIRE(resizedMetadata.generation == metadata.generation + 1u);
+  REQUIRE(resizedMetadata.readyForSampling);
+  RenderTargetHandle resizedHandle{};
+  const bool resizedHandleOk = backend.TryGetOffscreenRenderTargetHandle(targetKey, &resizedHandle, false);
+  if (resizedHandleOk)
+  {
+    REQUIRE(resizedHandle.IsValid());
+    REQUIRE(resizedHandle.width == resizedMetadata.width);
+    REQUIRE(resizedHandle.height == resizedMetadata.height);
+    REQUIRE(resizedHandle.generation == resizedMetadata.generation);
+  }
+  else
+  {
+    REQUIRE(backend.GetLastError().find("ImGui Vulkan texture registration is not ready") != std::string::npos);
+  }
+  REQUIRE(resizedMetadata.hasImGuiDescriptor == resizedHandleOk);
+
+  backend.DestroyOffscreenRenderTarget(targetKey);
+  REQUIRE_FALSE(backend.TryGetOffscreenRenderTargetMetadata(targetKey, &resizedMetadata));
+  REQUIRE_FALSE(backend.TryGetOffscreenRenderTargetHandle(targetKey, &resizedHandle, false));
+  REQUIRE(backend.GetLastError().find("unknown target key") != std::string::npos);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan editor viewport target stays stable across frame recording and resize",
+          "[renderer][foundation][vulkan][viewport]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(96, 96, "vulkan-editor-viewport-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan editor viewport test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  std::string error;
+  RenderTargetHandle missingViewportHandle{};
+  REQUIRE_FALSE(backend.TryGetEditorViewportRenderTargetHandle(&missingViewportHandle, false, &error));
+  REQUIRE(error.find("unknown target key") != std::string::npos);
+  REQUIRE_FALSE(missingViewportHandle.IsValid());
+
+  error.clear();
+  REQUIRE_FALSE(backend.EnsureEditorViewportRenderTarget(0u, 64u, &error));
+  REQUIRE(error.find("non-zero") != std::string::npos);
+
+  error.clear();
+  REQUIRE(backend.EnsureEditorViewportRenderTarget(96u, 64u, &error));
+
+  VulkanRenderBackend::OffscreenTargetMetadata initialMetadata{};
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata("__editor.viewport.scene", &initialMetadata));
+  REQUIRE(initialMetadata.width == 96u);
+  REQUIRE(initialMetadata.height == 64u);
+  REQUIRE(initialMetadata.readyForSampling);
+
+  RenderTargetHandle initialViewportHandle{};
+  const bool initialViewportHandleOk =
+      backend.TryGetEditorViewportRenderTargetHandle(&initialViewportHandle, false, &error);
+  if (initialViewportHandleOk)
+  {
+    REQUIRE(initialViewportHandle.IsValid());
+    REQUIRE(initialViewportHandle.width == initialMetadata.width);
+    REQUIRE(initialViewportHandle.height == initialMetadata.height);
+    REQUIRE(initialViewportHandle.generation == initialMetadata.generation);
+    REQUIRE_FALSE(initialViewportHandle.needsYFlip);
+  }
+  else
+  {
+    REQUIRE(error.find("ImGui Vulkan texture registration is not ready") != std::string::npos);
+  }
+
+  backend.BeginFrame({{}, "vulkan-editor-viewport-frame"});
+  backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, nullptr);
+  backend.EndFrame();
+  REQUIRE(backend.GetLastError().empty());
+
+  VulkanRenderBackend::OffscreenTargetMetadata afterFrameMetadata{};
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata("__editor.viewport.scene", &afterFrameMetadata));
+  REQUIRE(afterFrameMetadata.width == initialMetadata.width);
+  REQUIRE(afterFrameMetadata.height == initialMetadata.height);
+  REQUIRE(afterFrameMetadata.readyForSampling);
+  REQUIRE(afterFrameMetadata.generation == initialMetadata.generation);
+
+  RenderTargetHandle afterFrameViewportHandle{};
+  const bool afterFrameViewportHandleOk =
+      backend.TryGetEditorViewportRenderTargetHandle(&afterFrameViewportHandle, false, &error);
+  REQUIRE(afterFrameViewportHandleOk == initialViewportHandleOk);
+  if (afterFrameViewportHandleOk)
+  {
+    REQUIRE(afterFrameViewportHandle.IsValid());
+    REQUIRE(afterFrameViewportHandle.generation == initialViewportHandle.generation);
+  }
+
+  REQUIRE(backend.EnsureEditorViewportRenderTarget(144u, 72u, &error));
+  VulkanRenderBackend::OffscreenTargetMetadata resizedMetadata{};
+  REQUIRE(backend.TryGetOffscreenRenderTargetMetadata("__editor.viewport.scene", &resizedMetadata));
+  REQUIRE(resizedMetadata.width == 144u);
+  REQUIRE(resizedMetadata.height == 72u);
+  REQUIRE(resizedMetadata.generation == initialMetadata.generation + 1u);
+  REQUIRE(resizedMetadata.readyForSampling);
+
+  RenderTargetHandle resizedViewportHandle{};
+  const bool resizedViewportHandleOk =
+      backend.TryGetEditorViewportRenderTargetHandle(&resizedViewportHandle, true, &error);
+  REQUIRE(resizedViewportHandleOk == initialViewportHandleOk);
+  if (resizedViewportHandleOk)
+  {
+    REQUIRE(resizedViewportHandle.IsValid());
+    REQUIRE(resizedViewportHandle.width == resizedMetadata.width);
+    REQUIRE(resizedViewportHandle.height == resizedMetadata.height);
+    REQUIRE(resizedViewportHandle.generation == resizedMetadata.generation);
+    REQUIRE(resizedViewportHandle.needsYFlip);
+  }
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan backend reports and executes readback support deterministically",
+          "[renderer][foundation][vulkan][readback]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-readback-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan readback test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+  int framebufferWidth = 0;
+  int framebufferHeight = 0;
+  glfwGetFramebufferSize(window, &framebufferWidth, &framebufferHeight);
+  framebufferWidth = std::max(framebufferWidth, 1);
+  framebufferHeight = std::max(framebufferHeight, 1);
+
+  const RenderBackendCapabilities caps = backend.GetCapabilities();
+  std::vector<uint8_t> colorReadback;
+  std::vector<float> depthReadback;
+  std::string readbackError;
+
+  if (caps.supportsReadback)
+  {
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(framebufferWidth, framebufferHeight, colorReadback, &readbackError));
+    REQUIRE(readbackError.find("no captured frame yet") != std::string::npos);
+  }
+  else
+  {
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(framebufferWidth, framebufferHeight, colorReadback, &readbackError));
+    REQUIRE(readbackError.find("unavailable") != std::string::npos);
+  }
+
+  if (caps.supportsDepthReadback)
+  {
+    REQUIRE_FALSE(backend.ReadbackDepth32F(framebufferWidth, framebufferHeight, depthReadback, &readbackError));
+    REQUIRE(readbackError.find("no captured frame yet") != std::string::npos);
+  }
+  else
+  {
+    REQUIRE_FALSE(backend.ReadbackDepth32F(framebufferWidth, framebufferHeight, depthReadback, &readbackError));
+    REQUIRE(readbackError.find("unavailable") != std::string::npos);
+  }
+
+  Camera camera;
+  Mesh mesh = Mesh::CreateQuad();
+  Material material;
+  backend.BeginFrame({{}, "vulkan-readback-frame"});
+  backend.BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-readback-pass"});
+  backend.DrawMesh({&mesh, &material, Mat4::Identity()});
+  backend.EndPass();
+  backend.EndFrame();
+
+  if (caps.supportsReadback)
+  {
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(framebufferWidth + 1, framebufferHeight, colorReadback, &readbackError));
+    REQUIRE(readbackError.find("must match swapchain extent") != std::string::npos);
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(0, framebufferHeight, colorReadback, &readbackError));
+    REQUIRE(readbackError.find("positive dimensions") != std::string::npos);
+
+    backend.BeginFrame({{}, "vulkan-readback-active-frame"});
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(framebufferWidth, framebufferHeight, colorReadback, &readbackError));
+    REQUIRE(readbackError.find("outside active BeginFrame/EndFrame scope") != std::string::npos);
+    backend.EndFrame();
+
+    const bool colorOk =
+        backend.ReadbackColorBgr8(framebufferWidth, framebufferHeight, colorReadback, &readbackError);
+    if (colorOk)
+      REQUIRE(colorReadback.size() == static_cast<size_t>(framebufferWidth * framebufferHeight * 3));
+    else
+      REQUIRE_FALSE(readbackError.empty());
+  }
+  else
+  {
+    REQUIRE_FALSE(backend.ReadbackColorBgr8(64, 64, colorReadback, &readbackError));
+    REQUIRE_FALSE(readbackError.empty());
+  }
+
+  if (caps.supportsDepthReadback)
+  {
+    REQUIRE_FALSE(backend.ReadbackDepth32F(framebufferWidth, framebufferHeight + 1, depthReadback, &readbackError));
+    REQUIRE(readbackError.find("must match swapchain extent") != std::string::npos);
+    REQUIRE_FALSE(backend.ReadbackDepth32F(framebufferWidth, 0, depthReadback, &readbackError));
+    REQUIRE(readbackError.find("positive dimensions") != std::string::npos);
+
+    backend.BeginFrame({{}, "vulkan-depth-readback-active-frame"});
+    REQUIRE_FALSE(backend.ReadbackDepth32F(framebufferWidth, framebufferHeight, depthReadback, &readbackError));
+    REQUIRE(readbackError.find("outside active BeginFrame/EndFrame scope") != std::string::npos);
+    backend.EndFrame();
+
+    const bool depthOk =
+        backend.ReadbackDepth32F(framebufferWidth, framebufferHeight, depthReadback, &readbackError);
+    if (depthOk)
+      REQUIRE(depthReadback.size() == static_cast<size_t>(framebufferWidth * framebufferHeight));
+    else
+      REQUIRE_FALSE(readbackError.empty());
+  }
+  else
+  {
+    REQUIRE_FALSE(backend.ReadbackDepth32F(64, 64, depthReadback, &readbackError));
+    REQUIRE_FALSE(readbackError.empty());
+  }
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -266,6 +266,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   VulkanRenderBackend backend(window);
   REQUIRE(backend.IsInitialized());
   REQUIRE(backend.HasOpaqueRasterScaffold());
+  REQUIRE(backend.HasOpaquePipelineCreationScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -267,6 +267,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.IsInitialized());
   REQUIRE(backend.HasOpaqueRasterScaffold());
   REQUIRE(backend.HasOpaquePipelineCreationScaffold());
+  REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -15,6 +15,7 @@
 #include "renderer/Mesh.h"
 #include "renderer/RenderBackend.h"
 #include "renderer/Renderer.h"
+#include "renderer/RenderTargetHandle.h"
 #include "renderer/RenderViewUtils.h"
 #include "renderer/VulkanRenderBackend.h"
 #include "scene/Registry.h"
@@ -239,6 +240,26 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE_FALSE(vkCaps.supportsReadback);
   REQUIRE_FALSE(vkCaps.supportsDepthReadback);
   REQUIRE_FALSE(vkCaps.supportsDebugHud);
+}
+
+TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
+          "[renderer][foundation][handles]")
+{
+  const RenderTargetHandle glHandle = RenderTargetHandle::OpenGLTexture(42u, true);
+  REQUIRE(glHandle.IsValid());
+  REQUIRE(glHandle.backendId == RenderBackendId::OpenGL);
+  REQUIRE(glHandle.nativeType == RenderNativeHandleType::OpenGLTexture2D);
+  REQUIRE(glHandle.nativeHandle == 42u);
+  REQUIRE(glHandle.needsYFlip);
+
+  void *fakeDescriptorSet = reinterpret_cast<void *>(0x1234);
+  const RenderTargetHandle vkHandle =
+      RenderTargetHandle::VulkanDescriptorSet(fakeDescriptorSet, false);
+  REQUIRE(vkHandle.IsValid());
+  REQUIRE(vkHandle.backendId == RenderBackendId::Vulkan);
+  REQUIRE(vkHandle.nativeType == RenderNativeHandleType::VulkanImGuiDescriptorSet);
+  REQUIRE(vkHandle.nativeHandle == static_cast<uint64_t>(0x1234));
+  REQUIRE_FALSE(vkHandle.needsYFlip);
 }
 
 #if defined(MONOLITH_HAS_VULKAN)

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -132,6 +132,10 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
 
   const RenderBackendCapabilities caps = Renderer::GetBackendCapabilities();
   REQUIRE(caps.supportsWireframeOverlay);
+  REQUIRE(caps.supportsOffscreenTargets);
+  REQUIRE(caps.supportsNativeTextureHandles);
+  REQUIRE(caps.supportsReadback);
+  REQUIRE(caps.supportsDebugHud);
   REQUIRE_FALSE(caps.supportsComputePasses);
 }
 
@@ -147,6 +151,14 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
   REQUIRE(init.error.find("window handle") != std::string::npos);
   REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
   REQUIRE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+
+  const RenderBackendCapabilities vulkanCaps =
+      GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  REQUIRE_FALSE(vulkanCaps.supportsWireframeOverlay);
+  REQUIRE_FALSE(vulkanCaps.supportsOffscreenTargets);
+  REQUIRE_FALSE(vulkanCaps.supportsNativeTextureHandles);
+  REQUIRE_FALSE(vulkanCaps.supportsReadback);
+  REQUIRE_FALSE(vulkanCaps.supportsDebugHud);
 #else
   REQUIRE_FALSE(init.ok);
   REQUIRE(init.selected == RenderBackendId::Vulkan);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -308,6 +308,27 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
   REQUIRE(backend.HasOpaqueGraphicsPipelineScaffold());
 
+  void *instanceHandle = nullptr;
+  void *physicalDeviceHandle = nullptr;
+  void *deviceHandle = nullptr;
+  void *queueHandle = nullptr;
+  void *renderPassHandle = nullptr;
+  uint32_t queueFamily = 0;
+  uint32_t imageCount = 0;
+  REQUIRE(backend.TryGetImGuiVulkanInitData(&instanceHandle,
+                                            &physicalDeviceHandle,
+                                            &deviceHandle,
+                                            &queueFamily,
+                                            &queueHandle,
+                                            &renderPassHandle,
+                                            &imageCount));
+  REQUIRE(instanceHandle != nullptr);
+  REQUIRE(physicalDeviceHandle != nullptr);
+  REQUIRE(deviceHandle != nullptr);
+  REQUIRE(queueHandle != nullptr);
+  REQUIRE(renderPassHandle != nullptr);
+  REQUIRE(imageCount >= 2);
+
   glfwDestroyWindow(window);
   glfwTerminate();
 }

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -89,6 +89,23 @@ namespace
     int drawCalls = 0;
   };
 
+#if defined(MONOLITH_HAS_VULKAN)
+  struct OverlayRenderProbe
+  {
+    bool invoked = false;
+    void *commandBufferHandle = nullptr;
+  };
+
+  void CaptureOverlayRenderProbe(void *userData, void *commandBufferHandle)
+  {
+    if (!userData)
+      return;
+    auto *probe = static_cast<OverlayRenderProbe *>(userData);
+    probe->invoked = true;
+    probe->commandBufferHandle = commandBufferHandle;
+  }
+#endif
+
 } // namespace
 
 TEST_CASE("Renderer routes explicit frame and pass commands through backend seam",
@@ -383,6 +400,48 @@ TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaqu
   REQUIRE(backend.GetDrawCallCount() == 1);
   REQUIRE(backend.GetLastError().find("draw submissions are queued") != std::string::npos);
   REQUIRE(backend.GetLastError().find("Pending draws: 1") != std::string::npos);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan backend executes queued overlay callbacks while recording frame commands",
+          "[renderer][foundation][vulkan][overlay]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-overlay-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan overlay callback test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  OverlayRenderProbe overlayProbe;
+
+  backend.BeginFrame({{}, "vulkan-overlay-baseline"});
+  backend.EndFrame();
+
+  // Editor integration may queue draw data after frame submission; backend
+  // should consume it on the next frame recording.
+  backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
+  backend.BeginFrame({{}, "vulkan-overlay-frame"});
+  backend.EndFrame();
+
+  REQUIRE(overlayProbe.invoked);
+  REQUIRE(overlayProbe.commandBufferHandle != nullptr);
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -268,6 +268,7 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
   REQUIRE(backend.HasOpaqueRasterScaffold());
   REQUIRE(backend.HasOpaquePipelineCreationScaffold());
   REQUIRE(backend.HasOpaqueShaderPipelineScaffold());
+  REQUIRE(backend.HasOpaqueGraphicsPipelineScaffold());
 
   glfwDestroyWindow(window);
   glfwTerminate();

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -176,6 +176,37 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 #endif
 }
 
+TEST_CASE("RenderBackendSelection preserves native window handles for backend bootstrap",
+          "[renderer][foundation][backend][selection]") {
+  RenderBackendSelection selection;
+  selection.requested = RenderBackendId::Vulkan;
+  selection.nativeWindowHandle = reinterpret_cast<void*>(0x1234);
+
+  REQUIRE(selection.requested == RenderBackendId::Vulkan);
+  REQUIRE(selection.nativeWindowHandle == reinterpret_cast<void*>(0x1234));
+}
+
+TEST_CASE("Backend capability defaults express the current parity matrix",
+          "[renderer][foundation][backend][parity]") {
+  const RenderBackendCapabilities glCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
+  REQUIRE(glCaps.supportsDebugDraw);
+  REQUIRE(glCaps.supportsWireframeOverlay);
+  REQUIRE(glCaps.supportsOffscreenTargets);
+  REQUIRE(glCaps.supportsNativeTextureHandles);
+  REQUIRE(glCaps.supportsReadback);
+  REQUIRE(glCaps.supportsDepthReadback);
+  REQUIRE(glCaps.supportsDebugHud);
+
+  const RenderBackendCapabilities vkCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
+  REQUIRE_FALSE(vkCaps.supportsDebugDraw);
+  REQUIRE_FALSE(vkCaps.supportsWireframeOverlay);
+  REQUIRE_FALSE(vkCaps.supportsOffscreenTargets);
+  REQUIRE_FALSE(vkCaps.supportsNativeTextureHandles);
+  REQUIRE_FALSE(vkCaps.supportsReadback);
+  REQUIRE_FALSE(vkCaps.supportsDepthReadback);
+  REQUIRE_FALSE(vkCaps.supportsDebugHud);
+}
+
 #if defined(MONOLITH_HAS_VULKAN)
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -103,6 +103,24 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
   Renderer::ResetBackend();
 }
 
+TEST_CASE("Renderer forwards frame output config through the backend seam",
+          "[renderer][foundation][frame-output]") {
+  FakeRenderBackend backend;
+  Renderer::UseBackend(&backend);
+
+  const Vec4 clearColor{0.3f, 0.2f, 0.1f, 1.0f};
+  Renderer::BeginFrame(RenderFrameConfig{{}, "frame-output", clearColor, false, true});
+  Renderer::EndFrame();
+
+  REQUIRE(backend.events == std::vector<std::string>{"begin-frame", "end-frame"});
+  REQUIRE(backend.lastFrame.debugLabel == "frame-output");
+  REQUIRE(backend.lastFrame.clearColor == clearColor);
+  REQUIRE_FALSE(backend.lastFrame.clearColorBuffer);
+  REQUIRE(backend.lastFrame.clearDepthBuffer);
+
+  Renderer::ResetBackend();
+}
+
 TEST_CASE("Renderer initializes the default OpenGL backend through a typed selection",
           "[renderer][foundation][backend]") {
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Auto});

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -141,11 +141,19 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Vulkan});
 
+#if defined(MONOLITH_HAS_VULKAN)
+  REQUIRE_FALSE(init.ok);
+  REQUIRE(init.selected == RenderBackendId::Vulkan);
+  REQUIRE(init.error.find("window handle") != std::string::npos);
+  REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
+  REQUIRE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+#else
   REQUIRE_FALSE(init.ok);
   REQUIRE(init.selected == RenderBackendId::Vulkan);
   REQUIRE_FALSE(init.error.empty());
   REQUIRE(Renderer::GetBackendId() == RenderBackendId::OpenGL);
   REQUIRE_FALSE(Renderer::IsBackendSupported(RenderBackendId::Vulkan));
+#endif
 }
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -24,65 +24,76 @@
 
 using namespace Monolith;
 
-namespace {
+namespace
+{
 
-class FakeRenderBackend : public IRenderBackend {
- public:
-  void BeginFrame(const RenderFrameConfig& frame) override {
-    events.push_back("begin-frame");
-    lastFrame = frame;
-  }
+  class FakeRenderBackend : public IRenderBackend
+  {
+  public:
+    void BeginFrame(const RenderFrameConfig &frame) override
+    {
+      events.push_back("begin-frame");
+      lastFrame = frame;
+    }
 
-  void EndFrame() override {
-    events.push_back("end-frame");
-  }
+    void EndFrame() override
+    {
+      events.push_back("end-frame");
+    }
 
-  void BeginPass(const RenderPassConfig& pass) override {
-    events.push_back("begin-pass");
-    lastPass = pass;
-  }
+    void BeginPass(const RenderPassConfig &pass) override
+    {
+      events.push_back("begin-pass");
+      lastPass = pass;
+    }
 
-  void EndPass() override {
-    events.push_back("end-pass");
-  }
+    void EndPass() override
+    {
+      events.push_back("end-pass");
+    }
 
-  void DrawMesh(const MeshDrawCommand& command) override {
-    events.push_back("draw-mesh");
-    lastMesh = command;
-    ++drawCalls;
-  }
+    void DrawMesh(const MeshDrawCommand &command) override
+    {
+      events.push_back("draw-mesh");
+      lastMesh = command;
+      ++drawCalls;
+    }
 
-  void DrawSkinnedMesh(const SkinnedMeshDrawCommand& command) override {
-    events.push_back("draw-skinned");
-    lastSkinned = command;
-    ++drawCalls;
-  }
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &command) override
+    {
+      events.push_back("draw-skinned");
+      lastSkinned = command;
+      ++drawCalls;
+    }
 
-  void DrawWireframe(const WireframeDrawCommand& command) override {
-    events.push_back("draw-wireframe");
-    lastWireframe = command;
-    ++drawCalls;
-  }
+    void DrawWireframe(const WireframeDrawCommand &command) override
+    {
+      events.push_back("draw-wireframe");
+      lastWireframe = command;
+      ++drawCalls;
+    }
 
-  RenderBackendId GetBackendId() const override { return RenderBackendId::OpenGL; }
-  RenderBackendCapabilities GetCapabilities() const override {
-    return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
-  }
-  int GetDrawCallCount() const override { return drawCalls; }
+    RenderBackendId GetBackendId() const override { return RenderBackendId::OpenGL; }
+    RenderBackendCapabilities GetCapabilities() const override
+    {
+      return GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
+    }
+    int GetDrawCallCount() const override { return drawCalls; }
 
-  std::vector<std::string> events;
-  RenderFrameConfig lastFrame;
-  RenderPassConfig lastPass;
-  MeshDrawCommand lastMesh;
-  SkinnedMeshDrawCommand lastSkinned;
-  WireframeDrawCommand lastWireframe;
-  int drawCalls = 0;
-};
+    std::vector<std::string> events;
+    RenderFrameConfig lastFrame;
+    RenderPassConfig lastPass;
+    MeshDrawCommand lastMesh;
+    SkinnedMeshDrawCommand lastSkinned;
+    WireframeDrawCommand lastWireframe;
+    int drawCalls = 0;
+  };
 
-}  // namespace
+} // namespace
 
 TEST_CASE("Renderer routes explicit frame and pass commands through backend seam",
-          "[renderer][foundation]") {
+          "[renderer][foundation]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -109,7 +120,8 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
 }
 
 TEST_CASE("Renderer forwards frame output config through the backend seam",
-          "[renderer][foundation][frame-output]") {
+          "[renderer][foundation][frame-output]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -127,7 +139,8 @@ TEST_CASE("Renderer forwards frame output config through the backend seam",
 }
 
 TEST_CASE("Renderer initializes the default OpenGL backend through a typed selection",
-          "[renderer][foundation][backend]") {
+          "[renderer][foundation][backend]")
+{
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Auto});
 
   REQUIRE(init.ok);
@@ -147,7 +160,8 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
 }
 
 TEST_CASE("Renderer rejects unsupported backend requests without replacing the active backend",
-          "[renderer][foundation][backend]") {
+          "[renderer][foundation][backend]")
+{
   REQUIRE(Renderer::InitializeBackend({RenderBackendId::OpenGL}).ok);
 
   const RenderBackendInitResult init = Renderer::InitializeBackend({RenderBackendId::Vulkan});
@@ -178,17 +192,19 @@ TEST_CASE("Renderer rejects unsupported backend requests without replacing the a
 }
 
 TEST_CASE("RenderBackendSelection preserves native window handles for backend bootstrap",
-          "[renderer][foundation][backend][selection]") {
+          "[renderer][foundation][backend][selection]")
+{
   RenderBackendSelection selection;
   selection.requested = RenderBackendId::Vulkan;
-  selection.nativeWindowHandle = reinterpret_cast<void*>(0x1234);
+  selection.nativeWindowHandle = reinterpret_cast<void *>(0x1234);
 
   REQUIRE(selection.requested == RenderBackendId::Vulkan);
-  REQUIRE(selection.nativeWindowHandle == reinterpret_cast<void*>(0x1234));
+  REQUIRE(selection.nativeWindowHandle == reinterpret_cast<void *>(0x1234));
 }
 
 TEST_CASE("Backend capability defaults express the current parity matrix",
-          "[renderer][foundation][backend][parity]") {
+          "[renderer][foundation][backend][parity]")
+{
   const RenderBackendCapabilities glCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::OpenGL);
   REQUIRE(glCaps.supportsDebugDraw);
   REQUIRE(glCaps.supportsWireframeOverlay);
@@ -210,7 +226,8 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
 
 #if defined(MONOLITH_HAS_VULKAN)
 TEST_CASE("Vulkan material translation snapshots backend-relevant material state",
-          "[renderer][foundation][vulkan][translation]") {
+          "[renderer][foundation][vulkan][translation]")
+{
   Material material;
   material.color = {0.2f, 0.4f, 0.6f, 1.0f};
   material.roughness = 0.25f;
@@ -231,7 +248,8 @@ TEST_CASE("Vulkan material translation snapshots backend-relevant material state
 }
 
 TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
-          "[renderer][foundation][vulkan][pipeline]") {
+          "[renderer][foundation][vulkan][pipeline]")
+{
   VulkanRenderBackend::TranslatedMaterialState materialState;
   materialState.usesAlbedoMap = true;
   materialState.usesCustomShader = false;
@@ -246,19 +264,22 @@ TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
 }
 
 TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a window",
-          "[renderer][foundation][vulkan][scaffold]") {
+          "[renderer][foundation][vulkan][scaffold]")
+{
   if (!glfwInit())
     SKIP("GLFW initialization failed on this machine");
 
-  if (!glfwVulkanSupported()) {
+  if (!glfwVulkanSupported())
+  {
     glfwTerminate();
     SKIP("GLFW reports Vulkan unsupported on this machine");
   }
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
-  if (!window) {
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
+  if (!window)
+  {
     glfwTerminate();
     SKIP("Unable to create hidden GLFW window for Vulkan raster scaffold test");
   }
@@ -275,19 +296,22 @@ TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a
 }
 
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
-          "[renderer][foundation][vulkan][opaque]") {
+          "[renderer][foundation][vulkan][opaque]")
+{
   if (!glfwInit())
     SKIP("GLFW initialization failed on this machine");
 
-  if (!glfwVulkanSupported()) {
+  if (!glfwVulkanSupported())
+  {
     glfwTerminate();
     SKIP("GLFW reports Vulkan unsupported on this machine");
   }
 
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
-  if (!window) {
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-test", nullptr, nullptr);
+  if (!window)
+  {
     glfwTerminate();
     SKIP("Unable to create hidden GLFW window for Vulkan backend test");
   }
@@ -297,7 +321,8 @@ TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with
   selection.nativeWindowHandle = window;
   const RenderBackendInitResult init = Renderer::InitializeBackend(selection);
 
-  if (!init.ok) {
+  if (!init.ok)
+  {
     glfwDestroyWindow(window);
     glfwTerminate();
     FAIL(init.error);
@@ -320,10 +345,53 @@ TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with
   glfwDestroyWindow(window);
   glfwTerminate();
 }
+
+TEST_CASE("Vulkan backend reports actionable diagnostics for scaffold-only opaque draw execution",
+          "[renderer][foundation][vulkan][opaque][diagnostics]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-diagnostics-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan diagnostics test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  Mesh mesh;
+  Material material;
+  Camera camera;
+
+  backend.BeginFrame({{}, "vulkan-opaque-diagnostics"});
+  backend.BeginPass({RenderPassId::OpaqueScene, BuildRenderView(camera), "vulkan-opaque-pass"});
+  backend.DrawMesh({&mesh, &material, Mat4::Identity()});
+  backend.EndPass();
+  backend.EndFrame();
+
+  REQUIRE(backend.GetDrawCallCount() == 1);
+  REQUIRE(backend.GetLastError().find("draw submissions are queued") != std::string::npos);
+  REQUIRE(backend.GetLastError().find("Pending draws: 1") != std::string::npos);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
 #endif
 
 TEST_CASE("Renderer supports multiple explicit passes within a single frame",
-          "[renderer][foundation]") {
+          "[renderer][foundation]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -364,7 +432,8 @@ TEST_CASE("Renderer supports multiple explicit passes within a single frame",
 }
 
 TEST_CASE("RenderSystem submits visible mesh entities into the active explicit pass",
-          "[renderer][foundation][scene]") {
+          "[renderer][foundation][scene]")
+{
   FakeRenderBackend backend;
   Renderer::UseBackend(&backend);
 
@@ -403,7 +472,8 @@ TEST_CASE("RenderSystem submits visible mesh entities into the active explicit p
 }
 
 TEST_CASE("Material copies share shader and texture resource handles",
-          "[renderer][foundation][ownership]") {
+          "[renderer][foundation][ownership]")
+{
   auto shader = std::make_shared<Shader>();
   auto texture = std::make_shared<Texture>();
 

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -245,6 +245,32 @@ TEST_CASE("Vulkan opaque pipeline keys track translated material feature usage",
   REQUIRE(key.depthTestEnabled);
 }
 
+TEST_CASE("Vulkan backend exposes opaque raster scaffold once initialized with a window",
+          "[renderer][foundation][vulkan][scaffold]") {
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported()) {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow* window = glfwCreateWindow(64, 64, "vulkan-scaffold-test", nullptr, nullptr);
+  if (!window) {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan raster scaffold test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+  REQUIRE(backend.HasOpaqueRasterScaffold());
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -452,13 +452,13 @@ TEST_CASE("Vulkan backend executes queued overlay callbacks while recording fram
 
   OverlayRenderProbe overlayProbe;
 
-  backend.BeginFrame({{}, "vulkan-overlay-baseline"});
-  backend.EndFrame();
-
-  // Editor integration may queue draw data after frame submission; backend
-  // should consume it on the next frame recording.
+  // Frame-external queueing should be ignored by the backend.
   backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
+  REQUIRE_FALSE(overlayProbe.invoked);
+  REQUIRE(backend.GetLastError().find("active frame") != std::string::npos);
+
   backend.BeginFrame({{}, "vulkan-overlay-frame"});
+  backend.QueueOverlayRenderCallback(&CaptureOverlayRenderProbe, &overlayProbe);
   backend.EndFrame();
 
   REQUIRE(overlayProbe.invoked);

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -16,6 +16,7 @@
 #include "renderer/RenderBackend.h"
 #include "renderer/Renderer.h"
 #include "renderer/RenderViewUtils.h"
+#include "renderer/VulkanRenderBackend.h"
 #include "scene/Registry.h"
 #include "scene/components/MeshComponent.h"
 #include "scene/components/TransformComponent.h"
@@ -208,6 +209,27 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
 }
 
 #if defined(MONOLITH_HAS_VULKAN)
+TEST_CASE("Vulkan material translation snapshots backend-relevant material state",
+          "[renderer][foundation][vulkan][translation]") {
+  Material material;
+  material.color = {0.2f, 0.4f, 0.6f, 1.0f};
+  material.roughness = 0.25f;
+  material.metallic = 0.75f;
+  material.uvScale = 2.5f;
+  material.albedoMap = std::make_shared<Texture>();
+  material.shader = std::make_shared<Shader>();
+
+  const VulkanRenderBackend::TranslatedMaterialState translated =
+      VulkanRenderBackend::TranslateMaterialState(material);
+
+  REQUIRE(translated.baseColor == material.color);
+  REQUIRE(translated.roughness == Catch::Approx(material.roughness));
+  REQUIRE(translated.metallic == Catch::Approx(material.metallic));
+  REQUIRE(translated.uvScale == Catch::Approx(material.uvScale));
+  REQUIRE_FALSE(translated.usesAlbedoMap);
+  REQUIRE_FALSE(translated.usesCustomShader);
+}
+
 TEST_CASE("Vulkan backend accepts opaque-scene submissions when initialized with a window handle",
           "[renderer][foundation][vulkan][opaque]") {
   if (!glfwInit())

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -15,6 +15,43 @@ if(NOT TARGET glfw)
     FetchContent_MakeAvailable(glfw)
 endif()
 
+# ---- Optional Vulkan headers + loader scaffolding ----
+if(MONOLITH_ENGINE_ENABLE_VULKAN)
+    if(NOT TARGET monolith_vulkan_headers)
+        FetchContent_Declare(
+            vulkan_headers
+            GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers.git
+            GIT_TAG        vulkan-sdk-1.4.341.0
+            GIT_SHALLOW    TRUE
+        )
+        FetchContent_Populate(vulkan_headers)
+
+        add_library(monolith_vulkan_headers INTERFACE)
+        target_include_directories(monolith_vulkan_headers INTERFACE
+            ${vulkan_headers_SOURCE_DIR}/include
+        )
+    endif()
+
+    if(NOT TARGET monolith_volk)
+        FetchContent_Declare(
+            volk
+            GIT_REPOSITORY https://github.com/zeux/volk.git
+            GIT_TAG        1.4.304
+            GIT_SHALLOW    TRUE
+        )
+        FetchContent_Populate(volk)
+
+        add_library(monolith_volk STATIC ${volk_SOURCE_DIR}/volk.c)
+        target_include_directories(monolith_volk PUBLIC ${volk_SOURCE_DIR})
+        target_link_libraries(monolith_volk PUBLIC monolith_vulkan_headers)
+        target_compile_definitions(monolith_volk PUBLIC VK_NO_PROTOTYPES)
+        target_compile_options(monolith_volk PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/W0>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+        )
+    endif()
+endif()
+
 # ---- glad (OpenGL 4.1 Core, pre-generated, committed) ----
 if(NOT TARGET glad)
     add_subdirectory(glad)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT TARGET imgui_lib)
     )
     FetchContent_MakeAvailable(imgui)
 
-    add_library(imgui_lib STATIC
+    set(MONOLITH_IMGUI_SOURCES
         ${imgui_SOURCE_DIR}/imgui.cpp
         ${imgui_SOURCE_DIR}/imgui_draw.cpp
         ${imgui_SOURCE_DIR}/imgui_tables.cpp
@@ -87,11 +87,25 @@ if(NOT TARGET imgui_lib)
         ${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
         ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
     )
+
+    if(MONOLITH_ENGINE_ENABLE_VULKAN)
+        list(APPEND MONOLITH_IMGUI_SOURCES
+            ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+        )
+    endif()
+
+    add_library(imgui_lib STATIC ${MONOLITH_IMGUI_SOURCES})
     target_include_directories(imgui_lib PUBLIC
         ${imgui_SOURCE_DIR}
         ${imgui_SOURCE_DIR}/backends
     )
     target_link_libraries(imgui_lib PUBLIC glfw glad)
+
+    if(MONOLITH_ENGINE_ENABLE_VULKAN)
+        target_compile_definitions(imgui_lib PUBLIC IMGUI_IMPL_VULKAN_USE_VOLK)
+        target_link_libraries(imgui_lib PUBLIC monolith_volk monolith_vulkan_headers)
+    endif()
+
     # Suppress vendor warnings (MSVC -WX, GCC/Clang -Werror)
     target_compile_options(imgui_lib PRIVATE
         $<$<CXX_COMPILER_ID:MSVC>:/W0>


### PR DESCRIPTION
## Summary
- consolidate full Vulkan backend parity delivery for epic #119
- includes runtime Vulkan rasterization, editor viewport parity, offscreen targets, and screenshot/depth readback support
- includes expanded parity validation matrix and tests across renderer/editor/docs

## Included work
- #145 Vulkan mesh rasterization and pipeline translation
- #147 Vulkan offscreen render target parity
- #144 Vulkan editor viewport rendering parity
- #148 Vulkan screenshot and readback support
- related parity test/doc expansion

## Stack resolution
This PR replaces the prior stacked slices for final integration to `main`.

## Validation
- CI workflow checks on this PR (Linux/macOS/Windows + coverage + starter integration)
- local targeted suites were run while building the stack

Closes #119