### PR TITLE
feat(renderer): add scene tracing representation contracts for GI/reflections

### DIFF
--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -58,6 +58,9 @@ class IRenderBackend {
                                                    std::string* outError) const = 0;
   virtual bool TryGetLightingCompositePassContract(LightingCompositePassContract* outContract,
                                                    std::string* outError) const = 0;
+  virtual bool TryGetSceneTracingRepresentationContract(
+      SceneTracingRepresentationContract* outContract,
+      std::string* outError) const = 0;
   virtual bool InvalidateGiHistory(GiHistoryResetReason reason,
                                    std::string* outError) = 0;
 };

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -165,6 +165,15 @@ bool OpenGLRenderBackend::TryGetLightingCompositePassContract(
   return false;
 }
 
+bool OpenGLRenderBackend::TryGetSceneTracingRepresentationContract(
+    SceneTracingRepresentationContract* outContract, std::string* outError) const {
+  if (outContract)
+    *outContract = {};
+  if (outError)
+    *outError = "Scene tracing representation contract is unavailable on OpenGL backend.";
+  return false;
+}
+
 bool OpenGLRenderBackend::InvalidateGiHistory(GiHistoryResetReason, std::string* outError) {
   if (outError)
     *outError = "GI history invalidation is unavailable on OpenGL backend.";

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -53,6 +53,8 @@ class OpenGLRenderBackend : public IRenderBackend {
                                            std::string* outError) const override;
   bool TryGetLightingCompositePassContract(LightingCompositePassContract* outContract,
                                            std::string* outError) const override;
+  bool TryGetSceneTracingRepresentationContract(SceneTracingRepresentationContract* outContract,
+                                                std::string* outError) const override;
   bool InvalidateGiHistory(GiHistoryResetReason reason, std::string* outError) override;
 
  private:

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -256,6 +256,13 @@ namespace Monolith
     return ActiveBackend()->TryGetLightingCompositePassContract(outContract, outError);
   }
 
+  bool Renderer::TryGetSceneTracingRepresentationContract(
+      SceneTracingRepresentationContract *outContract,
+      std::string *outError)
+  {
+    return ActiveBackend()->TryGetSceneTracingRepresentationContract(outContract, outError);
+  }
+
   bool Renderer::TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                           std::string *outError)
   {

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -89,6 +89,9 @@ namespace Monolith
                                                     std::string *outError = nullptr);
     static bool TryGetLightingCompositePassContract(LightingCompositePassContract *outContract,
                                                     std::string *outError = nullptr);
+    static bool TryGetSceneTracingRepresentationContract(
+        SceneTracingRepresentationContract *outContract,
+        std::string *outError = nullptr);
     static bool TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                         std::string *outError = nullptr);
     static bool InvalidateGiHistory(GiHistoryResetReason reason,

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -1139,4 +1139,212 @@ namespace Monolith
     return contract;
   }
 
