### PR TITLE
feat(renderer): add backend-neutral scene texture and GI history abstractions

### DIFF
--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -6,6 +6,7 @@
 #include "renderer/RenderBackend.h"
 #include "renderer/RenderTargetHandle.h"
 #include "renderer/RenderTypes.h"
+#include "renderer/SceneTextureResources.h"
 
 namespace Monolith {
 
@@ -39,6 +40,18 @@ class IRenderBackend {
   virtual bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle* outHandle,
                                                       bool needsYFlip,
                                                       std::string* outError) = 0;
+  virtual bool EnsureSceneTextureResources(uint32_t width,
+                                           uint32_t height,
+                                           std::string* outError) = 0;
+  virtual bool TryGetSceneTextureCatalog(SceneTextureCatalog* outCatalog,
+                                         std::string* outError) const = 0;
+  virtual bool EnsureGiHistoryResources(uint32_t width,
+                                        uint32_t height,
+                                        std::string* outError) = 0;
+  virtual bool TryGetGiHistoryCatalog(GiHistoryCatalog* outCatalog,
+                                      std::string* outError) const = 0;
+  virtual bool InvalidateGiHistory(GiHistoryResetReason reason,
+                                   std::string* outError) = 0;
 };
 
 }  // namespace Monolith

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -95,6 +95,46 @@ bool OpenGLRenderBackend::TryGetEditorViewportRenderTargetHandle(RenderTargetHan
   return false;
 }
 
+bool OpenGLRenderBackend::EnsureSceneTextureResources(uint32_t,
+                                                      uint32_t,
+                                                      std::string* outError) {
+  if (outError)
+    *outError = "Scene texture abstraction resources are unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::TryGetSceneTextureCatalog(SceneTextureCatalog* outCatalog,
+                                                    std::string* outError) const {
+  if (outCatalog)
+    *outCatalog = {};
+  if (outError)
+    *outError = "Scene texture abstraction catalog is unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::EnsureGiHistoryResources(uint32_t,
+                                                   uint32_t,
+                                                   std::string* outError) {
+  if (outError)
+    *outError = "GI history abstraction resources are unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::TryGetGiHistoryCatalog(GiHistoryCatalog* outCatalog,
+                                                 std::string* outError) const {
+  if (outCatalog)
+    *outCatalog = {};
+  if (outError)
+    *outError = "GI history abstraction catalog is unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::InvalidateGiHistory(GiHistoryResetReason, std::string* outError) {
+  if (outError)
+    *outError = "GI history invalidation is unavailable on OpenGL backend.";
+  return false;
+}
+
 void OpenGLRenderBackend::BeginFrame(const RenderFrameConfig& frame) {
   MONOLITH_ASSERT(!m_frameActive, "OpenGLRenderBackend::BeginFrame called while a frame is active");
   glEnable(GL_DEPTH_TEST);

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -35,6 +35,17 @@ class OpenGLRenderBackend : public IRenderBackend {
   bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle* outHandle,
                                               bool needsYFlip,
                                               std::string* outError) override;
+  bool EnsureSceneTextureResources(uint32_t width,
+                                   uint32_t height,
+                                   std::string* outError) override;
+  bool TryGetSceneTextureCatalog(SceneTextureCatalog* outCatalog,
+                                 std::string* outError) const override;
+  bool EnsureGiHistoryResources(uint32_t width,
+                                uint32_t height,
+                                std::string* outError) override;
+  bool TryGetGiHistoryCatalog(GiHistoryCatalog* outCatalog,
+                              std::string* outError) const override;
+  bool InvalidateGiHistory(GiHistoryResetReason reason, std::string* outError) override;
 
  private:
   void UploadLights(const Shader& shader);

--- a/renderer/RenderBackend.cpp
+++ b/renderer/RenderBackend.cpp
@@ -29,24 +29,28 @@ RenderBackendCapabilities GetDefaultRenderBackendCapabilities(RenderBackendId ba
               .supportsDebugLabels = false,
               .supportsOffscreenTargets = true,
               .supportsNativeTextureHandles = true,
-              .supportsReadback = true,
-              .supportsDepthReadback = true,
-              .supportsDebugHud = true,
-              .supportsComputePasses = false,
-              .supportsGpuTimestamps = false,
-              .supportsBindlessResources = false};
+               .supportsReadback = true,
+               .supportsDepthReadback = true,
+               .supportsDebugHud = true,
+               .supportsComputePasses = false,
+               .supportsGpuTimestamps = false,
+               .supportsBindlessResources = false,
+               .supportsSceneTextureAbstractions = false,
+               .supportsGiHistoryResources = false};
     case RenderBackendId::Vulkan:
       return {.supportsDebugDraw = false,
               .supportsWireframeOverlay = false,
               .supportsDebugLabels = false,
               .supportsOffscreenTargets = true,
               .supportsNativeTextureHandles = true,
-              .supportsReadback = false,
-              .supportsDepthReadback = false,
-              .supportsDebugHud = false,
-              .supportsComputePasses = false,
-              .supportsGpuTimestamps = false,
-              .supportsBindlessResources = false};
+               .supportsReadback = false,
+               .supportsDepthReadback = false,
+               .supportsDebugHud = false,
+               .supportsComputePasses = false,
+               .supportsGpuTimestamps = false,
+               .supportsBindlessResources = false,
+               .supportsSceneTextureAbstractions = true,
+               .supportsGiHistoryResources = true};
   }
 
   return {};

