### PR TITLE
feat(renderer): add deferred G-buffer output contracts

### DIFF
--- a/renderer/RenderTypes.h
+++ b/renderer/RenderTypes.h
@@ -18,6 +18,7 @@ class SkinnedMesh;
 enum class RenderPassId {
   CompatibilityScene,
   OpaqueScene,
+  DeferredOpaque,
   WireframeOverlay,
   DebugOverlay,
 };

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -11,13 +11,17 @@ namespace Monolith
 
   enum class SceneTextureSemantic : uint8_t
   {
-    Color = 0,
+    BaseColor = 0,
     Depth,
-    Normals,
-    Material,
+    Normal,
+    RoughnessMetallic,
     Emissive,
     Velocity,
     Count,
+    // Compatibility aliases for pre-GBuffer naming.
+    Color = BaseColor,
+    Normals = Normal,
+    Material = RoughnessMetallic,
   };
 
   enum class GiHistorySemantic : uint8_t
@@ -67,7 +71,46 @@ namespace Monolith
     {
       return Get(semantic).IsValid();
     }
+
+    bool HasDeferredGBuffer() const
+    {
+      return Has(SceneTextureSemantic::BaseColor) &&
+             Has(SceneTextureSemantic::Depth) &&
+             Has(SceneTextureSemantic::Normal) &&
+             Has(SceneTextureSemantic::RoughnessMetallic) &&
+             Has(SceneTextureSemantic::Emissive);
+    }
   };