+  enum class SceneTracingRepresentationOwnership : uint8_t
+  {
+    BackendOwnedPersistent = 0,
+    BackendOwnedPerFrame,
+    ExternalTransient,
+  };
+
+  enum class SceneTracingRepresentationUpdatePolicy : uint8_t
+  {
+    Static = 0,
+    SceneBarrierOnly,
+    PerFrameAndSceneBarrier,
+    IncrementalStreaming,
+  };
+
+  struct MeshDistanceFieldTracingStructure
+  {
+    BackendResourceHandle atlas{};
+    uint32_t meshCount = 0;
+    uint32_t instanceCount = 0;
+    uint32_t pageCount = 0;
+    uint64_t revision = 0;
+
+    bool IsValid() const { return atlas.IsValid(); }
+  };
+
+  struct GlobalDistanceFieldTracingStructure
+  {
+    BackendResourceHandle volume{};
+    uint32_t clipmapCount = 0;
+    uint32_t voxelResolution = 0;
+    float worldExtent = 0.0f;
+    uint64_t revision = 0;
+
+    bool IsValid() const { return volume.IsValid(); }
+  };
+
+  struct SceneTracingDebugState
+  {
+    bool visualizationReady = false;
+    bool usesClosestApproximation = false;
+    bool temporalHistoryStable = false;
+    GiHistoryResetReason lastHistoryResetReason = GiHistoryResetReason::None;
+    SsrExecutionStatus ssrExecutionStatus = SsrExecutionStatus::Disabled;
+    SsgiExecutionStatus ssgiExecutionStatus = SsgiExecutionStatus::Disabled;
+    TemporalGiResolveExecutionStatus temporalResolveExecutionStatus =
+        TemporalGiResolveExecutionStatus::Disabled;
+  };
+
+  enum class SceneTracingRepresentationValidationStatus : uint8_t
+  {
+    DisabledBySettings = 0,
+    Valid,
+    MissingScreenSpaceContracts,
+    MissingMeshDistanceField,
+    MissingGlobalDistanceField,
+    BackendMismatch,
+    DimensionMismatch,
+  };
+
+  inline const char *ToString(SceneTracingRepresentationValidationStatus status)
+  {
+    switch (status)
+    {
+    case SceneTracingRepresentationValidationStatus::DisabledBySettings:
+      return "scene tracing representation disabled by settings";
+    case SceneTracingRepresentationValidationStatus::Valid:
+      return "valid";
+    case SceneTracingRepresentationValidationStatus::MissingScreenSpaceContracts:
+      return "scene tracing representation is missing required screen-space contracts";
+    case SceneTracingRepresentationValidationStatus::MissingMeshDistanceField:
+      return "scene tracing representation is missing mesh distance fields";
+    case SceneTracingRepresentationValidationStatus::MissingGlobalDistanceField:
+      return "scene tracing representation is missing global distance field";
+    case SceneTracingRepresentationValidationStatus::BackendMismatch:
+      return "scene tracing representation inputs come from mismatched backends";
+    case SceneTracingRepresentationValidationStatus::DimensionMismatch:
+      return "scene tracing representation inputs have mismatched dimensions";
+    }
+    return "unknown scene tracing representation validation status";
+  }
+
+  enum class SceneTracingRepresentationState : uint8_t
+  {
+    Disabled = 0,
+    Unavailable,
+    MeshDistanceFieldOnly,
+    GlobalDistanceFieldOnly,
+    HybridReady,
+  };
+
+  struct SceneTracingRepresentationContract
+  {
+    MeshDistanceFieldTracingStructure mesh{};
+    GlobalDistanceFieldTracingStructure global{};
+    ScreenSpaceReflectionPassContract ssr{};
+    ScreenSpaceGlobalIlluminationPassContract ssgi{};
+    TemporalGiResolvePassContract temporalResolve{};
+    BackendResourceHandle referenceDepth{};
+    uint64_t sceneFrameSerial = 0;
+    uint64_t historyRevision = 0;
+    SceneTracingRepresentationOwnership ownership =
+        SceneTracingRepresentationOwnership::BackendOwnedPersistent;
+    SceneTracingRepresentationUpdatePolicy updatePolicy =
+        SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier;
+    SceneTracingDebugState debug{};
+    SceneTracingRepresentationState state = SceneTracingRepresentationState::Unavailable;
+    SceneTracingRepresentationValidationStatus validationStatus =
+        SceneTracingRepresentationValidationStatus::DisabledBySettings;
+
+    bool IsValidForOffscreenQueries() const
+    {
+      return validationStatus == SceneTracingRepresentationValidationStatus::Valid &&
+             state == SceneTracingRepresentationState::HybridReady;
+    }
+  };
+
+  inline SceneTracingRepresentationContract BuildSceneTracingRepresentationContract(
+      const ScreenSpaceReflectionPassContract &ssrContract,
+      const ScreenSpaceGlobalIlluminationPassContract &ssgiContract,
+      const TemporalGiResolvePassContract &resolveContract,
+      const MeshDistanceFieldTracingStructure &meshStructure,
+      const GlobalDistanceFieldTracingStructure &globalStructure,
+      SceneTracingRepresentationOwnership ownership,
+      SceneTracingRepresentationUpdatePolicy updatePolicy,
+      bool enabled)
+  {
+    SceneTracingRepresentationContract contract{};
+    contract.ssr = ssrContract;
+    contract.ssgi = ssgiContract;
+    contract.temporalResolve = resolveContract;
+    contract.mesh = meshStructure;
+    contract.global = globalStructure;
+    contract.ownership = ownership;
+    contract.updatePolicy = updatePolicy;
+    contract.sceneFrameSerial = std::max(ssrContract.sceneFrameSerial, ssgiContract.sceneFrameSerial);
+    contract.historyRevision = resolveContract.historyRevision;
+    contract.referenceDepth =
+        ssgiContract.depth.IsValid() ? ssgiContract.depth : ssrContract.depth;
+    contract.debug.lastHistoryResetReason = resolveContract.historyResetReason;
+    contract.debug.ssrExecutionStatus = ssrContract.executionStatus;
+    contract.debug.ssgiExecutionStatus = ssgiContract.executionStatus;
+    contract.debug.temporalResolveExecutionStatus = resolveContract.executionStatus;
+    contract.debug.temporalHistoryStable =
+        resolveContract.executionStatus == TemporalGiResolveExecutionStatus::ResolveAndAccumulate &&
+        resolveContract.clampHistoryThisFrame &&
+        !resolveContract.rejectHistoryThisFrame;
+
+    if (!enabled)
+    {
+      contract.state = SceneTracingRepresentationState::Disabled;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::DisabledBySettings;
+      return contract;
+    }
+
+    if (ssrContract.validationStatus != SsrInputValidationStatus::Valid ||
+        ssgiContract.validationStatus != SsgiInputValidationStatus::Valid ||
+        resolveContract.validationStatus != TemporalGiResolveValidationStatus::Valid)
+    {
+      contract.state = SceneTracingRepresentationState::Unavailable;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::MissingScreenSpaceContracts;
+      return contract;
+    }
+
+    if (!meshStructure.IsValid())
+    {
+      contract.state = globalStructure.IsValid()
+                           ? SceneTracingRepresentationState::GlobalDistanceFieldOnly
+                           : SceneTracingRepresentationState::Unavailable;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::MissingMeshDistanceField;
+      contract.debug.visualizationReady = globalStructure.IsValid();
+      contract.debug.usesClosestApproximation = true;
+      return contract;
+    }
+    if (!globalStructure.IsValid())
+    {
+      contract.state = SceneTracingRepresentationState::MeshDistanceFieldOnly;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::MissingGlobalDistanceField;
+      contract.debug.visualizationReady = true;
+      contract.debug.usesClosestApproximation = true;
+      return contract;
+    }
+
+    if (contract.referenceDepth.backendId != meshStructure.atlas.backendId ||
+        contract.referenceDepth.backendId != globalStructure.volume.backendId)
+    {
+      contract.state = SceneTracingRepresentationState::Unavailable;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::BackendMismatch;
+      return contract;
+    }
+
+    if (contract.referenceDepth.width != meshStructure.atlas.width ||
+        contract.referenceDepth.height != meshStructure.atlas.height ||
+        contract.referenceDepth.width != globalStructure.volume.width ||
+        contract.referenceDepth.height != globalStructure.volume.height)
+    {
+      contract.state = SceneTracingRepresentationState::Unavailable;
+      contract.validationStatus = SceneTracingRepresentationValidationStatus::DimensionMismatch;
+      return contract;
+    }
+
+    contract.state = SceneTracingRepresentationState::HybridReady;
+    contract.validationStatus = SceneTracingRepresentationValidationStatus::Valid;
+    contract.debug.visualizationReady = true;
+    contract.debug.usesClosestApproximation = false;
+    return contract;
+  }
+
 } // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -47,6 +47,8 @@ namespace Monolith
         "__gi.history.specular_irradiance",
         "__gi.history.validation",
         "__gi.history.moments"};