--- a/renderer/RenderBackend.h
+++ b/renderer/RenderBackend.h
@@ -22,6 +22,8 @@ struct RenderBackendCapabilities {
   bool supportsComputePasses = false;
   bool supportsGpuTimestamps = false;
   bool supportsBindlessResources = false;
+  bool supportsSceneTextureAbstractions = false;
+  bool supportsGiHistoryResources = false;
 };
 
 struct RenderBackendSelection {

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -205,4 +205,36 @@ namespace Monolith
     return ActiveBackend()->TryGetEditorViewportRenderTargetHandle(outHandle, needsYFlip, outError);
   }
 
+  bool Renderer::EnsureSceneTextureResources(uint32_t width,
+                                             uint32_t height,
+                                             std::string *outError)
+  {
+    return ActiveBackend()->EnsureSceneTextureResources(width, height, outError);
+  }
+
+  bool Renderer::TryGetSceneTextureCatalog(SceneTextureCatalog *outCatalog,
+                                           std::string *outError)
+  {
+    return ActiveBackend()->TryGetSceneTextureCatalog(outCatalog, outError);
+  }
+
+  bool Renderer::EnsureGiHistoryResources(uint32_t width,
+                                          uint32_t height,
+                                          std::string *outError)
+  {
+    return ActiveBackend()->EnsureGiHistoryResources(width, height, outError);
+  }
+
+  bool Renderer::TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
+                                        std::string *outError)
+  {
+    return ActiveBackend()->TryGetGiHistoryCatalog(outCatalog, outError);
+  }
+
+  bool Renderer::InvalidateGiHistory(GiHistoryResetReason reason,
+                                     std::string *outError)
+  {
+    return ActiveBackend()->InvalidateGiHistory(reason, outError);
+  }
+
 } // namespace Monolith

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -7,6 +7,7 @@
 #include "renderer/RenderBackend.h"
 #include "renderer/IRenderBackend.h"
 #include "renderer/RenderTargetHandle.h"
+#include "renderer/SceneTextureResources.h"
 #include "renderer/RenderTypes.h"
 
 namespace Monolith
@@ -69,6 +70,18 @@ namespace Monolith
     static bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
                                                        bool needsYFlip = false,
                                                        std::string *outError = nullptr);
