### PR TITLE
feat(renderer): add cached hit-lighting representation contract

### DIFF
--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -61,6 +61,9 @@ class IRenderBackend {
   virtual bool TryGetSceneTracingRepresentationContract(
       SceneTracingRepresentationContract* outContract,
       std::string* outError) const = 0;
+  virtual bool TryGetCachedHitLightingRepresentationContract(
+      CachedHitLightingRepresentationContract* outContract,
+      std::string* outError) const = 0;
   virtual bool InvalidateGiHistory(GiHistoryResetReason reason,
                                    std::string* outError) = 0;
 };

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -174,6 +174,15 @@ bool OpenGLRenderBackend::TryGetSceneTracingRepresentationContract(
   return false;
 }
 
+bool OpenGLRenderBackend::TryGetCachedHitLightingRepresentationContract(
+    CachedHitLightingRepresentationContract* outContract, std::string* outError) const {
+  if (outContract)
+    *outContract = {};
+  if (outError)
+    *outError = "Cached hit-lighting representation is unavailable on OpenGL backend.";
+  return false;
+}
+
 bool OpenGLRenderBackend::InvalidateGiHistory(GiHistoryResetReason, std::string* outError) {
   if (outError)
     *outError = "GI history invalidation is unavailable on OpenGL backend.";

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -55,6 +55,9 @@ class OpenGLRenderBackend : public IRenderBackend {
                                            std::string* outError) const override;
   bool TryGetSceneTracingRepresentationContract(SceneTracingRepresentationContract* outContract,
                                                 std::string* outError) const override;
+  bool TryGetCachedHitLightingRepresentationContract(
+      CachedHitLightingRepresentationContract* outContract,
+      std::string* outError) const override;
   bool InvalidateGiHistory(GiHistoryResetReason reason, std::string* outError) override;
 
  private:

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -263,6 +263,13 @@ namespace Monolith
     return ActiveBackend()->TryGetSceneTracingRepresentationContract(outContract, outError);
   }
 
+  bool Renderer::TryGetCachedHitLightingRepresentationContract(
+      CachedHitLightingRepresentationContract *outContract,
+      std::string *outError)
+  {
+    return ActiveBackend()->TryGetCachedHitLightingRepresentationContract(outContract, outError);
+  }
+
   bool Renderer::TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                           std::string *outError)
   {

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -92,6 +92,9 @@ namespace Monolith
     static bool TryGetSceneTracingRepresentationContract(
         SceneTracingRepresentationContract *outContract,
         std::string *outError = nullptr);
+    static bool TryGetCachedHitLightingRepresentationContract(
+        CachedHitLightingRepresentationContract *outContract,
+        std::string *outError = nullptr);
     static bool TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                         std::string *outError = nullptr);
     static bool InvalidateGiHistory(GiHistoryResetReason reason,

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -1347,4 +1347,275 @@ namespace Monolith
     return contract;
   }
 