+    constexpr const char *kMeshDistanceFieldTargetKey = "__scene.tracing.mesh_distance_field";
+    constexpr const char *kGlobalDistanceFieldTargetKey = "__scene.tracing.global_distance_field";
 
     uint64_t HashResourceKey(const std::string &key)
     {
@@ -826,7 +828,50 @@ namespace Monolith
       m_sceneTextureCatalog.Set(semantic, handle);
     }
 
+    if (!EnsureOffscreenRenderTarget(kMeshDistanceFieldTargetKey, width, height))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+    if (!EnsureOffscreenRenderTarget(kGlobalDistanceFieldTargetKey, width, height))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    BackendResourceHandle meshDistanceFieldHandle{};
+    if (!BuildOffscreenResourceHandle(kMeshDistanceFieldTargetKey, &meshDistanceFieldHandle))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    BackendResourceHandle globalDistanceFieldHandle{};
+    if (!BuildOffscreenResourceHandle(kGlobalDistanceFieldTargetKey, &globalDistanceFieldHandle))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    m_meshDistanceFieldTracingStructure.atlas = meshDistanceFieldHandle;
+    m_meshDistanceFieldTracingStructure.meshCount = 0;
+    m_meshDistanceFieldTracingStructure.instanceCount = 0;
+    m_meshDistanceFieldTracingStructure.pageCount = std::max(1u, (width * height) / 256u);
+    m_meshDistanceFieldTracingStructure.revision = meshDistanceFieldHandle.generation;
+
+    m_globalDistanceFieldTracingStructure.volume = globalDistanceFieldHandle;
+    m_globalDistanceFieldTracingStructure.clipmapCount = 4;
+    m_globalDistanceFieldTracingStructure.voxelResolution = std::min(width, height);
+    m_globalDistanceFieldTracingStructure.worldExtent = 512.0f;
+    m_globalDistanceFieldTracingStructure.revision = globalDistanceFieldHandle.generation;
+
     ++m_sceneTextureCatalog.frameSerial;
