### PR TITLE
feat(renderer): add temporal jitter and motion-history contracts

### DIFF
--- a/renderer/RenderTypes.h
+++ b/renderer/RenderTypes.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "math/Mat4.h"
+#include "math/Vec2.h"
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 #include "renderer/Light.h"
@@ -29,12 +32,85 @@ struct RenderView {
   Vec3 cameraPosition = Vec3::Zero();
 };
 
+enum class TemporalQualityTier : uint8_t {
+  Disabled = 0,
+  Low,
+  Medium,
+  High,
+  Ultra,
+};
+
+struct TemporalJitterConfig {
+  bool enabled = false;
+  TemporalQualityTier qualityTier = TemporalQualityTier::Disabled;
+  uint32_t sequenceSeed = 0;
+  uint32_t sequenceLength = 0;
+  uint64_t frameIndex = 0;
+};
+
+inline constexpr uint32_t TemporalJitterSampleCountForTier(TemporalQualityTier tier) {
+  switch (tier) {
+    case TemporalQualityTier::Disabled:
+      return 1u;
+    case TemporalQualityTier::Low:
+      return 2u;
+    case TemporalQualityTier::Medium:
+      return 8u;
+    case TemporalQualityTier::High:
+      return 16u;
+    case TemporalQualityTier::Ultra:
+      return 32u;
+  }
+  return 1u;
+}
+
+inline float HaltonSequence(uint32_t index, uint32_t base) {
+  float result = 0.0f;
+  float inverseBase = 1.0f / static_cast<float>(base);
+  float fraction = inverseBase;
+  uint32_t i = index;
+  while (i > 0u) {
+    result += static_cast<float>(i % base) * fraction;
+    i /= base;
+    fraction *= inverseBase;
+  }
+  return result;
+}
+
+inline Vec2 BuildTemporalJitterOffset(const TemporalJitterConfig& jitter) {
+  if (!jitter.enabled || jitter.qualityTier == TemporalQualityTier::Disabled)
+    return Vec2::Zero();
+
+  const uint32_t tierSampleCount = TemporalJitterSampleCountForTier(jitter.qualityTier);
+  const uint32_t requestedSequenceLength = std::max(jitter.sequenceLength, 1u);
+  const uint32_t sampleCount = std::max(tierSampleCount, requestedSequenceLength);
+  const uint64_t deterministicIndex64 =
+      (jitter.frameIndex + static_cast<uint64_t>(jitter.sequenceSeed)) % sampleCount;
+  const uint32_t deterministicIndex = static_cast<uint32_t>(deterministicIndex64);
+  const float jitterX = HaltonSequence(deterministicIndex + 1u, 2u) - 0.5f;
+  const float jitterY = HaltonSequence(deterministicIndex + 1u, 3u) - 0.5f;
+  return {jitterX, jitterY};
+}
+
+struct RenderFrameTemporalState {
+  bool enableTemporalReprojection = false;
+  bool forceHistoryReset = false;
+  bool cameraCut = false;
+  bool sceneChanged = false;
+  uint64_t sceneToken = 0;
+  uint64_t cameraToken = 0;
+  uint32_t renderWidth = 0;
+  uint32_t renderHeight = 0;
+  TemporalJitterConfig jitter{};
+};
+
 struct RenderFrameConfig {
   std::vector<Light> lights;
   std::string debugLabel;
   Vec4 clearColor = {0.1f, 0.1f, 0.15f, 1.0f};
   bool clearColorBuffer = true;
   bool clearDepthBuffer = true;
+  RenderFrameTemporalState temporal{};
 };
 
 struct RenderPassConfig {

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -231,6 +231,29 @@ namespace Monolith
     return ActiveBackend()->TryGetGiHistoryCatalog(outCatalog, outError);
   }
 