+  enum class CachedHitLightingCapturePolicy : uint8_t
+  {
+    Disabled = 0,
+    ScreenSpaceMissesOnly,
+    ScreenSpaceMissesAndDisocclusions,
+    FullReseedOnInvalidation,
+  };
+
+  enum class CachedHitLightingUpdatePolicy : uint8_t
+  {
+    Static = 0,
+    SceneBarrierOnly,
+    PerFrameBudgeted,
+  };
+
+  enum class CachedHitLightingInvalidationReason : uint8_t
+  {
+    None = 0,
+    ViewportResize,
+    CameraCut,
+    SceneBarrier,
+    TemporalDisabled,
+    SceneTracingInvalid,
+  };
+
+  inline CachedHitLightingInvalidationReason ToCachedHitLightingInvalidationReason(
+      GiHistoryResetReason reason)
+  {
+    switch (reason)
+    {
+    case GiHistoryResetReason::None:
+      return CachedHitLightingInvalidationReason::None;
+    case GiHistoryResetReason::ViewportResize:
+      return CachedHitLightingInvalidationReason::ViewportResize;
+    case GiHistoryResetReason::CameraCut:
+      return CachedHitLightingInvalidationReason::CameraCut;
+    case GiHistoryResetReason::SceneBarrier:
+    case GiHistoryResetReason::CameraJitterSequenceChanged:
+      return CachedHitLightingInvalidationReason::SceneBarrier;
+    case GiHistoryResetReason::TemporalDisabled:
+      return CachedHitLightingInvalidationReason::TemporalDisabled;
+    }
+    return CachedHitLightingInvalidationReason::None;
+  }
+
+  enum class CachedHitLightingRepresentationValidationStatus : uint8_t
+  {
+    DisabledBySettings = 0,
+    Valid,
+    MissingSceneTracingRepresentation,
+    MissingLightingCompositeContract,
+    MissingCacheSurface,
+    BackendMismatch,
+    DimensionMismatch,
+  };
+
+  enum class CachedHitLightingRepresentationState : uint8_t
+  {
+    Disabled = 0,
+    Unavailable,
+    Invalidated,
+    Warmup,
+    Ready,
+  };
+
+  enum class CachedHitLightingLookupIntegrationPoint : uint8_t
+  {
+    None = 0,
+    SsrMiss = 1u << 0u,
+    SsgiMiss = 1u << 1u,
+    LightingComposite = 1u << 2u,
+  };
+
+  inline uint8_t CachedHitLightingLookupMask(CachedHitLightingLookupIntegrationPoint point)
+  {
+    return static_cast<uint8_t>(point);
+  }
+
+  struct CachedHitLightingLookupPolicy
+  {
+    uint8_t integrationMask = 0;
+    bool allowApproximationFallback = true;
+    bool requireTemporalStability = true;
+
+    bool Uses(CachedHitLightingLookupIntegrationPoint point) const
+    {
+      return (integrationMask & CachedHitLightingLookupMask(point)) != 0u;
+    }
+  };
+
+  struct CachedHitLightingDebugState
+  {
+    bool cacheAllocated = false;
+    bool lookupEnabled = false;
+    bool captureRequested = false;
+    uint32_t captureBudget = 0;
+    uint32_t capturesCommitted = 0;
+    uint32_t residentSurfaceCount = 0;
+    float estimatedHitRatio = 0.0f;
+    CachedHitLightingInvalidationReason lastInvalidationReason =
+        CachedHitLightingInvalidationReason::None;
+    SceneTracingRepresentationValidationStatus tracingValidationStatus =
+        SceneTracingRepresentationValidationStatus::DisabledBySettings;
+    LightingCompositeValidationStatus compositeValidationStatus =
+        LightingCompositeValidationStatus::MissingBaseColor;
+  };
+
+  struct CachedHitLightingRepresentationContract
+  {
+    BackendResourceHandle radianceCache{};
+    BackendResourceHandle momentsCache{};
+    BackendResourceHandle referenceDepth{};
+    SceneTracingRepresentationContract sceneTracing{};
+    LightingCompositePassContract lightingComposite{};
+    uint64_t sceneFrameSerial = 0;
+    uint64_t historyRevision = 0;
+    uint64_t cacheRevision = 0;
+    uint32_t maxSurfaceCount = 0;
+    uint32_t residentSurfaceCount = 0;
+    CachedHitLightingCapturePolicy capturePolicy = CachedHitLightingCapturePolicy::Disabled;
+    CachedHitLightingUpdatePolicy updatePolicy = CachedHitLightingUpdatePolicy::Static;
+    CachedHitLightingLookupPolicy lookupPolicy{};
+    CachedHitLightingDebugState debug{};
+    CachedHitLightingRepresentationValidationStatus validationStatus =
+        CachedHitLightingRepresentationValidationStatus::DisabledBySettings;
+    CachedHitLightingRepresentationState state = CachedHitLightingRepresentationState::Unavailable;
+
+    bool IsValidForLookup() const
+    {
+      return validationStatus == CachedHitLightingRepresentationValidationStatus::Valid &&
+             state == CachedHitLightingRepresentationState::Ready;
+    }
+  };
+
+  inline CachedHitLightingRepresentationContract BuildCachedHitLightingRepresentationContract(
+      const SceneTracingRepresentationContract &sceneTracingContract,
+      const LightingCompositePassContract &lightingCompositeContract,
+      const BackendResourceHandle &radianceCacheHandle,
+      const BackendResourceHandle &momentsCacheHandle,
+      uint64_t cacheRevision,
+      uint32_t maxSurfaceCount,
+      uint32_t residentSurfaceCount,
+      CachedHitLightingCapturePolicy capturePolicy,
+      CachedHitLightingUpdatePolicy updatePolicy,
+      CachedHitLightingInvalidationReason invalidationReason,
+      bool enabled)
+  {
+    CachedHitLightingRepresentationContract contract{};
+    contract.radianceCache = radianceCacheHandle;
+    contract.momentsCache = momentsCacheHandle;
+    contract.sceneTracing = sceneTracingContract;
+    contract.lightingComposite = lightingCompositeContract;
+    contract.sceneFrameSerial = std::max(sceneTracingContract.sceneFrameSerial,
+                                         lightingCompositeContract.sceneFrameSerial);
+    contract.historyRevision = std::max(sceneTracingContract.historyRevision,
+                                        lightingCompositeContract.historyRevision);
+    contract.cacheRevision = cacheRevision;
+    contract.maxSurfaceCount = maxSurfaceCount;
+    contract.residentSurfaceCount = std::min(residentSurfaceCount, maxSurfaceCount);
+    contract.capturePolicy = capturePolicy;
+    contract.updatePolicy = updatePolicy;
+    contract.referenceDepth = sceneTracingContract.referenceDepth.IsValid()
+                                  ? sceneTracingContract.referenceDepth
+                                  : lightingCompositeContract.baseColor;
+    contract.debug.cacheAllocated = radianceCacheHandle.IsValid() && momentsCacheHandle.IsValid();
+    contract.debug.lastInvalidationReason = invalidationReason;
+    contract.debug.tracingValidationStatus = sceneTracingContract.validationStatus;
+    contract.debug.compositeValidationStatus = lightingCompositeContract.validationStatus;
+    contract.debug.residentSurfaceCount = contract.residentSurfaceCount;
+
+    contract.lookupPolicy.integrationMask =
+        CachedHitLightingLookupMask(CachedHitLightingLookupIntegrationPoint::LightingComposite);
+    if (sceneTracingContract.ssr.validationStatus == SsrInputValidationStatus::Valid)
+    {
+      contract.lookupPolicy.integrationMask |=
+          CachedHitLightingLookupMask(CachedHitLightingLookupIntegrationPoint::SsrMiss);
+    }
+    if (sceneTracingContract.ssgi.validationStatus == SsgiInputValidationStatus::Valid)
+    {
+      contract.lookupPolicy.integrationMask |=
+          CachedHitLightingLookupMask(CachedHitLightingLookupIntegrationPoint::SsgiMiss);
+    }
+    contract.lookupPolicy.allowApproximationFallback = sceneTracingContract.debug.usesClosestApproximation;
+    contract.lookupPolicy.requireTemporalStability = true;
+
+    if (!enabled)
+    {
+      contract.state = CachedHitLightingRepresentationState::Disabled;
+      contract.validationStatus = CachedHitLightingRepresentationValidationStatus::DisabledBySettings;
+      return contract;
+    }
+
+    if (!sceneTracingContract.IsValidForOffscreenQueries())
+    {
+      contract.state = CachedHitLightingRepresentationState::Unavailable;
+      contract.validationStatus =
+          CachedHitLightingRepresentationValidationStatus::MissingSceneTracingRepresentation;
+      return contract;
+    }
+
+    if (lightingCompositeContract.validationStatus != LightingCompositeValidationStatus::Valid)
+    {
+      contract.state = CachedHitLightingRepresentationState::Unavailable;
+      contract.validationStatus =
+          CachedHitLightingRepresentationValidationStatus::MissingLightingCompositeContract;
+      return contract;
+    }
+
+    if (!radianceCacheHandle.IsValid() || !momentsCacheHandle.IsValid())
+    {
+      contract.state = CachedHitLightingRepresentationState::Unavailable;
+      contract.validationStatus = CachedHitLightingRepresentationValidationStatus::MissingCacheSurface;
+      return contract;
+    }
+
+    if (contract.referenceDepth.backendId != radianceCacheHandle.backendId ||
+        contract.referenceDepth.backendId != momentsCacheHandle.backendId)
+    {
+      contract.state = CachedHitLightingRepresentationState::Unavailable;
+      contract.validationStatus = CachedHitLightingRepresentationValidationStatus::BackendMismatch;
+      return contract;
+    }
+
+    if (contract.referenceDepth.width != radianceCacheHandle.width ||
+        contract.referenceDepth.height != radianceCacheHandle.height ||
+        contract.referenceDepth.width != momentsCacheHandle.width ||
+        contract.referenceDepth.height != momentsCacheHandle.height)
+    {
+      contract.state = CachedHitLightingRepresentationState::Unavailable;
+      contract.validationStatus = CachedHitLightingRepresentationValidationStatus::DimensionMismatch;
+      return contract;
+    }
+
+    contract.validationStatus = CachedHitLightingRepresentationValidationStatus::Valid;
+    contract.debug.captureBudget = std::max(1u, contract.maxSurfaceCount / 16u);
+    contract.debug.captureRequested =
+        invalidationReason != CachedHitLightingInvalidationReason::None ||
+        contract.sceneTracing.ssr.executionStatus == SsrExecutionStatus::FallbackOnly ||
+        contract.sceneTracing.ssgi.executionStatus == SsgiExecutionStatus::FallbackOnly;
+    contract.debug.capturesCommitted =
+        contract.debug.captureRequested
+            ? std::min(contract.debug.captureBudget, contract.maxSurfaceCount - contract.residentSurfaceCount)
+            : 0u;
+
+    if (contract.maxSurfaceCount > 0u)
+    {
+      contract.debug.estimatedHitRatio =
+          static_cast<float>(contract.residentSurfaceCount) / static_cast<float>(contract.maxSurfaceCount);
+    }
+
+    if (invalidationReason != CachedHitLightingInvalidationReason::None)
+    {
+      contract.state = CachedHitLightingRepresentationState::Invalidated;
+      contract.debug.lookupEnabled = false;
+      return contract;
+    }
+
+    if (!sceneTracingContract.debug.temporalHistoryStable ||
+        lightingCompositeContract.executionStatus ==
+            LightingCompositeExecutionStatus::DirectLightingOnlyFallback)
+    {
+      contract.state = CachedHitLightingRepresentationState::Warmup;
+      contract.debug.lookupEnabled = false;
+      return contract;
+    }
+
+    contract.state = CachedHitLightingRepresentationState::Ready;
+    contract.debug.lookupEnabled = true;
+    return contract;
+  }
+
 } // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -49,6 +49,8 @@ namespace Monolith
         "__gi.history.moments"};
     constexpr const char *kMeshDistanceFieldTargetKey = "__scene.tracing.mesh_distance_field";
     constexpr const char *kGlobalDistanceFieldTargetKey = "__scene.tracing.global_distance_field";