+    m_lastSceneTracingRepresentationContract = {};
+    m_hasSceneTracingRepresentationContract = false;
     return true;
   }
 
@@ -978,6 +1023,25 @@ namespace Monolith
     return true;
   }
 
+  bool VulkanRenderBackend::TryGetSceneTracingRepresentationContract(
+      SceneTracingRepresentationContract *outContract,
+      std::string *outError) const
+  {
+    if (!outContract)
+      return false;
+
+    if (!m_hasSceneTracingRepresentationContract)
+    {
+      *outContract = {};
+      if (outError)
+        *outError = "Scene tracing representation contract has not been produced for this frame.";
+      return false;
+    }
+
+    *outContract = m_lastSceneTracingRepresentationContract;
+    return true;
+  }
+
   bool VulkanRenderBackend::InvalidateGiHistory(GiHistoryResetReason reason,
                                                 std::string *outError)
   {
@@ -1071,6 +1135,29 @@ namespace Monolith
         m_sceneTextureCatalog,
         m_lastTemporalGiResolvePassContract);
     m_hasLightingCompositePassContract = true;
+
+    m_meshDistanceFieldTracingStructure.meshCount =
+        static_cast<uint32_t>(m_context ? m_context->opaqueMeshGpuBuffers.size() : 0u);
+    m_meshDistanceFieldTracingStructure.instanceCount =
+        static_cast<uint32_t>(m_pendingOpaqueDraws.size());
+    m_meshDistanceFieldTracingStructure.revision = std::max(
+        m_meshDistanceFieldTracingStructure.revision,
+        m_meshDistanceFieldTracingStructure.atlas.generation);
+    m_globalDistanceFieldTracingStructure.revision = std::max(
+        m_globalDistanceFieldTracingStructure.revision,
+        m_globalDistanceFieldTracingStructure.volume.generation);
+
+    const bool tracingEnabled = m_activeFrame.temporal.jitter.qualityTier != TemporalQualityTier::Disabled;
+    m_lastSceneTracingRepresentationContract = BuildSceneTracingRepresentationContract(
+        m_lastSsrPassContract,
+        m_lastSsgiPassContract,
+        m_lastTemporalGiResolvePassContract,
+        m_meshDistanceFieldTracingStructure,
+        m_globalDistanceFieldTracingStructure,
+        SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+        SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+        tracingEnabled);
+    m_hasSceneTracingRepresentationContract = true;
   }
 
   bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &targetKey,
@@ -3868,10 +3955,12 @@ namespace Monolith
     m_lastSsgiPassContract = {};
     m_lastTemporalGiResolvePassContract = {};
     m_lastLightingCompositePassContract = {};
+    m_lastSceneTracingRepresentationContract = {};
     m_hasSsrPassContract = false;
     m_hasSsgiPassContract = false;
     m_hasTemporalGiResolvePassContract = false;
     m_hasLightingCompositePassContract = false;
+    m_hasSceneTracingRepresentationContract = false;
     m_activeView = {};
     if (m_pendingOpaqueDraws.capacity() < 256)
       m_pendingOpaqueDraws.reserve(256);