+  bool Renderer::TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
+                                                          std::string *outError)
+  {
+    if (!outContract)
+      return false;
+
+    SceneTextureCatalog sceneTextures{};
+    if (!TryGetSceneTextureCatalog(&sceneTextures, outError))
+      return false;
+
+    GiHistoryCatalog history{};
+    if (!TryGetGiHistoryCatalog(&history, outError))
+      return false;
+
+    *outContract = BuildTemporalReprojectionInputContract(sceneTextures, history);
+    if (outContract->IsValid())
+      return true;
+
+    if (outError)
+      *outError = ToString(outContract->validationStatus);
+    return false;
+  }
+
   bool Renderer::InvalidateGiHistory(GiHistoryResetReason reason,
                                      std::string *outError)
   {

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -80,6 +80,8 @@ namespace Monolith
                                          std::string *outError = nullptr);
     static bool TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
                                        std::string *outError = nullptr);
+    static bool TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
+                                                        std::string *outError = nullptr);
     static bool InvalidateGiHistory(GiHistoryResetReason reason,
                                     std::string *outError = nullptr);
 

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "renderer/RenderBackend.h"
+#include "renderer/RenderTypes.h"
 
 namespace Monolith
 {
@@ -22,6 +23,7 @@ namespace Monolith
     Color = BaseColor,
     Normals = Normal,
     Material = RoughnessMetallic,
+    MotionVector = Velocity,
   };
 
   enum class GiHistorySemantic : uint8_t
@@ -39,7 +41,68 @@ namespace Monolith
     ViewportResize,
     CameraCut,
     SceneBarrier,
+    CameraJitterSequenceChanged,
+    TemporalDisabled,
   };
+
+  struct TemporalHistoryState
+  {
+    bool initialized = false;
+    bool temporalEnabled = false;
+    bool forceHistoryReset = false;
+    bool cameraCut = false;
+    bool sceneChanged = false;
+    TemporalQualityTier qualityTier = TemporalQualityTier::Disabled;
+    uint64_t sceneToken = 0;
+    uint64_t cameraToken = 0;
+    uint32_t renderWidth = 0;
+    uint32_t renderHeight = 0;
+    uint32_t jitterSequenceSeed = 0;
+    uint32_t jitterSequenceLength = 0;
+  };
+
+  inline TemporalHistoryState BuildTemporalHistoryState(const RenderFrameTemporalState &state)
+  {
+    return {
+        true,
+        state.enableTemporalReprojection,
+        state.forceHistoryReset,
+        state.cameraCut,
+        state.sceneChanged,
+        state.jitter.qualityTier,
+        state.sceneToken,
+        state.cameraToken,
+        state.renderWidth,
+        state.renderHeight,
+        state.jitter.sequenceSeed,
+        state.jitter.sequenceLength};
+  }
+
+  inline GiHistoryResetReason DetermineGiHistoryResetReason(const TemporalHistoryState &previous,
+                                                            const TemporalHistoryState &current)
+  {
+    if (!previous.initialized)
+      return GiHistoryResetReason::None;
+    if (current.forceHistoryReset)
+      return GiHistoryResetReason::SceneBarrier;
+    if (!current.temporalEnabled)
+      return GiHistoryResetReason::TemporalDisabled;
+    if (!previous.temporalEnabled && current.temporalEnabled)
+      return GiHistoryResetReason::SceneBarrier;
+    if (previous.renderWidth != current.renderWidth || previous.renderHeight != current.renderHeight)
+      return GiHistoryResetReason::ViewportResize;
+    if (current.sceneChanged || previous.sceneToken != current.sceneToken)
+      return GiHistoryResetReason::SceneBarrier;
+    if (current.cameraCut || previous.cameraToken != current.cameraToken)
+      return GiHistoryResetReason::CameraCut;
+    if (previous.qualityTier != current.qualityTier ||
+        previous.jitterSequenceSeed != current.jitterSequenceSeed ||
+        previous.jitterSequenceLength != current.jitterSequenceLength)
+    {
+      return GiHistoryResetReason::CameraJitterSequenceChanged;
+    }
+    return GiHistoryResetReason::None;
+  }
 
   struct BackendResourceHandle
   {
@@ -117,6 +180,8 @@ namespace Monolith
     std::array<BackendResourceHandle, static_cast<size_t>(GiHistorySemantic::Count)> handles{};
     GiHistoryResetReason lastResetReason = GiHistoryResetReason::None;
     uint64_t revision = 0;
+    TemporalHistoryState ownerState{};
+    bool validForTemporalReuse = false;
 
     void Set(GiHistorySemantic semantic, const BackendResourceHandle &handle)
     {
@@ -133,5 +198,109 @@ namespace Monolith
       return Get(semantic).IsValid();
     }
   };
