### PR TITLE
context: improve light quality

### DIFF
--- a/editor/EditorImGuiBackend.cpp
+++ b/editor/EditorImGuiBackend.cpp
@@ -146,6 +146,21 @@ namespace Monolith::Editor
     return false;
   }
 
+  RenderBackendId ResolveEditorImGuiBackend(RenderBackendId backendId, int glfwClientApi)
+  {
+    if (backendId != RenderBackendId::OpenGL && backendId != RenderBackendId::Auto)
+      return backendId;
+
+    if (glfwClientApi != GLFW_NO_API)
+      return RenderBackendId::OpenGL;
+
+#if defined(MONOLITH_HAS_VULKAN)
+    return RenderBackendId::Vulkan;
+#else
+    return RenderBackendId::OpenGL;
+#endif
+  }
+
   bool InitEditorImGuiBackend(GLFWwindow *window, RenderBackendId backendId)
   {
     if (!window || !IsSupportedEditorImGuiBackend(backendId))
@@ -155,8 +170,14 @@ namespace Monolith::Editor
     {
     case RenderBackendId::Auto:
     case RenderBackendId::OpenGL:
+      if (glfwGetCurrentContext() != window)
+        return false;
       ImGui_ImplGlfw_InitForOpenGL(window, true);
-      ImGui_ImplOpenGL3_Init("#version 410");
+      if (!ImGui_ImplOpenGL3_Init("#version 410"))
+      {
+        ImGui_ImplGlfw_Shutdown();
+        return false;
+      }
       return true;
     case RenderBackendId::Vulkan:
     {

--- a/editor/EditorImGuiBackend.h
+++ b/editor/EditorImGuiBackend.h
@@ -8,6 +8,7 @@ struct ImDrawData;
 namespace Monolith::Editor {
 
 bool IsSupportedEditorImGuiBackend(RenderBackendId backendId);
+RenderBackendId ResolveEditorImGuiBackend(RenderBackendId backendId, int glfwClientApi);
 bool InitEditorImGuiBackend(GLFWwindow* window, RenderBackendId backendId);
 void ShutdownEditorImGuiBackend(RenderBackendId backendId);
 void BeginEditorImGuiFrame(RenderBackendId backendId);

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -1482,6 +1482,32 @@ namespace Monolith
 
     // ---- Lifecycle ---------------------------------------------------------------
 
+    void EditorLayer::EnsureImGuiBackendInitialized()
+    {
+      if (m_imguiBackendInitialized || !m_window)
+        return;
+
+      const RenderBackendId requestedBackendId =
+          ResolveEditorImGuiBackend(Renderer::GetBackendId(),
+                                    glfwGetWindowAttrib(m_window, GLFW_CLIENT_API));
+      m_imguiBackendInitialized = InitEditorImGuiBackend(m_window, requestedBackendId);
+      if (!m_imguiBackendInitialized)
+      {
+        if (!m_imguiBackendInitRetryLogged)
+        {
+          LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'; retrying.",
+                   ToString(requestedBackendId));
+          m_imguiBackendInitRetryLogged = true;
+        }
+        return;
+      }
+
+      m_imguiBackendId = requestedBackendId;
+      m_imguiBackendInitRetryLogged = false;
+      LOG_INFO("[Editor] ImGui backend initialized for renderer backend '%s'.",
+               ToString(m_imguiBackendId));
+    }
+
     void EditorLayer::Init(GLFWwindow *window)
     {
       m_window = window;
@@ -1510,16 +1536,10 @@ namespace Monolith
       }
       LoadWorkspaceState();
 
-      const RenderBackendId requestedBackendId =
-          ResolveEditorImGuiBackend(Renderer::GetBackendId(),
-                                    glfwGetWindowAttrib(window, GLFW_CLIENT_API));
-      m_imguiBackendInitialized = InitEditorImGuiBackend(window, requestedBackendId);
-      m_imguiBackendId = m_imguiBackendInitialized ? requestedBackendId : RenderBackendId::Auto;
-      if (!m_imguiBackendInitialized)
-      {
-        LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'",
-                 ToString(requestedBackendId));
-      }
+      m_imguiBackendInitialized = false;
+      m_imguiBackendId = RenderBackendId::Auto;
+      m_imguiBackendInitRetryLogged = false;
+      EnsureImGuiBackendInitialized();
 
       m_schema.LoadFromFile("assets/editor_schema.json");
 
@@ -1552,6 +1572,7 @@ namespace Monolith
         ShutdownEditorImGuiBackend(m_imguiBackendId);
       m_imguiBackendInitialized = false;
       m_imguiBackendId = RenderBackendId::Auto;
+      m_imguiBackendInitRetryLogged = false;
       ImGui::DestroyContext();
     }
 
@@ -2371,6 +2392,7 @@ namespace Monolith
       m_viewGizmoPickRect.Clear();
       ProcessPendingPathDrops();
 
+      EnsureImGuiBackendInitialized();
       if (m_imguiBackendInitialized)
         BeginEditorImGuiFrame(m_imguiBackendId);
       ImGui::NewFrame();

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -1510,11 +1510,15 @@ namespace Monolith
       }
       LoadWorkspaceState();
 