@@ -4095,6 +4184,12 @@ namespace Monolith
   }
   bool VulkanRenderBackend::TryGetLightingCompositePassContract(
       LightingCompositePassContract *,
+      std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetSceneTracingRepresentationContract(
+      SceneTracingRepresentationContract *,
       std::string *) const
   {
     return false;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -65,6 +65,9 @@ namespace Monolith
                                              std::string *outError) const override;
     bool TryGetLightingCompositePassContract(LightingCompositePassContract *outContract,
                                              std::string *outError) const override;
+    bool TryGetSceneTracingRepresentationContract(
+        SceneTracingRepresentationContract *outContract,
+        std::string *outError) const override;
     bool InvalidateGiHistory(GiHistoryResetReason reason,
                              std::string *outError) override;
 
@@ -201,12 +204,16 @@ namespace Monolith
     ScreenSpaceGlobalIlluminationPassContract m_lastSsgiPassContract;
     TemporalGiResolvePassContract m_lastTemporalGiResolvePassContract;
     LightingCompositePassContract m_lastLightingCompositePassContract;
+    MeshDistanceFieldTracingStructure m_meshDistanceFieldTracingStructure;
+    GlobalDistanceFieldTracingStructure m_globalDistanceFieldTracingStructure;
+    SceneTracingRepresentationContract m_lastSceneTracingRepresentationContract;
     TemporalHistoryState m_lastTemporalHistoryState;
     bool m_hasTemporalHistoryState = false;
     bool m_hasSsrPassContract = false;
     bool m_hasSsgiPassContract = false;
     bool m_hasTemporalGiResolvePassContract = false;
     bool m_hasLightingCompositePassContract = false;
+    bool m_hasSceneTracingRepresentationContract = false;
   };
 
 } // namespace Monolith

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -274,6 +274,49 @@ namespace
       *outContract = BuildLightingCompositePassContract(sceneTextures, resolve);
       return true;
     }