+    constexpr const char *kCachedHitLightingRadianceTargetKey = "__scene.cached_hit_lighting.radiance";
+    constexpr const char *kCachedHitLightingMomentsTargetKey = "__scene.cached_hit_lighting.moments";
 
     uint64_t HashResourceKey(const std::string &key)
     {
@@ -857,6 +859,33 @@ namespace Monolith
       return false;
     }
 
+    const uint64_t previousRadianceGeneration = m_cachedHitLightingRadianceHandle.generation;
+    if (!EnsureOffscreenRenderTarget(kCachedHitLightingRadianceTargetKey, width, height))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+    if (!EnsureOffscreenRenderTarget(kCachedHitLightingMomentsTargetKey, width, height))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
+    if (!BuildOffscreenResourceHandle(kCachedHitLightingRadianceTargetKey, &m_cachedHitLightingRadianceHandle))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+    if (!BuildOffscreenResourceHandle(kCachedHitLightingMomentsTargetKey, &m_cachedHitLightingMomentsHandle))
+    {
+      if (outError)
+        *outError = m_lastError;
+      return false;
+    }
+
     m_meshDistanceFieldTracingStructure.atlas = meshDistanceFieldHandle;
     m_meshDistanceFieldTracingStructure.meshCount = 0;
     m_meshDistanceFieldTracingStructure.instanceCount = 0;