+    static bool EnsureSceneTextureResources(uint32_t width,
+                                            uint32_t height,
+                                            std::string *outError = nullptr);
+    static bool TryGetSceneTextureCatalog(SceneTextureCatalog *outCatalog,
+                                          std::string *outError = nullptr);
+    static bool EnsureGiHistoryResources(uint32_t width,
+                                         uint32_t height,
+                                         std::string *outError = nullptr);
+    static bool TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
+                                       std::string *outError = nullptr);
+    static bool InvalidateGiHistory(GiHistoryResetReason reason,
+                                    std::string *outError = nullptr);
 
   private:
     static IRenderBackend *ActiveBackend();

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "renderer/RenderBackend.h"
+
+namespace Monolith
+{
+
+  enum class SceneTextureSemantic : uint8_t
+  {
+    Color = 0,
+    Depth,
+    Normals,
+    Material,
+    Emissive,
+    Velocity,
+    Count,
+  };
+
+  enum class GiHistorySemantic : uint8_t
+  {
+    DiffuseIrradiance = 0,
+    SpecularIrradiance,
+    Validation,
+    Moments,
+    Count,
+  };
+
+  enum class GiHistoryResetReason : uint8_t
+  {
+    None = 0,
+    ViewportResize,
+    CameraCut,
+    SceneBarrier,
+  };
+
+  struct BackendResourceHandle
+  {
+    RenderBackendId backendId = RenderBackendId::Auto;
+    uint64_t resourceId = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint64_t generation = 0;
+
+    bool IsValid() const { return resourceId != 0; }
+  };
+
+  struct SceneTextureCatalog
+  {
+    std::array<BackendResourceHandle, static_cast<size_t>(SceneTextureSemantic::Count)> handles{};
+    uint64_t frameSerial = 0;
+
+    void Set(SceneTextureSemantic semantic, const BackendResourceHandle &handle)
+    {
+      handles[static_cast<size_t>(semantic)] = handle;
+    }
+
+    const BackendResourceHandle &Get(SceneTextureSemantic semantic) const
+    {
+      return handles[static_cast<size_t>(semantic)];
+    }
+
+    bool Has(SceneTextureSemantic semantic) const
+    {
+      return Get(semantic).IsValid();
+    }
+  };
+
+  struct GiHistoryCatalog
+  {
+    std::array<BackendResourceHandle, static_cast<size_t>(GiHistorySemantic::Count)> handles{};
+    GiHistoryResetReason lastResetReason = GiHistoryResetReason::None;
+    uint64_t revision = 0;
+
+    void Set(GiHistorySemantic semantic, const BackendResourceHandle &handle)
+    {
+      handles[static_cast<size_t>(semantic)] = handle;
+    }
+
+    const BackendResourceHandle &Get(GiHistorySemantic semantic) const
+    {
+      return handles[static_cast<size_t>(semantic)];
+    }
+
+    bool Has(GiHistorySemantic semantic) const
+    {
+      return Get(semantic).IsValid();
+    }
+  };
+
+} // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -35,6 +35,42 @@ namespace Monolith
     constexpr uint32_t kInvalidQueueFamily = std::numeric_limits<uint32_t>::max();
     constexpr VkFormat kOffscreenTargetFormat = VK_FORMAT_R8G8B8A8_UNORM;
     constexpr const char *kEditorViewportTargetKey = "__editor.viewport.scene";
+    constexpr std::array<const char *, static_cast<size_t>(SceneTextureSemantic::Count)> kSceneTextureTargetKeys = {
+        "__scene.color",
+        "__scene.depth",
+        "__scene.normals",
+        "__scene.material",
+        "__scene.emissive",
+        "__scene.velocity"};
+    constexpr std::array<const char *, static_cast<size_t>(GiHistorySemantic::Count)> kGiHistoryTargetKeys = {
+        "__gi.history.diffuse_irradiance",
+        "__gi.history.specular_irradiance",
+        "__gi.history.validation",
+        "__gi.history.moments"};
+
+    uint64_t HashResourceKey(const std::string &key)
+    {
+      constexpr uint64_t kFNVOffset = 14695981039346656037ull;
+      constexpr uint64_t kFNVPrime = 1099511628211ull;
+
+      uint64_t hash = kFNVOffset;
+      for (unsigned char c : key)
+      {
+        hash ^= static_cast<uint64_t>(c);
+        hash *= kFNVPrime;
+      }
+      return hash;
+    }
+
+    const char *SceneTextureTargetKey(SceneTextureSemantic semantic)
+    {
+      return kSceneTextureTargetKeys[static_cast<size_t>(semantic)];
+    }
+
+    const char *GiHistoryTargetKey(GiHistorySemantic semantic)
+    {
+      return kGiHistoryTargetKeys[static_cast<size_t>(semantic)];
+    }
 
     const char *VkResultName(VkResult result)
     {
@@ -755,6 +791,161 @@ namespace Monolith
     return ok;
   }
 