+    bool TryGetSceneTracingRepresentationContract(SceneTracingRepresentationContract *outContract,
+                                                  std::string *outError) const override
+    {
+      if (!outContract)
+        return false;
+
+      ScreenSpaceReflectionPassContract ssr{};
+      ScreenSpaceGlobalIlluminationPassContract ssgi{};
+      TemporalGiResolvePassContract resolve{};
+      if (!TryGetScreenSpaceReflectionPassContract(&ssr, outError) ||
+          !TryGetScreenSpaceGlobalIlluminationPassContract(&ssgi, outError) ||
+          !TryGetTemporalGiResolvePassContract(&resolve, outError))
+      {
+        *outContract = {};
+        return false;
+      }
+
+      const BackendResourceHandle reference = sceneTextures.Get(SceneTextureSemantic::Depth);
+      MeshDistanceFieldTracingStructure mesh{};
+      mesh.atlas = {reference.backendId, 0x901u, reference.width, reference.height, 3u};
+      mesh.meshCount = 3u;
+      mesh.instanceCount = 5u;
+      mesh.pageCount = 64u;
+      mesh.revision = 3u;
+
+      GlobalDistanceFieldTracingStructure global{};
+      global.volume = {reference.backendId, 0x902u, reference.width, reference.height, 7u};
+      global.clipmapCount = 4u;
+      global.voxelResolution = std::min(reference.width, reference.height);
+      global.worldExtent = 512.0f;
+      global.revision = 7u;
+
+      *outContract = BuildSceneTracingRepresentationContract(
+          ssr,
+          ssgi,
+          resolve,
+          mesh,
+          global,
+          SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+          SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+          true);
+      return true;
+    }
     bool InvalidateGiHistory(GiHistoryResetReason reason, std::string *outError) override
     {
       if (!giHistory.Has(GiHistorySemantic::DiffuseIrradiance))
@@ -887,6 +930,83 @@ TEST_CASE("Lighting composite contract remains fallback-aware when temporal reso
   REQUIRE_FALSE(fallbackComposite.temporalStabilityExpected);
 }
 
+TEST_CASE("Scene tracing representation contract captures mesh and global distance field state",
+          "[renderer][foundation][temporal][tracing]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Depth, {RenderBackendId::Vulkan, 0x91u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Normal, {RenderBackendId::Vulkan, 0x92u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::RoughnessMetallic,
+                    {RenderBackendId::Vulkan, 0x93u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::BaseColor, {RenderBackendId::Vulkan, 0x94u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Emissive, {RenderBackendId::Vulkan, 0x95u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {RenderBackendId::Vulkan, 0x96u, 960u, 540u, 1u});
+  sceneTextures.frameSerial = 90u;
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance,
+              {RenderBackendId::Vulkan, 0xA1u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::SpecularIrradiance,
+              {RenderBackendId::Vulkan, 0xA2u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::Validation, {RenderBackendId::Vulkan, 0xA3u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::Moments, {RenderBackendId::Vulkan, 0xA4u, 960u, 540u, 2u});
+  history.revision = 77u;
+  history.validForTemporalReuse = true;
+
+  const ScreenSpaceReflectionPassContract ssr = BuildScreenSpaceReflectionPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true, ScreenSpaceReflectionMissPolicy::ProbeFallback);
+  const ScreenSpaceGlobalIlluminationPassContract ssgi = BuildScreenSpaceGlobalIlluminationPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true);
+  const TemporalGiResolvePassContract resolve = BuildTemporalGiResolvePassContract(ssr, ssgi, history);
+
+  MeshDistanceFieldTracingStructure mesh{};
+  mesh.atlas = {RenderBackendId::Vulkan, 0xB1u, 960u, 540u, 5u};
+  mesh.meshCount = 12u;
+  mesh.instanceCount = 20u;
+  mesh.pageCount = 128u;
+  mesh.revision = 5u;
+
+  GlobalDistanceFieldTracingStructure global{};
+  global.volume = {RenderBackendId::Vulkan, 0xB2u, 960u, 540u, 5u};
+  global.clipmapCount = 5u;
+  global.voxelResolution = 540u;
+  global.worldExtent = 1024.0f;
+  global.revision = 5u;
+
+  const SceneTracingRepresentationContract tracing = BuildSceneTracingRepresentationContract(
+      ssr,
+      ssgi,
+      resolve,
+      mesh,
+      global,
+      SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+      SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+      true);
+
+  REQUIRE(tracing.IsValidForOffscreenQueries());
+  REQUIRE(tracing.validationStatus == SceneTracingRepresentationValidationStatus::Valid);
+  REQUIRE(tracing.state == SceneTracingRepresentationState::HybridReady);
+  REQUIRE(tracing.debug.visualizationReady);
+  REQUIRE_FALSE(tracing.debug.usesClosestApproximation);
+  REQUIRE(tracing.mesh.meshCount == 12u);
+  REQUIRE(tracing.global.clipmapCount == 5u);
+
+  mesh.atlas = {};
+  const SceneTracingRepresentationContract missingMesh = BuildSceneTracingRepresentationContract(
+      ssr,
+      ssgi,
+      resolve,
+      mesh,
+      global,
+      SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+      SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+      true);
+  REQUIRE_FALSE(missingMesh.IsValidForOffscreenQueries());
+  REQUIRE(missingMesh.validationStatus ==
+          SceneTracingRepresentationValidationStatus::MissingMeshDistanceField);
+  REQUIRE(missingMesh.debug.usesClosestApproximation);
+}
+
 TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
           "[renderer][foundation][abstractions]")
 {
@@ -944,6 +1064,12 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
            LightingCompositeExecutionStatus::CompositeWithIndirect ||
            compositeContract.executionStatus ==
                LightingCompositeExecutionStatus::DirectLightingOnlyFallback));
+  SceneTracingRepresentationContract tracingContract{};
+  REQUIRE(Renderer::TryGetSceneTracingRepresentationContract(&tracingContract, &error));
+  REQUIRE(tracingContract.validationStatus == SceneTracingRepresentationValidationStatus::Valid);
+  REQUIRE(tracingContract.IsValidForOffscreenQueries());
+  REQUIRE(tracingContract.mesh.IsValid());
+  REQUIRE(tracingContract.global.IsValid());
   REQUIRE(Renderer::InvalidateGiHistory(GiHistoryResetReason::SceneBarrier, &error));
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
   REQUIRE(giHistory.lastResetReason == GiHistoryResetReason::SceneBarrier);


### PR DESCRIPTION
## Summary
Add backend-neutral scene tracing representation for off-screen GI/reflection queries.

Closes #171