@@ -868,10 +897,23 @@ namespace Monolith
     m_globalDistanceFieldTracingStructure.voxelResolution = std::min(width, height);
     m_globalDistanceFieldTracingStructure.worldExtent = 512.0f;
     m_globalDistanceFieldTracingStructure.revision = globalDistanceFieldHandle.generation;
+    m_cachedHitLightingMaxSurfaceCount = std::max(1u, (width * height) / 4u);
+    m_cachedHitLightingResidentSurfaceCount = std::min(
+        m_cachedHitLightingResidentSurfaceCount,
+        m_cachedHitLightingMaxSurfaceCount);
+    if (previousRadianceGeneration != 0 &&
+        previousRadianceGeneration != m_cachedHitLightingRadianceHandle.generation)
+    {
+      m_cachedHitLightingInvalidationReason = CachedHitLightingInvalidationReason::ViewportResize;
+      m_cachedHitLightingResidentSurfaceCount = 0;
+      ++m_cachedHitLightingRevision;
+    }
 
     ++m_sceneTextureCatalog.frameSerial;
     m_lastSceneTracingRepresentationContract = {};
     m_hasSceneTracingRepresentationContract = false;
+    m_lastCachedHitLightingRepresentationContract = {};
+    m_hasCachedHitLightingRepresentationContract = false;
     return true;
   }
 