+
+  enum class TemporalInputValidationStatus : uint8_t
+  {
+    Valid = 0,
+    MissingDepth,
+    MissingNormal,
+    MissingMotionVectors,
+    MissingHistory,
+    BackendMismatch,
+    DimensionMismatch,
+  };
+
+  inline const char *ToString(TemporalInputValidationStatus status)
+  {
+    switch (status)
+    {
+    case TemporalInputValidationStatus::Valid:
+      return "valid";
+    case TemporalInputValidationStatus::MissingDepth:
+      return "missing depth input";
+    case TemporalInputValidationStatus::MissingNormal:
+      return "missing normal input";
+    case TemporalInputValidationStatus::MissingMotionVectors:
+      return "missing motion vector input";
+    case TemporalInputValidationStatus::MissingHistory:
+      return "missing temporal history input";
+    case TemporalInputValidationStatus::BackendMismatch:
+      return "temporal inputs come from mismatched backends";
+    case TemporalInputValidationStatus::DimensionMismatch:
+      return "temporal inputs have mismatched dimensions";
+    }
+    return "unknown temporal input validation status";
+  }
+
+  struct TemporalReprojectionInputContract
+  {
+    BackendResourceHandle depth{};
+    BackendResourceHandle normal{};
+    BackendResourceHandle motionVectors{};
+    BackendResourceHandle historySurface{};
+    uint64_t sceneFrameSerial = 0;
+    uint64_t historyRevision = 0;
+    GiHistoryResetReason historyResetReason = GiHistoryResetReason::None;
+    bool historyValidForReuse = false;
+    TemporalInputValidationStatus validationStatus = TemporalInputValidationStatus::MissingDepth;
+
+    bool IsValid() const { return validationStatus == TemporalInputValidationStatus::Valid; }
+  };
+
+  inline TemporalReprojectionInputContract
+  BuildTemporalReprojectionInputContract(const SceneTextureCatalog &sceneTextures,
+                                         const GiHistoryCatalog &history)
+  {
+    TemporalReprojectionInputContract contract{};
+    contract.sceneFrameSerial = sceneTextures.frameSerial;
+    contract.historyRevision = history.revision;
+    contract.historyResetReason = history.lastResetReason;
+    contract.historyValidForReuse = history.validForTemporalReuse;
+    contract.depth = sceneTextures.Get(SceneTextureSemantic::Depth);
+    contract.normal = sceneTextures.Get(SceneTextureSemantic::Normal);
+    contract.motionVectors = sceneTextures.Get(SceneTextureSemantic::MotionVector);
+    contract.historySurface = history.Get(GiHistorySemantic::DiffuseIrradiance);
+
+    if (!contract.depth.IsValid())
+    {
+      contract.validationStatus = TemporalInputValidationStatus::MissingDepth;
+      return contract;
+    }
+    if (!contract.normal.IsValid())
+    {
+      contract.validationStatus = TemporalInputValidationStatus::MissingNormal;
+      return contract;
+    }
+    if (!contract.motionVectors.IsValid())
+    {
+      contract.validationStatus = TemporalInputValidationStatus::MissingMotionVectors;
+      return contract;
+    }
+    if (!contract.historySurface.IsValid())
+    {
+      contract.validationStatus = TemporalInputValidationStatus::MissingHistory;
+      return contract;
+    }
+    if (contract.depth.backendId != contract.normal.backendId ||
+        contract.depth.backendId != contract.motionVectors.backendId ||
+        contract.depth.backendId != contract.historySurface.backendId)
+    {
+      contract.validationStatus = TemporalInputValidationStatus::BackendMismatch;
+      return contract;
+    }
+    if (contract.depth.width != contract.normal.width ||
+        contract.depth.height != contract.normal.height ||
+        contract.depth.width != contract.motionVectors.width ||
+        contract.depth.height != contract.motionVectors.height ||
+        contract.depth.width != contract.historySurface.width ||
+        contract.depth.height != contract.historySurface.height)
+    {
+      contract.validationStatus = TemporalInputValidationStatus::DimensionMismatch;
+      return contract;
+    }
+
+    contract.validationStatus = TemporalInputValidationStatus::Valid;
+    return contract;
+  }
 
 } // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -881,6 +881,8 @@ namespace Monolith
 
     ++m_giHistoryCatalog.revision;
     m_giHistoryCatalog.lastResetReason = GiHistoryResetReason::None;