+  bool VulkanRenderBackend::EnsureSceneTextureResources(uint32_t width,
+                                                        uint32_t height,
+                                                        std::string *outError)
+  {
+    m_sceneTextureCatalog = {};
+    if (width == 0 || height == 0)
+    {
+      m_lastError = "Scene texture abstraction dimensions must be non-zero.";
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    for (size_t i = 0; i < static_cast<size_t>(SceneTextureSemantic::Count); ++i)
+    {
+      const auto semantic = static_cast<SceneTextureSemantic>(i);
+      if (!EnsureOffscreenRenderTarget(SceneTextureTargetKey(semantic), width, height))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+
+      BackendResourceHandle handle{};
+      if (!BuildOffscreenResourceHandle(SceneTextureTargetKey(semantic), &handle))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+      m_sceneTextureCatalog.Set(semantic, handle);
+    }
+
+    ++m_sceneTextureCatalog.frameSerial;
+    return true;
+  }
+
+  bool VulkanRenderBackend::TryGetSceneTextureCatalog(SceneTextureCatalog *outCatalog,
+                                                      std::string *outError) const
+  {
+    if (!outCatalog)
+      return false;
+    if (!m_sceneTextureCatalog.Has(SceneTextureSemantic::Color))
+    {
+      *outCatalog = {};
+      if (outError)
+        *outError = "Scene texture abstraction catalog has not been initialized.";
+      return false;
+    }
+
+    *outCatalog = m_sceneTextureCatalog;
+    return true;
+  }
+
+  bool VulkanRenderBackend::EnsureGiHistoryResources(uint32_t width,
+                                                     uint32_t height,
+                                                     std::string *outError)
+  {
+    if (width == 0 || height == 0)
+    {
+      m_lastError = "GI history abstraction dimensions must be non-zero.";
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    for (size_t i = 0; i < static_cast<size_t>(GiHistorySemantic::Count); ++i)
+    {
+      const auto semantic = static_cast<GiHistorySemantic>(i);
+      if (!EnsureOffscreenRenderTarget(GiHistoryTargetKey(semantic), width, height))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+
+      BackendResourceHandle handle{};
+      if (!BuildOffscreenResourceHandle(GiHistoryTargetKey(semantic), &handle))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+      m_giHistoryCatalog.Set(semantic, handle);
+    }
+
+    ++m_giHistoryCatalog.revision;
+    m_giHistoryCatalog.lastResetReason = GiHistoryResetReason::None;
+    return true;
+  }
+
+  bool VulkanRenderBackend::TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
+                                                   std::string *outError) const
+  {
+    if (!outCatalog)
+      return false;
+    if (!m_giHistoryCatalog.Has(GiHistorySemantic::DiffuseIrradiance))
+    {
+      *outCatalog = {};
+      if (outError)
+        *outError = "GI history abstraction catalog has not been initialized.";
+      return false;
+    }
+
+    *outCatalog = m_giHistoryCatalog;
+    return true;
+  }
+
+  bool VulkanRenderBackend::InvalidateGiHistory(GiHistoryResetReason reason,
+                                                std::string *outError)
+  {
+    if (!m_giHistoryCatalog.Has(GiHistorySemantic::DiffuseIrradiance))
+    {
+      m_lastError = "GI history abstraction invalidation requires initialized history resources.";
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    for (size_t i = 0; i < static_cast<size_t>(GiHistorySemantic::Count); ++i)
+    {
+      const auto semantic = static_cast<GiHistorySemantic>(i);
+      const char *targetKey = GiHistoryTargetKey(semantic);
+      OffscreenTargetMetadata metadata{};
+      if (!TryGetOffscreenRenderTargetMetadata(targetKey, &metadata))
+      {
+        m_lastError = "GI history abstraction invalidation encountered a missing history surface.";
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+
+      DestroyOffscreenRenderTargetResources(targetKey);
+      if (!CreateOffscreenRenderTargetResources(targetKey, metadata.width, metadata.height, metadata.generation))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+
+      BackendResourceHandle handle{};
+      if (!BuildOffscreenResourceHandle(targetKey, &handle))
+      {
+        if (outError)
+          *outError = m_lastError;
+        return false;
+      }
+      m_giHistoryCatalog.Set(semantic, handle);
+    }
+
+    ++m_giHistoryCatalog.revision;
+    m_giHistoryCatalog.lastResetReason = reason;
+    return true;
+  }
+
   bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &targetKey,
                                                         uint32_t width,
                                                         uint32_t height)
@@ -837,6 +1028,26 @@ namespace Monolith
   void VulkanRenderBackend::DestroyOffscreenRenderTarget(const std::string &targetKey)
   {
     DestroyOffscreenRenderTargetResources(targetKey);
+  }
+
+  bool VulkanRenderBackend::BuildOffscreenResourceHandle(const std::string &targetKey,
+                                                         BackendResourceHandle *outHandle) const
+  {
+    if (!m_context || !outHandle)
+      return false;
+
+    const auto it = m_context->offscreenTargets.find(targetKey);
+    if (it == m_context->offscreenTargets.end())
+      return false;
+
+    const Context::OffscreenRenderTarget &target = it->second;
+    *outHandle = {
+        RenderBackendId::Vulkan,
+        HashResourceKey(targetKey),
+        target.width,
+        target.height,
+        target.generation};
+    return outHandle->IsValid();
   }
 
   void VulkanRenderBackend::DestroyAllOffscreenRenderTargets()
@@ -1625,6 +1836,8 @@ namespace Monolith
     m_context.reset();
     m_frameActive = false;
     m_passActive = false;
+    m_sceneTextureCatalog = {};
+    m_giHistoryCatalog = {};
   }
 
   void VulkanRenderBackend::DestroySwapchain()
@@ -3694,6 +3907,17 @@ namespace Monolith
   {
     return false;
   }
+  bool VulkanRenderBackend::EnsureSceneTextureResources(uint32_t, uint32_t, std::string *) { return false; }
+  bool VulkanRenderBackend::TryGetSceneTextureCatalog(SceneTextureCatalog *, std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::EnsureGiHistoryResources(uint32_t, uint32_t, std::string *) { return false; }
+  bool VulkanRenderBackend::TryGetGiHistoryCatalog(GiHistoryCatalog *, std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::InvalidateGiHistory(GiHistoryResetReason, std::string *) { return false; }
   bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &, uint32_t, uint32_t) { return false; }
   bool VulkanRenderBackend::TryGetOffscreenRenderTargetHandle(const std::string &,
                                                               RenderTargetHandle *,
@@ -3708,6 +3932,10 @@ namespace Monolith
   }
   void VulkanRenderBackend::DestroyOffscreenRenderTarget(const std::string &) {}
   void VulkanRenderBackend::DestroyAllOffscreenRenderTargets() {}
+  bool VulkanRenderBackend::BuildOffscreenResourceHandle(const std::string &, BackendResourceHandle *) const
+  {
+    return false;
+  }
 
   bool VulkanRenderBackend::Initialize(void *)
   {

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -46,6 +46,18 @@ namespace Monolith
     bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
                                                 bool needsYFlip,
                                                 std::string *outError) override;
+    bool EnsureSceneTextureResources(uint32_t width,
+                                     uint32_t height,
+                                     std::string *outError) override;
+    bool TryGetSceneTextureCatalog(SceneTextureCatalog *outCatalog,
+                                   std::string *outError) const override;
+    bool EnsureGiHistoryResources(uint32_t width,
+                                  uint32_t height,
+                                  std::string *outError) override;
+    bool TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
+                                std::string *outError) const override;
+    bool InvalidateGiHistory(GiHistoryResetReason reason,
+                             std::string *outError) override;
 
     RenderBackendId GetBackendId() const override { return RenderBackendId::Vulkan; }
     RenderBackendCapabilities GetCapabilities() const override;
@@ -143,6 +155,8 @@ namespace Monolith
                                               uint32_t height,
                                               uint64_t previousGeneration);
     void DestroyOffscreenRenderTargetResources(const std::string &targetKey);