@@ -1042,6 +1084,25 @@ namespace Monolith
     return true;
   }
 
+  bool VulkanRenderBackend::TryGetCachedHitLightingRepresentationContract(
+      CachedHitLightingRepresentationContract *outContract,
+      std::string *outError) const
+  {
+    if (!outContract)
+      return false;
+
+    if (!m_hasCachedHitLightingRepresentationContract)
+    {
+      *outContract = {};
+      if (outError)
+        *outError = "Cached hit-lighting representation contract has not been produced for this frame.";
+      return false;
+    }
+
+    *outContract = m_lastCachedHitLightingRepresentationContract;
+    return true;
+  }
+
   bool VulkanRenderBackend::InvalidateGiHistory(GiHistoryResetReason reason,
                                                 std::string *outError)
   {
@@ -1088,6 +1149,9 @@ namespace Monolith
     m_giHistoryCatalog.lastResetReason = reason;
     m_giHistoryCatalog.ownerState = m_lastTemporalHistoryState;
     m_giHistoryCatalog.validForTemporalReuse = false;
+    m_cachedHitLightingInvalidationReason = ToCachedHitLightingInvalidationReason(reason);
+    m_cachedHitLightingResidentSurfaceCount = 0;
+    ++m_cachedHitLightingRevision;
     return true;
   }
 
@@ -1158,6 +1222,47 @@ namespace Monolith
         SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
         tracingEnabled);
     m_hasSceneTracingRepresentationContract = true;