-      const RenderBackendId backendId = Renderer::GetBackendId();
-      m_imguiBackendInitialized = InitEditorImGuiBackend(window, backendId);
+      const RenderBackendId requestedBackendId =
+          ResolveEditorImGuiBackend(Renderer::GetBackendId(),
+                                    glfwGetWindowAttrib(window, GLFW_CLIENT_API));
+      m_imguiBackendInitialized = InitEditorImGuiBackend(window, requestedBackendId);
+      m_imguiBackendId = m_imguiBackendInitialized ? requestedBackendId : RenderBackendId::Auto;
       if (!m_imguiBackendInitialized)
       {
-        LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'", ToString(backendId));
+        LOG_WARN("[Editor] No supported ImGui backend for renderer backend '%s'",
+                 ToString(requestedBackendId));
       }
 
       m_schema.LoadFromFile("assets/editor_schema.json");
@@ -1545,8 +1549,9 @@ namespace Monolith
         ImGui::SaveIniSettingsToDisk(m_imguiIniPath.c_str());
       m_mcpController.Shutdown();
       if (m_imguiBackendInitialized)
-        ShutdownEditorImGuiBackend(Renderer::GetBackendId());
+        ShutdownEditorImGuiBackend(m_imguiBackendId);
       m_imguiBackendInitialized = false;
+      m_imguiBackendId = RenderBackendId::Auto;
       ImGui::DestroyContext();
     }
 
@@ -2367,7 +2372,7 @@ namespace Monolith
       ProcessPendingPathDrops();
 
       if (m_imguiBackendInitialized)
-        BeginEditorImGuiFrame(Renderer::GetBackendId());
+        BeginEditorImGuiFrame(m_imguiBackendId);
       ImGui::NewFrame();
 
       const EditorHistorySnapshot frameHistoryBefore = m_active ? CaptureHistorySnapshot()
@@ -2420,7 +2425,7 @@ namespace Monolith
 
       ImGui::Render();
       if (m_imguiBackendInitialized)
-        RenderEditorImGuiDrawData(Renderer::GetBackendId(), ImGui::GetDrawData());
+        RenderEditorImGuiDrawData(m_imguiBackendId, ImGui::GetDrawData());
     }
 
     void EditorLayer::DrawDockspace()

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -18,6 +18,7 @@
 #include "editor/TransformGizmo.h"
 #include "mcp/McpController.h"
 #include "renderer/Camera.h"
+#include "renderer/RenderBackend.h"
 #include "renderer/Shader.h"
 
 struct GLFWwindow;