+    m_giHistoryCatalog.ownerState = m_lastTemporalHistoryState;
+    m_giHistoryCatalog.validForTemporalReuse = false;
     return true;
   }
 
@@ -945,6 +947,8 @@ namespace Monolith
 
     ++m_giHistoryCatalog.revision;
     m_giHistoryCatalog.lastResetReason = reason;
+    m_giHistoryCatalog.ownerState = m_lastTemporalHistoryState;
+    m_giHistoryCatalog.validForTemporalReuse = false;
     return true;
   }
 
@@ -1840,6 +1844,8 @@ namespace Monolith
     m_passActive = false;
     m_sceneTextureCatalog = {};
     m_giHistoryCatalog = {};
+    m_lastTemporalHistoryState = {};
+    m_hasTemporalHistoryState = false;
   }
 
   void VulkanRenderBackend::DestroySwapchain()
@@ -3724,6 +3730,19 @@ namespace Monolith
     }
 
     m_activeFrame = frame;
+    const TemporalHistoryState currentTemporalHistoryState = BuildTemporalHistoryState(frame.temporal);
+    if (m_hasTemporalHistoryState)
+    {
+      const GiHistoryResetReason resetReason =
+          DetermineGiHistoryResetReason(m_lastTemporalHistoryState, currentTemporalHistoryState);
+      if (resetReason != GiHistoryResetReason::None &&
+          m_giHistoryCatalog.Has(GiHistorySemantic::DiffuseIrradiance))
+      {
+        InvalidateGiHistory(resetReason, nullptr);
+      }
+    }
+    m_lastTemporalHistoryState = currentTemporalHistoryState;
+    m_hasTemporalHistoryState = true;
     m_activeView = {};
     if (m_pendingOpaqueDraws.capacity() < 256)
       m_pendingOpaqueDraws.reserve(256);
@@ -3804,6 +3823,11 @@ namespace Monolith
     m_pendingOpaqueDraws.clear();
     m_pendingOverlayRenderCallback = nullptr;
     m_pendingOverlayRenderUserData = nullptr;
+    if (m_giHistoryCatalog.Has(GiHistorySemantic::DiffuseIrradiance))
+    {
+      m_giHistoryCatalog.ownerState = m_lastTemporalHistoryState;
+      m_giHistoryCatalog.validForTemporalReuse = m_lastTemporalHistoryState.temporalEnabled;
+    }
   }
 
   void VulkanRenderBackend::BeginPass(const RenderPassConfig &pass)

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -184,6 +184,8 @@ namespace Monolith
     bool m_passActive = false;
     SceneTextureCatalog m_sceneTextureCatalog;
     GiHistoryCatalog m_giHistoryCatalog;
+    TemporalHistoryState m_lastTemporalHistoryState;
+    bool m_hasTemporalHistoryState = false;
   };
 
 } // namespace Monolith

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -180,6 +180,7 @@ namespace
       }
       ++giHistory.revision;
       giHistory.lastResetReason = GiHistoryResetReason::None;