+
+    const bool hitLightingEnabled = m_activeFrame.temporal.jitter.qualityTier >= TemporalQualityTier::Medium;
+    CachedHitLightingCapturePolicy capturePolicy = CachedHitLightingCapturePolicy::Disabled;
+    CachedHitLightingUpdatePolicy updatePolicy = CachedHitLightingUpdatePolicy::Static;
+    if (hitLightingEnabled)
+    {
+      capturePolicy = m_cachedHitLightingInvalidationReason != CachedHitLightingInvalidationReason::None
+                          ? CachedHitLightingCapturePolicy::FullReseedOnInvalidation
+                          : CachedHitLightingCapturePolicy::ScreenSpaceMissesAndDisocclusions;
+      updatePolicy = CachedHitLightingUpdatePolicy::PerFrameBudgeted;
+    }
+
+    if (hitLightingEnabled &&
+        m_lastSceneTracingRepresentationContract.IsValidForOffscreenQueries() &&
+        m_cachedHitLightingMaxSurfaceCount > 0u)
+    {
+      const uint32_t budget = std::max(1u, m_cachedHitLightingMaxSurfaceCount / 16u);
+      m_cachedHitLightingResidentSurfaceCount = std::min(
+          m_cachedHitLightingMaxSurfaceCount,
+          m_cachedHitLightingResidentSurfaceCount + budget);
+    }
+
+    m_lastCachedHitLightingRepresentationContract = BuildCachedHitLightingRepresentationContract(
+        m_lastSceneTracingRepresentationContract,
+        m_lastLightingCompositePassContract,
+        m_cachedHitLightingRadianceHandle,
+        m_cachedHitLightingMomentsHandle,
+        m_cachedHitLightingRevision,
+        m_cachedHitLightingMaxSurfaceCount,
+        m_cachedHitLightingResidentSurfaceCount,
+        capturePolicy,
+        updatePolicy,
+        m_cachedHitLightingInvalidationReason,
+        hitLightingEnabled);
+    m_hasCachedHitLightingRepresentationContract = true;
+    if (m_lastCachedHitLightingRepresentationContract.validationStatus ==
+            CachedHitLightingRepresentationValidationStatus::Valid &&
+        m_cachedHitLightingInvalidationReason != CachedHitLightingInvalidationReason::None)
+    {
+      m_cachedHitLightingInvalidationReason = CachedHitLightingInvalidationReason::None;
+    }
   }
 
   bool VulkanRenderBackend::EnsureOffscreenRenderTarget(const std::string &targetKey,
@@ -3956,11 +4061,13 @@ namespace Monolith
     m_lastTemporalGiResolvePassContract = {};
     m_lastLightingCompositePassContract = {};
     m_lastSceneTracingRepresentationContract = {};
+    m_lastCachedHitLightingRepresentationContract = {};
     m_hasSsrPassContract = false;
     m_hasSsgiPassContract = false;
     m_hasTemporalGiResolvePassContract = false;
     m_hasLightingCompositePassContract = false;
     m_hasSceneTracingRepresentationContract = false;
+    m_hasCachedHitLightingRepresentationContract = false;
     m_activeView = {};
     if (m_pendingOpaqueDraws.capacity() < 256)
       m_pendingOpaqueDraws.reserve(256);
@@ -4190,6 +4297,12 @@ namespace Monolith
   }
   bool VulkanRenderBackend::TryGetSceneTracingRepresentationContract(
       SceneTracingRepresentationContract *,
+      std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetCachedHitLightingRepresentationContract(
+      CachedHitLightingRepresentationContract *,
       std::string *) const
   {
     return false;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -68,6 +68,9 @@ namespace Monolith
     bool TryGetSceneTracingRepresentationContract(
         SceneTracingRepresentationContract *outContract,
         std::string *outError) const override;
+    bool TryGetCachedHitLightingRepresentationContract(
+        CachedHitLightingRepresentationContract *outContract,
+        std::string *outError) const override;
     bool InvalidateGiHistory(GiHistoryResetReason reason,
                              std::string *outError) override;
 
@@ -207,13 +210,22 @@ namespace Monolith
     MeshDistanceFieldTracingStructure m_meshDistanceFieldTracingStructure;
     GlobalDistanceFieldTracingStructure m_globalDistanceFieldTracingStructure;
     SceneTracingRepresentationContract m_lastSceneTracingRepresentationContract;
+    CachedHitLightingRepresentationContract m_lastCachedHitLightingRepresentationContract;
     TemporalHistoryState m_lastTemporalHistoryState;
+    BackendResourceHandle m_cachedHitLightingRadianceHandle;
+    BackendResourceHandle m_cachedHitLightingMomentsHandle;
+    uint64_t m_cachedHitLightingRevision = 0;
+    uint32_t m_cachedHitLightingMaxSurfaceCount = 0;
+    uint32_t m_cachedHitLightingResidentSurfaceCount = 0;
+    CachedHitLightingInvalidationReason m_cachedHitLightingInvalidationReason =
+        CachedHitLightingInvalidationReason::None;
     bool m_hasTemporalHistoryState = false;
     bool m_hasSsrPassContract = false;
     bool m_hasSsgiPassContract = false;
     bool m_hasTemporalGiResolvePassContract = false;
     bool m_hasLightingCompositePassContract = false;
     bool m_hasSceneTracingRepresentationContract = false;
+    bool m_hasCachedHitLightingRepresentationContract = false;
   };
 
 } // namespace Monolith

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -317,6 +317,39 @@ namespace
           true);
       return true;
     }