+
+  struct DeferredGBufferCatalog
+  {
+    BackendResourceHandle baseColor{};
+    BackendResourceHandle depth{};
+    BackendResourceHandle normal{};
+    BackendResourceHandle roughnessMetallic{};
+    BackendResourceHandle emissive{};
+    uint64_t frameSerial = 0;
+
+    bool IsComplete() const
+    {
+      return baseColor.IsValid() &&
+             depth.IsValid() &&
+             normal.IsValid() &&
+             roughnessMetallic.IsValid() &&
+             emissive.IsValid();
+    }
+  };
+
+  inline DeferredGBufferCatalog BuildDeferredGBufferCatalog(const SceneTextureCatalog &catalog)
+  {
+    return {
+        catalog.Get(SceneTextureSemantic::BaseColor),
+        catalog.Get(SceneTextureSemantic::Depth),
+        catalog.Get(SceneTextureSemantic::Normal),
+        catalog.Get(SceneTextureSemantic::RoughnessMetallic),
+        catalog.Get(SceneTextureSemantic::Emissive),
+        catalog.frameSerial};
+  }
 
   struct GiHistoryCatalog
   {

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -36,11 +36,11 @@ namespace Monolith
     constexpr VkFormat kOffscreenTargetFormat = VK_FORMAT_R8G8B8A8_UNORM;
     constexpr const char *kEditorViewportTargetKey = "__editor.viewport.scene";
     constexpr std::array<const char *, static_cast<size_t>(SceneTextureSemantic::Count)> kSceneTextureTargetKeys = {
-        "__scene.color",
-        "__scene.depth",
-        "__scene.normals",
-        "__scene.material",
-        "__scene.emissive",
+        "__scene.gbuffer.base_color",
+        "__scene.gbuffer.depth",
+        "__scene.gbuffer.normal",
+        "__scene.gbuffer.roughness_metallic",
+        "__scene.gbuffer.emissive",
         "__scene.velocity"};
     constexpr std::array<const char *, static_cast<size_t>(GiHistorySemantic::Count)> kGiHistoryTargetKeys = {
         "__gi.history.diffuse_irradiance",
@@ -408,7 +408,9 @@ namespace Monolith
 
     constexpr bool IsSupportedVulkanScenePass(const RenderPassId passId)
     {
-      return passId == RenderPassId::OpaqueScene || passId == RenderPassId::CompatibilityScene;
+      return passId == RenderPassId::OpaqueScene ||
+             passId == RenderPassId::DeferredOpaque ||
+             passId == RenderPassId::CompatibilityScene;
     }
 
     uint8_t PackOpaquePipelineKey(const VulkanRenderBackend::OpaquePipelineKey &key)
@@ -833,7 +835,7 @@ namespace Monolith
   {
     if (!outCatalog)
       return false;
-    if (!m_sceneTextureCatalog.Has(SceneTextureSemantic::Color))
+    if (!m_sceneTextureCatalog.HasDeferredGBuffer())
     {
       *outCatalog = {};
       if (outError)

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -151,7 +151,7 @@ namespace
     {
       if (!outCatalog)
         return false;
-      if (!sceneTextures.Has(SceneTextureSemantic::Color))
+      if (!sceneTextures.HasDeferredGBuffer())
       {
         if (outError)
           *outError = "fake backend has no scene textures";
@@ -429,16 +429,30 @@ TEST_CASE("Scene texture and GI history catalogs stay backend-neutral and typed"
           "[renderer][foundation][abstractions]")
 {
   SceneTextureCatalog sceneTextures{};
-  sceneTextures.Set(SceneTextureSemantic::Color,
+  sceneTextures.Set(SceneTextureSemantic::BaseColor,
                     {RenderBackendId::Vulkan, 0xA1u, 1920u, 1080u, 3u});
+  sceneTextures.Set(SceneTextureSemantic::Normal,
+                    {RenderBackendId::Vulkan, 0xA3u, 1920u, 1080u, 3u});
+  sceneTextures.Set(SceneTextureSemantic::RoughnessMetallic,
+                    {RenderBackendId::Vulkan, 0xA4u, 1920u, 1080u, 3u});
   sceneTextures.Set(SceneTextureSemantic::Depth,
                     {RenderBackendId::Vulkan, 0xA2u, 1920u, 1080u, 3u});
+  sceneTextures.Set(SceneTextureSemantic::Emissive,
+                    {RenderBackendId::Vulkan, 0xA5u, 1920u, 1080u, 3u});
 
-  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Color));
+  REQUIRE(sceneTextures.HasDeferredGBuffer());
   REQUIRE(sceneTextures.Has(SceneTextureSemantic::Depth));
-  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).backendId == RenderBackendId::Vulkan);
-  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).resourceId == 0xA1u);
-  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Color).generation == 3u);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::BaseColor).backendId == RenderBackendId::Vulkan);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::BaseColor).resourceId == 0xA1u);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::BaseColor).generation == 3u);
+
+  const DeferredGBufferCatalog gbuffer = BuildDeferredGBufferCatalog(sceneTextures);
+  REQUIRE(gbuffer.IsComplete());
+  REQUIRE(gbuffer.baseColor.resourceId == 0xA1u);
+  REQUIRE(gbuffer.normal.resourceId == 0xA3u);
+  REQUIRE(gbuffer.roughnessMetallic.resourceId == 0xA4u);
+  REQUIRE(gbuffer.depth.resourceId == 0xA2u);
+  REQUIRE(gbuffer.emissive.resourceId == 0xA5u);
 
   GiHistoryCatalog history{};
   history.Set(GiHistorySemantic::DiffuseIrradiance,
@@ -466,9 +480,11 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
 
   SceneTextureCatalog sceneTextures{};
   REQUIRE(Renderer::TryGetSceneTextureCatalog(&sceneTextures, &error));
-  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Normals));
-  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normals).width == 128u);
-  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normals).height == 72u);
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::Normal));
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::BaseColor));
+  REQUIRE(sceneTextures.Has(SceneTextureSemantic::RoughnessMetallic));
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normal).width == 128u);
+  REQUIRE(sceneTextures.Get(SceneTextureSemantic::Normal).height == 72u);
 
   GiHistoryCatalog giHistory{};
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
@@ -1089,6 +1105,24 @@ TEST_CASE("Renderer supports multiple explicit passes within a single frame",
   REQUIRE(backend.lastPass.id == RenderPassId::WireframeOverlay);
   REQUIRE(backend.lastPass.view.cameraPosition.x == Catch::Approx(4.0f));
   REQUIRE(Renderer::GetDrawCallCount() == 2);
+
+  Renderer::ResetBackend();
+}
+
+TEST_CASE("Renderer forwards deferred opaque pass identifiers through backend seam",
+          "[renderer][foundation]")
+{
+  FakeRenderBackend backend;
+  Renderer::UseBackend(&backend);
+
+  Camera camera;
+  Renderer::BeginFrame(RenderFrameConfig{});
+  Renderer::BeginPass(
+      RenderPassConfig{RenderPassId::DeferredOpaque, BuildRenderView(camera), "deferred-opaque"});
+  Renderer::EndPass();
+  Renderer::EndFrame();
+
+  REQUIRE(backend.lastPass.id == RenderPassId::DeferredOpaque);
 
   Renderer::ResetBackend();
 }


### PR DESCRIPTION
## Summary
Add deferred G-buffer outputs and contracts required by GI/reflection passes.

Closes #166