+      giHistory.validForTemporalReuse = false;
       return true;
     }
     bool TryGetGiHistoryCatalog(GiHistoryCatalog *outCatalog,
@@ -215,6 +216,7 @@ namespace
       }
       ++giHistory.revision;
       giHistory.lastResetReason = reason;
+      giHistory.validForTemporalReuse = false;
       return true;
     }
     std::vector<std::string> events;
@@ -305,6 +307,33 @@ TEST_CASE("Renderer forwards frame output config through the backend seam",
   REQUIRE(backend.lastFrame.clearDepthBuffer);
 
   Renderer::ResetBackend();
+}
+
+TEST_CASE("Temporal jitter sequence is deterministic and tier-aware",
+          "[renderer][foundation][temporal]")
+{
+  TemporalJitterConfig jitter{};
+  jitter.enabled = true;
+  jitter.qualityTier = TemporalQualityTier::Medium;
+  jitter.sequenceSeed = 7u;
+  jitter.sequenceLength = 8u;
+  jitter.frameIndex = 5u;
+
+  const Vec2 sampleA = BuildTemporalJitterOffset(jitter);
+  const Vec2 sampleB = BuildTemporalJitterOffset(jitter);
+  REQUIRE(sampleA == sampleB);
+
+  TemporalJitterConfig differentFrame = jitter;
+  differentFrame.frameIndex = jitter.frameIndex + 1u;
+  const Vec2 sampleNext = BuildTemporalJitterOffset(differentFrame);
+  REQUIRE(sampleA != sampleNext);
+
+  TemporalJitterConfig disabled = jitter;
+  disabled.enabled = false;
+  REQUIRE(BuildTemporalJitterOffset(disabled) == Vec2::Zero());
+
+  REQUIRE(TemporalJitterSampleCountForTier(TemporalQualityTier::Low) <
+          TemporalJitterSampleCountForTier(TemporalQualityTier::High));
 }
 
 TEST_CASE("Renderer initializes the default OpenGL backend through a typed selection",
@@ -461,11 +490,93 @@ TEST_CASE("Scene texture and GI history catalogs stay backend-neutral and typed"
               {RenderBackendId::Vulkan, 0xB2u, 960u, 540u, 8u});
   history.lastResetReason = GiHistoryResetReason::CameraCut;
   history.revision = 42u;
+  history.validForTemporalReuse = true;
 
   REQUIRE(history.Has(GiHistorySemantic::DiffuseIrradiance));
   REQUIRE(history.Get(GiHistorySemantic::DiffuseIrradiance).resourceId == 0xB1u);
   REQUIRE(history.lastResetReason == GiHistoryResetReason::CameraCut);
   REQUIRE(history.revision == 42u);
+  REQUIRE(history.validForTemporalReuse);
+}
+
+TEST_CASE("Temporal reprojection input contract validates motion and history seams",
+          "[renderer][foundation][temporal]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Depth, {RenderBackendId::Vulkan, 0xD1u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Normal, {RenderBackendId::Vulkan, 0xD2u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {RenderBackendId::Vulkan, 0xD3u, 1280u, 720u, 1u});
+  sceneTextures.frameSerial = 9u;
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance,
+              {RenderBackendId::Vulkan, 0xE1u, 1280u, 720u, 4u});
+  history.revision = 10u;
+  history.validForTemporalReuse = true;
+
+  const TemporalReprojectionInputContract valid =
+      BuildTemporalReprojectionInputContract(sceneTextures, history);
+  REQUIRE(valid.IsValid());
+  REQUIRE(valid.validationStatus == TemporalInputValidationStatus::Valid);
+  REQUIRE(valid.motionVectors.resourceId == 0xD3u);
+  REQUIRE(valid.historySurface.resourceId == 0xE1u);
+  REQUIRE(valid.sceneFrameSerial == 9u);
+  REQUIRE(valid.historyRevision == 10u);
+
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {});
+  const TemporalReprojectionInputContract missingMotion =
+      BuildTemporalReprojectionInputContract(sceneTextures, history);
+  REQUIRE_FALSE(missingMotion.IsValid());
+  REQUIRE(missingMotion.validationStatus == TemporalInputValidationStatus::MissingMotionVectors);
+}
+
+TEST_CASE("Temporal history reset reasons stay deterministic across scene and camera changes",
+          "[renderer][foundation][temporal]")
+{
+  RenderFrameTemporalState baseline{};
+  baseline.enableTemporalReprojection = true;
+  baseline.sceneToken = 11u;
+  baseline.cameraToken = 17u;
+  baseline.renderWidth = 1920u;
+  baseline.renderHeight = 1080u;
+  baseline.jitter.enabled = true;
+  baseline.jitter.qualityTier = TemporalQualityTier::High;
+  baseline.jitter.sequenceSeed = 2u;
+  baseline.jitter.sequenceLength = 16u;
+
+  TemporalHistoryState previous = BuildTemporalHistoryState(baseline);
+  TemporalHistoryState current = BuildTemporalHistoryState(baseline);
+  REQUIRE(DetermineGiHistoryResetReason(previous, current) == GiHistoryResetReason::None);
+
+  RenderFrameTemporalState resized = baseline;
+  resized.renderWidth = 1280u;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(resized)) ==
+          GiHistoryResetReason::ViewportResize);
+
+  RenderFrameTemporalState sceneChanged = baseline;
+  sceneChanged.sceneToken = baseline.sceneToken + 1u;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(sceneChanged)) ==
+          GiHistoryResetReason::SceneBarrier);
+
+  RenderFrameTemporalState cameraChanged = baseline;
+  cameraChanged.cameraToken = baseline.cameraToken + 1u;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(cameraChanged)) ==
+          GiHistoryResetReason::CameraCut);
+
+  RenderFrameTemporalState jitterChanged = baseline;
+  jitterChanged.jitter.sequenceSeed = baseline.jitter.sequenceSeed + 1u;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(jitterChanged)) ==
+          GiHistoryResetReason::CameraJitterSequenceChanged);
+
+  RenderFrameTemporalState disabled = baseline;
+  disabled.enableTemporalReprojection = false;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(disabled)) ==
+          GiHistoryResetReason::TemporalDisabled);
+
+  RenderFrameTemporalState forcedReset = baseline;
+  forcedReset.forceHistoryReset = true;
+  REQUIRE(DetermineGiHistoryResetReason(previous, BuildTemporalHistoryState(forcedReset)) ==
+          GiHistoryResetReason::SceneBarrier);
 }
 
 TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