+    bool TryGetCachedHitLightingRepresentationContract(
+        CachedHitLightingRepresentationContract *outContract,
+        std::string *outError) const override
+    {
+      if (!outContract)
+        return false;
+
+      SceneTracingRepresentationContract tracing{};
+      LightingCompositePassContract composite{};
+      if (!TryGetSceneTracingRepresentationContract(&tracing, outError) ||
+          !TryGetLightingCompositePassContract(&composite, outError))
+      {
+        *outContract = {};
+        return false;
+      }
+
+      const BackendResourceHandle reference = tracing.referenceDepth;
+      *outContract = BuildCachedHitLightingRepresentationContract(
+          tracing,
+          composite,
+          {reference.backendId, 0xA01u, reference.width, reference.height, cachedHitLightingRevision},
+          {reference.backendId, 0xA02u, reference.width, reference.height, cachedHitLightingRevision},
+          cachedHitLightingRevision,
+          4096u,
+          cachedHitLightingResidentSurfaceCount,
+          cachedHitLightingInvalidationReason == CachedHitLightingInvalidationReason::None
+              ? CachedHitLightingCapturePolicy::ScreenSpaceMissesAndDisocclusions
+              : CachedHitLightingCapturePolicy::FullReseedOnInvalidation,
+          CachedHitLightingUpdatePolicy::PerFrameBudgeted,
+          cachedHitLightingInvalidationReason,
+          true);
+      return true;
+    }
     bool InvalidateGiHistory(GiHistoryResetReason reason, std::string *outError) override
     {
       if (!giHistory.Has(GiHistorySemantic::DiffuseIrradiance))
@@ -336,6 +369,9 @@ namespace
       ++giHistory.revision;
       giHistory.lastResetReason = reason;
       giHistory.validForTemporalReuse = false;
+      cachedHitLightingInvalidationReason = ToCachedHitLightingInvalidationReason(reason);
+      ++cachedHitLightingRevision;
+      cachedHitLightingResidentSurfaceCount = 0u;
       return true;
     }
     std::vector<std::string> events;
@@ -347,6 +383,10 @@ namespace
     int drawCalls = 0;
     SceneTextureCatalog sceneTextures;
     GiHistoryCatalog giHistory;
+    CachedHitLightingInvalidationReason cachedHitLightingInvalidationReason =
+        CachedHitLightingInvalidationReason::None;
+    uint64_t cachedHitLightingRevision = 1u;
+    uint32_t cachedHitLightingResidentSurfaceCount = 256u;
   };
 
 #if defined(MONOLITH_HAS_VULKAN)
@@ -1007,6 +1047,91 @@ TEST_CASE("Scene tracing representation contract captures mesh and global distan
   REQUIRE(missingMesh.debug.usesClosestApproximation);
 }
 