+    bool BuildOffscreenResourceHandle(const std::string &targetKey,
+                                      BackendResourceHandle *outHandle) const;
     bool TryRegisterOffscreenTargetImGuiDescriptor(const std::string &targetKey,
                                                    RenderTargetHandle *outHandle,
                                                    bool needsYFlip);
@@ -168,6 +182,8 @@ namespace Monolith
     int m_executedOpaqueIndexedDraws = 0;
     bool m_frameActive = false;
     bool m_passActive = false;
+    SceneTextureCatalog m_sceneTextureCatalog;
+    GiHistoryCatalog m_giHistoryCatalog;
   };
 
 } // namespace Monolith

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -126,6 +126,97 @@ namespace
         *outError = "fake backend has no viewport target handle";
       return false;
     }
+    bool EnsureSceneTextureResources(uint32_t width,
+                                     uint32_t height,
+                                     std::string *outError) override
+    {
+      if (width == 0 || height == 0)
+      {
+        if (outError)
+          *outError = "invalid scene texture dimensions";
+        return false;
+      }
+
+      sceneTextures = {};
+      for (size_t i = 0; i < static_cast<size_t>(SceneTextureSemantic::Count); ++i)
+      {
+        sceneTextures.Set(static_cast<SceneTextureSemantic>(i),
+                          {RenderBackendId::OpenGL, 100u + i, width, height, 1u});
+      }
+      ++sceneTextures.frameSerial;
+      return true;
+    }
+    bool TryGetSceneTextureCatalog(SceneTextureCatalog *outCatalog,
+                                   std::string *outError) const override
+    {
+      if (!outCatalog)
+        return false;
+      if (!sceneTextures.Has(SceneTextureSemantic::Color))
+      {
+        if (outError)
+          *outError = "fake backend has no scene textures";
+        *outCatalog = {};
+        return false;
+      }
+      *outCatalog = sceneTextures;
+      return true;
+    }
+    bool EnsureGiHistoryResources(uint32_t width,
+                                  uint32_t height,
+                                  std::string *outError) override
+    {
+      if (width == 0 || height == 0)
+      {
+        if (outError)
+          *outError = "invalid gi history dimensions";
+        return false;
+      }
+
+      giHistory = {};
+      for (size_t i = 0; i < static_cast<size_t>(GiHistorySemantic::Count); ++i)
+      {
+        giHistory.Set(static_cast<GiHistorySemantic>(i),
+                      {RenderBackendId::OpenGL, 200u + i, width, height, 1u});
+      }
+      ++giHistory.revision;
+      giHistory.lastResetReason = GiHistoryResetReason::None;
+      return true;
+    }
+    bool TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
+                                std::string *outError) const override
+    {
+      if (!outCatalog)
+        return false;
+      if (!giHistory.Has(GiHistorySemantic::DiffuseIrradiance))
+      {
+        if (outError)
+          *outError = "fake backend has no gi history";
+        *outCatalog = {};
+        return false;
+      }
+      *outCatalog = giHistory;
+      return true;
+    }
+    bool InvalidateGiHistory(GiHistoryResetReason reason, std::string *outError) override
+    {
+      if (!giHistory.Has(GiHistorySemantic::DiffuseIrradiance))
+      {
+        if (outError)
+          *outError = "fake backend has no gi history to invalidate";
+        return false;
+      }
+
+      for (size_t i = 0; i < static_cast<size_t>(GiHistorySemantic::Count); ++i)
+      {
+        const auto semantic = static_cast<GiHistorySemantic>(i);
+        BackendResourceHandle handle = giHistory.Get(semantic);
+        ++handle.generation;
+        giHistory.Set(semantic, handle);
+      }
+      ++giHistory.revision;
+      giHistory.lastResetReason = reason;
+      return true;
+    }
     std::vector<std::string> events;
     RenderFrameConfig lastFrame;
     RenderPassConfig lastPass;