@@ -148,6 +149,7 @@ class EditorLayer {
   GLFWwindow* m_window = nullptr;
   bool m_active = false;
   bool m_imguiBackendInitialized = false;
+  RenderBackendId m_imguiBackendId = RenderBackendId::Auto;
   bool m_playMode = false;
   bool m_wantsReload = false;
   bool m_prevMouseL = false;

--- a/editor/EditorLayer.h
+++ b/editor/EditorLayer.h
@@ -68,6 +68,7 @@ class EditorLayer {
 
   // Toggle editor mode and update cursor accordingly.
   void Toggle();
+  void EnsureImGuiBackendInitialized();
 
   // Process input / picking for this frame.
   // In fly mode the camera position/target are updated directly.
@@ -150,6 +151,7 @@ class EditorLayer {
   bool m_active = false;
   bool m_imguiBackendInitialized = false;
   RenderBackendId m_imguiBackendId = RenderBackendId::Auto;
+  bool m_imguiBackendInitRetryLogged = false;
   bool m_playMode = false;
   bool m_wantsReload = false;
   bool m_prevMouseL = false;

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -24,6 +24,8 @@
 - `Renderer::EndPass()`
 - `Renderer::EndFrame()`
 
+`RenderFrameConfig` now includes `giPipeline` toggles for scaffolded GI stages (SSR, SSGI, temporal resolve, composite). These stages are disabled by default and require explicit per-frame opt-in.
+
 ## Geometry Sources
 
 - Procedural primitives (`Mesh::CreateSphere`, `CreateBox`, `CreatePlane`, etc.)
@@ -35,3 +37,4 @@
 - `Mesh`/`SkinnedMesh` are move-only RAII wrappers over VAO/VBO/EBO resources.
 - `Material` can use either solid color or optional `albedoMap` texture.
 - Shaders are copied to `build/.../bin/shaders` by CMake post-build command.
+- Vulkan supports GI scaffold pass IDs (`ScreenSpaceReflections`, `ScreenSpaceGlobalIllumination`, `TemporalGiResolve`, `GiComposite`) behind frame-level enable flags.

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -34,7 +34,13 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
               .supportsDebugHud = true,
               .supportsComputePasses = false,
               .supportsGpuTimestamps = false,
-              .supportsBindlessResources = false};
+              .supportsBindlessResources = false,
+              .supportsScreenSpaceReflections = false,
+              .supportsScreenSpaceGlobalIllumination = false,
+              .supportsTemporalGiResolve = false,
+              .supportsGiComposite = false,
+              .maxReflectionQuality = RenderFeatureQualityTier::Off,
+              .maxGlobalIlluminationQuality = RenderFeatureQualityTier::Off};
     case RenderBackendId::Vulkan:
       return {.supportsDebugDraw = false,
               .supportsWireframeOverlay = false,
@@ -46,7 +52,13 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
               .supportsDebugHud = false,
               .supportsComputePasses = false,
               .supportsGpuTimestamps = false,
-              .supportsBindlessResources = false};
+              .supportsBindlessResources = false,
+              .supportsScreenSpaceReflections = false,
+              .supportsScreenSpaceGlobalIllumination = false,
+              .supportsTemporalGiResolve = false,
+              .supportsGiComposite = false,
+              .maxReflectionQuality = RenderFeatureQualityTier::Off,
+              .maxGlobalIlluminationQuality = RenderFeatureQualityTier::Off};
   }
 
   return {};

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "renderer/RenderTypes.h"
+
 namespace Monolith {
 
 enum class RenderBackendId {
@@ -22,6 +24,12 @@ struct RenderBackendCapabilities {
   bool supportsComputePasses = false;
   bool supportsGpuTimestamps = false;
   bool supportsBindlessResources = false;
+  bool supportsScreenSpaceReflections = false;
+  bool supportsScreenSpaceGlobalIllumination = false;
+  bool supportsTemporalGiResolve = false;
+  bool supportsGiComposite = false;
+  RenderFeatureQualityTier maxReflectionQuality = RenderFeatureQualityTier::Off;
+  RenderFeatureQualityTier maxGlobalIlluminationQuality = RenderFeatureQualityTier::Off;
 };
 
 struct RenderBackendSelection {

--- a/renderer/RenderTypes.h
+++ b/renderer/RenderTypes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -15,9 +16,21 @@ class Mesh;
 class Shader;
 class SkinnedMesh;
 
+enum class RenderFeatureQualityTier : uint8_t {
+  Off = 0,
+  Low = 1,
+  Medium = 2,
+  High = 3,
+  Ultra = 4,
+};
+
 enum class RenderPassId {
   CompatibilityScene,
   OpaqueScene,
+  ScreenSpaceReflections,
+  ScreenSpaceGlobalIllumination,
+  TemporalGiResolve,
+  GiComposite,
   WireframeOverlay,
   DebugOverlay,
 };
@@ -28,12 +41,23 @@ struct RenderView {
   Vec3 cameraPosition = Vec3::Zero();
 };
 
+struct GiPipelineFrameConfig {
+  bool enableScreenSpaceReflections = false;
+  RenderFeatureQualityTier reflectionQuality = RenderFeatureQualityTier::Off;
+  bool enableScreenSpaceGlobalIllumination = false;
+  RenderFeatureQualityTier globalIlluminationQuality = RenderFeatureQualityTier::Off;
+  bool enableTemporalResolve = false;
+  bool enableComposite = false;
+  bool resetTemporalHistory = false;
+};
+
 struct RenderFrameConfig {
   std::vector<Light> lights;
   std::string debugLabel;
   Vec4 clearColor = {0.1f, 0.1f, 0.15f, 1.0f};
   bool clearColorBuffer = true;
   bool clearDepthBuffer = true;
+  GiPipelineFrameConfig giPipeline;
 };
 
 struct RenderPassConfig {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -375,6 +375,33 @@ namespace Monolith
       return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
     }
 
+    constexpr bool IsVulkanGiScaffoldPass(const RenderPassId passId)
+    {
+      return passId == RenderPassId::ScreenSpaceReflections ||
+             passId == RenderPassId::ScreenSpaceGlobalIllumination ||
+             passId == RenderPassId::TemporalGiResolve ||
+             passId == RenderPassId::GiComposite;
+    }
+
+    bool IsEnabledGiScaffoldPass(const RenderPassId passId, const GiPipelineFrameConfig &giConfig)
+    {
+      switch (passId)
+      {
+      case RenderPassId::ScreenSpaceReflections:
+        return giConfig.enableScreenSpaceReflections &&
+               giConfig.reflectionQuality != RenderFeatureQualityTier::Off;
+      case RenderPassId::ScreenSpaceGlobalIllumination:
+        return giConfig.enableScreenSpaceGlobalIllumination &&
+               giConfig.globalIlluminationQuality != RenderFeatureQualityTier::Off;
+      case RenderPassId::TemporalGiResolve:
+        return giConfig.enableTemporalResolve;
+      case RenderPassId::GiComposite:
+        return giConfig.enableComposite;
+      default:
+        return false;
+      }
+    }
+
     uint8_t PackOpaquePipelineKey(const VulkanRenderBackend::OpaquePipelineKey &key)
     {
       uint8_t packed = 0u;
@@ -436,9 +463,15 @@ namespace Monolith
     caps.supportsReadback = m_context && m_context->supportsColorReadback;
     caps.supportsDepthReadback = m_context && m_context->supportsDepthReadback;
     caps.supportsDebugHud = false;
-    caps.supportsComputePasses = false;
+    caps.supportsComputePasses = true;
     caps.supportsGpuTimestamps = false;
     caps.supportsBindlessResources = false;
+    caps.supportsScreenSpaceReflections = true;
+    caps.supportsScreenSpaceGlobalIllumination = true;
+    caps.supportsTemporalGiResolve = true;
+    caps.supportsGiComposite = true;
+    caps.maxReflectionQuality = RenderFeatureQualityTier::High;
+    caps.maxGlobalIlluminationQuality = RenderFeatureQualityTier::High;
     return caps;
   }
 
@@ -3516,6 +3549,7 @@ namespace Monolith
     m_context->frameCommandsRecorded = false;
     m_drawCalls = 0;
     m_executedOpaqueIndexedDraws = 0;
+    m_executedGiScaffoldPasses = 0;
     m_frameActive = true;
   }
 
@@ -3598,8 +3632,26 @@ namespace Monolith
     if (!m_frameActive || m_passActive)
       return;
 
+    if (IsVulkanGiScaffoldPass(pass.id))
+    {
+      const RenderBackendCapabilities caps = GetCapabilities();
+      const bool passIsSupported =
+          (pass.id == RenderPassId::ScreenSpaceReflections && caps.supportsScreenSpaceReflections) ||
+          (pass.id == RenderPassId::ScreenSpaceGlobalIllumination &&
+           caps.supportsScreenSpaceGlobalIllumination) ||
+          (pass.id == RenderPassId::TemporalGiResolve && caps.supportsTemporalGiResolve) ||
+          (pass.id == RenderPassId::GiComposite && caps.supportsGiComposite);
+      if (!passIsSupported || !IsEnabledGiScaffoldPass(pass.id, m_activeFrame.giPipeline))
+      {
+        m_lastError = "Vulkan GI scaffold pass requires explicit frame-level GI enablement and capability support.";
+        return;
+      }
+    }
+
     m_activePassId = pass.id;
     m_activeView = pass.view;
+    if (IsVulkanGiScaffoldPass(pass.id))
+      ++m_executedGiScaffoldPasses;
     m_passActive = true;
   }
 

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -68,6 +68,7 @@ namespace Monolith
     void QueueOverlayRenderCallback(OverlayRenderCallback callback, void *userData);
     const std::string &GetLastError() const { return m_lastError; }
     int GetExecutedOpaqueIndexedDrawCount() const { return m_executedOpaqueIndexedDraws; }
+    int GetExecutedGiScaffoldPassCount() const { return m_executedGiScaffoldPasses; }
 
     struct OffscreenTargetMetadata
     {
@@ -166,6 +167,7 @@ namespace Monolith
     RenderPassId m_activePassId = RenderPassId::OpaqueScene;
     int m_drawCalls = 0;
     int m_executedOpaqueIndexedDraws = 0;
+    int m_executedGiScaffoldPasses = 0;
     bool m_frameActive = false;
     bool m_passActive = false;
   };

--- a/tests/test_editor.cpp
+++ b/tests/test_editor.cpp
@@ -14,6 +14,7 @@
 
 #include <imgui.h>
 #include <imgui_internal.h>
+#include <GLFW/glfw3.h>
 
 #include "core/ProjectPath.h"
 #include "editor/EditorLayer.h"
@@ -252,6 +253,29 @@ TEST_CASE("EditorImGuiBackend: backend support reflects build capabilities",
     REQUIRE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
 #else
     REQUIRE_FALSE(IsSupportedEditorImGuiBackend(RenderBackendId::Vulkan));
+#endif
+}
+
+TEST_CASE("EditorImGuiBackend: backend resolution follows GLFW client API",
+          "[editor][imgui][backend]")
+{
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::OpenGL, GLFW_OPENGL_API) ==
+            RenderBackendId::OpenGL);
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::Auto, GLFW_OPENGL_API) ==
+            RenderBackendId::OpenGL);
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::Vulkan, GLFW_OPENGL_API) ==
+            RenderBackendId::Vulkan);
+
+#if defined(MONOLITH_HAS_VULKAN)
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::OpenGL, GLFW_NO_API) ==
+            RenderBackendId::Vulkan);
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::Auto, GLFW_NO_API) ==
+            RenderBackendId::Vulkan);
+#else
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::OpenGL, GLFW_NO_API) ==
+            RenderBackendId::OpenGL);
+    REQUIRE(ResolveEditorImGuiBackend(RenderBackendId::Auto, GLFW_NO_API) ==
+            RenderBackendId::OpenGL);
 #endif
 }
 

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -174,6 +174,13 @@ TEST_CASE("Renderer routes explicit frame and pass commands through backend seam
   REQUIRE(backend.events ==
           std::vector<std::string>{"begin-frame", "begin-pass", "draw-mesh", "end-pass", "end-frame"});
   REQUIRE(backend.lastFrame.lights.size() == 2);
+  REQUIRE_FALSE(backend.lastFrame.giPipeline.enableScreenSpaceReflections);
+  REQUIRE(backend.lastFrame.giPipeline.reflectionQuality == RenderFeatureQualityTier::Off);
+  REQUIRE_FALSE(backend.lastFrame.giPipeline.enableScreenSpaceGlobalIllumination);
+  REQUIRE(backend.lastFrame.giPipeline.globalIlluminationQuality == RenderFeatureQualityTier::Off);
+  REQUIRE_FALSE(backend.lastFrame.giPipeline.enableTemporalResolve);
+  REQUIRE_FALSE(backend.lastFrame.giPipeline.enableComposite);
+  REQUIRE_FALSE(backend.lastFrame.giPipeline.resetTemporalHistory);
   REQUIRE(backend.lastPass.id == RenderPassId::OpaqueScene);
   REQUIRE(backend.lastMesh.mesh == &mesh);
   REQUIRE(backend.lastMesh.material == &material);
@@ -202,7 +209,15 @@ TEST_CASE("Renderer forwards frame output config through the backend seam",
   Renderer::UseBackend(&backend);
 
   const Vec4 clearColor{0.3f, 0.2f, 0.1f, 1.0f};
-  Renderer::BeginFrame(RenderFrameConfig{{}, "frame-output", clearColor, false, true});
+  const GiPipelineFrameConfig giConfig{
+      .enableScreenSpaceReflections = true,
+      .reflectionQuality = RenderFeatureQualityTier::Medium,
+      .enableScreenSpaceGlobalIllumination = true,
+      .globalIlluminationQuality = RenderFeatureQualityTier::Low,
+      .enableTemporalResolve = true,
+      .enableComposite = true,
+      .resetTemporalHistory = true};
+  Renderer::BeginFrame(RenderFrameConfig{{}, "frame-output", clearColor, false, true, giConfig});
   Renderer::EndFrame();
 
   REQUIRE(backend.events == std::vector<std::string>{"begin-frame", "end-frame"});
@@ -210,6 +225,13 @@ TEST_CASE("Renderer forwards frame output config through the backend seam",
   REQUIRE(backend.lastFrame.clearColor == clearColor);
   REQUIRE_FALSE(backend.lastFrame.clearColorBuffer);
   REQUIRE(backend.lastFrame.clearDepthBuffer);
+  REQUIRE(backend.lastFrame.giPipeline.enableScreenSpaceReflections);
+  REQUIRE(backend.lastFrame.giPipeline.reflectionQuality == RenderFeatureQualityTier::Medium);
+  REQUIRE(backend.lastFrame.giPipeline.enableScreenSpaceGlobalIllumination);
+  REQUIRE(backend.lastFrame.giPipeline.globalIlluminationQuality == RenderFeatureQualityTier::Low);
+  REQUIRE(backend.lastFrame.giPipeline.enableTemporalResolve);
+  REQUIRE(backend.lastFrame.giPipeline.enableComposite);
+  REQUIRE(backend.lastFrame.giPipeline.resetTemporalHistory);
 
   Renderer::ResetBackend();
 }
@@ -233,6 +255,12 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
   REQUIRE(caps.supportsDepthReadback);
   REQUIRE(caps.supportsDebugHud);
   REQUIRE_FALSE(caps.supportsComputePasses);
+  REQUIRE_FALSE(caps.supportsScreenSpaceReflections);
+  REQUIRE_FALSE(caps.supportsScreenSpaceGlobalIllumination);
+  REQUIRE_FALSE(caps.supportsTemporalGiResolve);
+  REQUIRE_FALSE(caps.supportsGiComposite);
+  REQUIRE(caps.maxReflectionQuality == RenderFeatureQualityTier::Off);
+  REQUIRE(caps.maxGlobalIlluminationQuality == RenderFeatureQualityTier::Off);
 }
 
 TEST_CASE("Renderer rejects unsupported backend requests without replacing the active backend",
@@ -289,6 +317,12 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE(glCaps.supportsReadback);
   REQUIRE(glCaps.supportsDepthReadback);
   REQUIRE(glCaps.supportsDebugHud);
+  REQUIRE_FALSE(glCaps.supportsScreenSpaceReflections);
+  REQUIRE_FALSE(glCaps.supportsScreenSpaceGlobalIllumination);
+  REQUIRE_FALSE(glCaps.supportsTemporalGiResolve);
+  REQUIRE_FALSE(glCaps.supportsGiComposite);
+  REQUIRE(glCaps.maxReflectionQuality == RenderFeatureQualityTier::Off);
+  REQUIRE(glCaps.maxGlobalIlluminationQuality == RenderFeatureQualityTier::Off);
 
   const RenderBackendCapabilities vkCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   REQUIRE_FALSE(vkCaps.supportsDebugDraw);
@@ -298,6 +332,12 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE_FALSE(vkCaps.supportsReadback);
   REQUIRE_FALSE(vkCaps.supportsDepthReadback);
   REQUIRE_FALSE(vkCaps.supportsDebugHud);
+  REQUIRE_FALSE(vkCaps.supportsScreenSpaceReflections);
+  REQUIRE_FALSE(vkCaps.supportsScreenSpaceGlobalIllumination);
+  REQUIRE_FALSE(vkCaps.supportsTemporalGiResolve);
+  REQUIRE_FALSE(vkCaps.supportsGiComposite);
+  REQUIRE(vkCaps.maxReflectionQuality == RenderFeatureQualityTier::Off);
+  REQUIRE(vkCaps.maxGlobalIlluminationQuality == RenderFeatureQualityTier::Off);
 }
 
 TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
@@ -565,6 +605,74 @@ TEST_CASE("Vulkan backend executes queued overlay callbacks while recording fram
 
   REQUIRE(overlayProbe.invoked);
   REQUIRE(overlayProbe.commandBufferHandle != nullptr);
+
+  glfwDestroyWindow(window);
+  glfwTerminate();
+}
+
+TEST_CASE("Vulkan backend gates GI scaffold passes behind frame-level GI configuration",
+          "[renderer][foundation][vulkan][gi]")
+{
+  if (!glfwInit())
+    SKIP("GLFW initialization failed on this machine");
+
+  if (!glfwVulkanSupported())
+  {
+    glfwTerminate();
+    SKIP("GLFW reports Vulkan unsupported on this machine");
+  }
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+  GLFWwindow *window = glfwCreateWindow(64, 64, "vulkan-gi-scaffold-test", nullptr, nullptr);
+  if (!window)
+  {
+    glfwTerminate();
+    SKIP("Unable to create hidden GLFW window for Vulkan GI scaffold test");
+  }
+
+  VulkanRenderBackend backend(window);
+  REQUIRE(backend.IsInitialized());
+
+  const RenderBackendCapabilities caps = backend.GetCapabilities();
+  REQUIRE(caps.supportsComputePasses);
+  REQUIRE(caps.supportsScreenSpaceReflections);
+  REQUIRE(caps.supportsScreenSpaceGlobalIllumination);
+  REQUIRE(caps.supportsTemporalGiResolve);
+  REQUIRE(caps.supportsGiComposite);
+  REQUIRE(caps.maxReflectionQuality == RenderFeatureQualityTier::High);
+  REQUIRE(caps.maxGlobalIlluminationQuality == RenderFeatureQualityTier::High);
+
+  Camera camera;
+  backend.BeginFrame({{}, "vulkan-gi-disabled"});
+  backend.BeginPass({RenderPassId::ScreenSpaceReflections, BuildRenderView(camera), "ssr-disabled"});
+  REQUIRE(backend.GetExecutedGiScaffoldPassCount() == 0);
+  REQUIRE(backend.GetLastError().find("requires explicit frame-level GI enablement") !=
+          std::string::npos);
+  backend.EndFrame();
+
+  RenderFrameConfig giFrame{};
+  giFrame.debugLabel = "vulkan-gi-enabled";
+  giFrame.giPipeline.enableScreenSpaceReflections = true;
+  giFrame.giPipeline.reflectionQuality = RenderFeatureQualityTier::Medium;
+  giFrame.giPipeline.enableScreenSpaceGlobalIllumination = true;
+  giFrame.giPipeline.globalIlluminationQuality = RenderFeatureQualityTier::Low;
+  giFrame.giPipeline.enableTemporalResolve = true;
+  giFrame.giPipeline.enableComposite = true;
+
+  backend.BeginFrame(giFrame);
+  backend.BeginPass({RenderPassId::ScreenSpaceReflections, BuildRenderView(camera), "ssr"});
+  backend.EndPass();
+  backend.BeginPass(
+      {RenderPassId::ScreenSpaceGlobalIllumination, BuildRenderView(camera), "ssgi"});
+  backend.EndPass();
+  backend.BeginPass({RenderPassId::TemporalGiResolve, BuildRenderView(camera), "temporal"});
+  backend.EndPass();
+  backend.BeginPass({RenderPassId::GiComposite, BuildRenderView(camera), "composite"});
+  backend.EndPass();
+  backend.EndFrame();
+
+  REQUIRE(backend.GetExecutedGiScaffoldPassCount() == 4);
 
   glfwDestroyWindow(window);
   glfwTerminate();


### PR DESCRIPTION
## Summary
- add GI quality-tier and frame-level GI pipeline config scaffolding
- extend render pass IDs for SSR/SSGI/temporal/composite pipeline stages
- add Vulkan GI scaffold pass gating behind explicit frame-level flags
- add renderer foundation tests for capability defaults and GI pass behavior
- document new GI scaffold controls in renderer README

## Validation
- cmake --preset debug-msvc
- cmake --build --preset debug-msvc
- ctest --preset debug-msvc -C Debug --output-on-failure

#163 