+TEST_CASE("Cached hit-lighting contract expresses lifecycle and lookup integration",
+          "[renderer][foundation][temporal][tracing][cache]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Depth, {RenderBackendId::Vulkan, 0xC1u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Normal, {RenderBackendId::Vulkan, 0xC2u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::RoughnessMetallic,
+                    {RenderBackendId::Vulkan, 0xC3u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::BaseColor, {RenderBackendId::Vulkan, 0xC4u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Emissive, {RenderBackendId::Vulkan, 0xC5u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {RenderBackendId::Vulkan, 0xC6u, 960u, 540u, 1u});
+  sceneTextures.frameSerial = 91u;
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance,
+              {RenderBackendId::Vulkan, 0xD1u, 960u, 540u, 3u});
+  history.Set(GiHistorySemantic::SpecularIrradiance,
+              {RenderBackendId::Vulkan, 0xD2u, 960u, 540u, 3u});
+  history.Set(GiHistorySemantic::Validation, {RenderBackendId::Vulkan, 0xD3u, 960u, 540u, 3u});
+  history.Set(GiHistorySemantic::Moments, {RenderBackendId::Vulkan, 0xD4u, 960u, 540u, 3u});
+  history.revision = 90u;
+  history.validForTemporalReuse = true;
+
+  const ScreenSpaceReflectionPassContract ssr = BuildScreenSpaceReflectionPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true, ScreenSpaceReflectionMissPolicy::ProbeFallback);
+  const ScreenSpaceGlobalIlluminationPassContract ssgi = BuildScreenSpaceGlobalIlluminationPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true);
+  const TemporalGiResolvePassContract resolve = BuildTemporalGiResolvePassContract(ssr, ssgi, history);
+  const LightingCompositePassContract composite = BuildLightingCompositePassContract(sceneTextures, resolve);
+
+  MeshDistanceFieldTracingStructure mesh{};
+  mesh.atlas = {RenderBackendId::Vulkan, 0xE1u, 960u, 540u, 6u};
+  GlobalDistanceFieldTracingStructure global{};
+  global.volume = {RenderBackendId::Vulkan, 0xE2u, 960u, 540u, 6u};
+  const SceneTracingRepresentationContract tracing = BuildSceneTracingRepresentationContract(
+      ssr,
+      ssgi,
+      resolve,
+      mesh,
+      global,
+      SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+      SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+      true);
+  REQUIRE(tracing.IsValidForOffscreenQueries());
+
+  const CachedHitLightingRepresentationContract invalidated = BuildCachedHitLightingRepresentationContract(
+      tracing,
+      composite,
+      {RenderBackendId::Vulkan, 0xF1u, 960u, 540u, 8u},
+      {RenderBackendId::Vulkan, 0xF2u, 960u, 540u, 8u},
+      8u,
+      8192u,
+      512u,
+      CachedHitLightingCapturePolicy::FullReseedOnInvalidation,
+      CachedHitLightingUpdatePolicy::PerFrameBudgeted,
+      CachedHitLightingInvalidationReason::SceneBarrier,
+      true);
+  REQUIRE(invalidated.validationStatus == CachedHitLightingRepresentationValidationStatus::Valid);
+  REQUIRE(invalidated.state == CachedHitLightingRepresentationState::Invalidated);
+  REQUIRE_FALSE(invalidated.IsValidForLookup());
+  REQUIRE(invalidated.lookupPolicy.Uses(CachedHitLightingLookupIntegrationPoint::SsrMiss));
+  REQUIRE(invalidated.lookupPolicy.Uses(CachedHitLightingLookupIntegrationPoint::SsgiMiss));
+  REQUIRE(invalidated.lookupPolicy.Uses(CachedHitLightingLookupIntegrationPoint::LightingComposite));
+  REQUIRE(invalidated.debug.captureRequested);
+
+  const CachedHitLightingRepresentationContract ready = BuildCachedHitLightingRepresentationContract(
+      tracing,
+      composite,
+      {RenderBackendId::Vulkan, 0xF1u, 960u, 540u, 9u},
+      {RenderBackendId::Vulkan, 0xF2u, 960u, 540u, 9u},
+      9u,
+      8192u,
+      4096u,
+      CachedHitLightingCapturePolicy::ScreenSpaceMissesAndDisocclusions,
+      CachedHitLightingUpdatePolicy::PerFrameBudgeted,
+      CachedHitLightingInvalidationReason::None,
+      true);
+  REQUIRE(ready.validationStatus == CachedHitLightingRepresentationValidationStatus::Valid);
+  REQUIRE(ready.state == CachedHitLightingRepresentationState::Ready);
+  REQUIRE(ready.IsValidForLookup());
+  REQUIRE(ready.debug.lookupEnabled);
+  REQUIRE(ready.debug.estimatedHitRatio > 0.4f);
+  REQUIRE(ready.updatePolicy == CachedHitLightingUpdatePolicy::PerFrameBudgeted);
+}
+
 TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
           "[renderer][foundation][abstractions]")
 {
@@ -1070,6 +1195,15 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
   REQUIRE(tracingContract.IsValidForOffscreenQueries());
   REQUIRE(tracingContract.mesh.IsValid());
   REQUIRE(tracingContract.global.IsValid());
+  CachedHitLightingRepresentationContract cachedHitLightingContract{};
+  REQUIRE(Renderer::TryGetCachedHitLightingRepresentationContract(&cachedHitLightingContract, &error));
+  REQUIRE(cachedHitLightingContract.validationStatus ==
+          CachedHitLightingRepresentationValidationStatus::Valid);
+  REQUIRE(cachedHitLightingContract.lookupPolicy.Uses(
+      CachedHitLightingLookupIntegrationPoint::LightingComposite));
+  REQUIRE((cachedHitLightingContract.state == CachedHitLightingRepresentationState::Warmup ||
+           cachedHitLightingContract.state == CachedHitLightingRepresentationState::Ready ||
+           cachedHitLightingContract.state == CachedHitLightingRepresentationState::Invalidated));
   REQUIRE(Renderer::InvalidateGiHistory(GiHistoryResetReason::SceneBarrier, &error));
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
   REQUIRE(giHistory.lastResetReason == GiHistoryResetReason::SceneBarrier);


### PR DESCRIPTION
## Summary
Add cached hit-lighting representation with lifecycle/invalidation contracts.

Closes #172