@@ -133,6 +224,8 @@ namespace
     SkinnedMeshDrawCommand lastSkinned;
     WireframeDrawCommand lastWireframe;
     int drawCalls = 0;
+    SceneTextureCatalog sceneTextures;
+    GiHistoryCatalog giHistory;
   };
 
 #if defined(MONOLITH_HAS_VULKAN)
@@ -233,6 +326,8 @@ TEST_CASE("Renderer initializes the default OpenGL backend through a typed selec
   REQUIRE(caps.supportsDepthReadback);
   REQUIRE(caps.supportsDebugHud);
   REQUIRE_FALSE(caps.supportsComputePasses);
+  REQUIRE_FALSE(caps.supportsSceneTextureAbstractions);
+  REQUIRE_FALSE(caps.supportsGiHistoryResources);
 }
 
 TEST_CASE("Renderer rejects unsupported backend requests without replacing the active backend",
@@ -289,6 +384,8 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE(glCaps.supportsReadback);
   REQUIRE(glCaps.supportsDepthReadback);
   REQUIRE(glCaps.supportsDebugHud);
+  REQUIRE_FALSE(glCaps.supportsSceneTextureAbstractions);
+  REQUIRE_FALSE(glCaps.supportsGiHistoryResources);
 
   const RenderBackendCapabilities vkCaps = GetDefaultRenderBackendCapabilities(RenderBackendId::Vulkan);
   REQUIRE_FALSE(vkCaps.supportsDebugDraw);
@@ -298,6 +395,8 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE_FALSE(vkCaps.supportsReadback);
   REQUIRE_FALSE(vkCaps.supportsDepthReadback);
   REQUIRE_FALSE(vkCaps.supportsDebugHud);
+  REQUIRE(vkCaps.supportsSceneTextureAbstractions);
+  REQUIRE(vkCaps.supportsGiHistoryResources);
 }
 
 TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