@@ -476,7 +587,7 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
 
   std::string error;
   REQUIRE(Renderer::EnsureSceneTextureResources(128u, 72u, &error));
-  REQUIRE(Renderer::EnsureGiHistoryResources(64u, 64u, &error));
+  REQUIRE(Renderer::EnsureGiHistoryResources(128u, 72u, &error));
 
   SceneTextureCatalog sceneTextures{};
   REQUIRE(Renderer::TryGetSceneTextureCatalog(&sceneTextures, &error));
@@ -489,6 +600,10 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
   GiHistoryCatalog giHistory{};
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
   const uint64_t initialGeneration = giHistory.Get(GiHistorySemantic::DiffuseIrradiance).generation;
+  TemporalReprojectionInputContract temporalInputs{};
+  REQUIRE(Renderer::TryGetTemporalReprojectionInputContract(&temporalInputs, &error));
+  REQUIRE(temporalInputs.IsValid());
+  REQUIRE(temporalInputs.motionVectors.IsValid());
   REQUIRE(Renderer::InvalidateGiHistory(GiHistoryResetReason::SceneBarrier, &error));
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
   REQUIRE(giHistory.lastResetReason == GiHistoryResetReason::SceneBarrier);


### PR DESCRIPTION
## Summary
Add camera jitter, motion vector contracts, and temporal history management rules.

Closes #167