@@ -324,6 +423,62 @@ TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
   REQUIRE(vkHandle.height == 0u);
   REQUIRE(vkHandle.generation == 0u);
   REQUIRE_FALSE(vkHandle.needsYFlip);
+}
+
+TEST_CASE("Scene texture and GI history catalogs stay backend-neutral and typed",
+          "[renderer][foundation][abstractions]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Color,
+                    {RenderBackendId::Vulkan, 0xA1u, 1920u, 1080u, 3u});
+  sceneTextures.Set(SceneTextureSemantic::Depth,
+                    {RenderBackendId::Vulkan, 0xA2u, 1920u, 1080u, 3u});
+
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Color));
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Depth));
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).backendId == RenderBackendId::Vulkan);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).resourceId == 0xA1u);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).generation == 3u);
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance,
+              {RenderBackendId::Vulkan, 0xB1u, 960u, 540u, 8u});
+  history.Set(GiHistorySemantic::Validation,
+              {RenderBackendId::Vulkan, 0xB2u, 960u, 540u, 8u});
+  history.lastResetReason = GiHistoryResetReason::CameraCut;
+  history.revision = 42u;
+
+  REQUIRE(history.Has(GiHistorySemantic::DiffuseIrradiance));
+  REQUIRE(history.Get(GiHistorySemantic::DiffuseIrradiance).resourceId == 0xB1u);
+  REQUIRE(history.lastResetReason == GiHistoryResetReason::CameraCut);
+  REQUIRE(history.revision == 42u);
+}
+
+TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
+          "[renderer][foundation][abstractions]")
+{
+  FakeRenderBackend backend;
+  Renderer::UseBackend(&backend);
+
+  std::string error;
+  REQUIRE(Renderer::EnsureSceneTextureResources(128u, 72u, &error));
+  REQUIRE(Renderer::EnsureGiHistoryResources(64u, 64u, &error));
+
+  SceneTextureCatalog sceneTextures{};
+  REQUIRE(Renderer::TryGetSceneTextureCatalog(&sceneTextures, &error));
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Normals));
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normals).width == 128u);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normals).height == 72u);
+
+  GiHistoryCatalog giHistory{};
+  REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
+  const uint64_t initialGeneration = giHistory.Get(GiHistorySemantic::DiffuseIrradiance).generation;
+  REQUIRE(Renderer::InvalidateGiHistory(GiHistoryResetReason::SceneBarrier, &error));
+  REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
+  REQUIRE(giHistory.lastResetReason == GiHistoryResetReason::SceneBarrier);
+  REQUIRE(giHistory.Get(GiHistorySemantic::DiffuseIrradiance).generation == initialGeneration + 1u);
+
+  Renderer::ResetBackend();
 }
 
 #if defined(MONOLITH_HAS_VULKAN)


### PR DESCRIPTION
## Summary
Add backend-neutral scene texture and GI history abstractions and wire renderer/backend seams.

Closes #165
