### PR TITLE
feat(renderer): add radiance-cache final gather and debug contracts

### DIFF
--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -64,6 +64,12 @@ class IRenderBackend {
   virtual bool TryGetCachedHitLightingRepresentationContract(
       CachedHitLightingRepresentationContract* outContract,
       std::string* outError) const = 0;
+  virtual bool TryGetRadianceCacheFinalGatherContract(
+      RadianceCacheFinalGatherContract* outContract,
+      std::string* outError) const = 0;
+  virtual bool TryGetGiReflectionDebugVisualizationContract(
+      GiReflectionDebugVisualizationContract* outContract,
+      std::string* outError) const = 0;
   virtual bool InvalidateGiHistory(GiHistoryResetReason reason,
                                    std::string* outError) = 0;
 };

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -183,6 +183,24 @@ bool OpenGLRenderBackend::TryGetCachedHitLightingRepresentationContract(
   return false;
 }
 
+bool OpenGLRenderBackend::TryGetRadianceCacheFinalGatherContract(
+    RadianceCacheFinalGatherContract* outContract, std::string* outError) const {
+  if (outContract)
+    *outContract = {};
+  if (outError)
+    *outError = "Radiance-cache final-gather contract is unavailable on OpenGL backend.";
+  return false;
+}
+
+bool OpenGLRenderBackend::TryGetGiReflectionDebugVisualizationContract(
+    GiReflectionDebugVisualizationContract* outContract, std::string* outError) const {
+  if (outContract)
+    *outContract = {};
+  if (outError)
+    *outError = "GI/reflection debug visualization contract is unavailable on OpenGL backend.";
+  return false;
+}
+
 bool OpenGLRenderBackend::InvalidateGiHistory(GiHistoryResetReason, std::string* outError) {
   if (outError)
     *outError = "GI history invalidation is unavailable on OpenGL backend.";

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -58,6 +58,12 @@ class OpenGLRenderBackend : public IRenderBackend {
   bool TryGetCachedHitLightingRepresentationContract(
       CachedHitLightingRepresentationContract* outContract,
       std::string* outError) const override;
+  bool TryGetRadianceCacheFinalGatherContract(
+      RadianceCacheFinalGatherContract* outContract,
+      std::string* outError) const override;
+  bool TryGetGiReflectionDebugVisualizationContract(
+      GiReflectionDebugVisualizationContract* outContract,
+      std::string* outError) const override;
   bool InvalidateGiHistory(GiHistoryResetReason reason, std::string* outError) override;
 
  private:

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -270,6 +270,20 @@ namespace Monolith
     return ActiveBackend()->TryGetCachedHitLightingRepresentationContract(outContract, outError);
   }
 
+  bool Renderer::TryGetRadianceCacheFinalGatherContract(
+      RadianceCacheFinalGatherContract *outContract,
+      std::string *outError)
+  {
+    return ActiveBackend()->TryGetRadianceCacheFinalGatherContract(outContract, outError);
+  }
+
+  bool Renderer::TryGetGiReflectionDebugVisualizationContract(
+      GiReflectionDebugVisualizationContract *outContract,
+      std::string *outError)
+  {
+    return ActiveBackend()->TryGetGiReflectionDebugVisualizationContract(outContract, outError);
+  }
+
   bool Renderer::TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                           std::string *outError)
   {

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -95,6 +95,12 @@ namespace Monolith
     static bool TryGetCachedHitLightingRepresentationContract(
         CachedHitLightingRepresentationContract *outContract,
         std::string *outError = nullptr);
+    static bool TryGetRadianceCacheFinalGatherContract(
+        RadianceCacheFinalGatherContract *outContract,
+        std::string *outError = nullptr);
+    static bool TryGetGiReflectionDebugVisualizationContract(
+        GiReflectionDebugVisualizationContract *outContract,
+        std::string *outError = nullptr);
     static bool TryGetTemporalReprojectionInputContract(TemporalReprojectionInputContract *outContract,
                                                         std::string *outError = nullptr);
     static bool InvalidateGiHistory(GiHistoryResetReason reason,

--- a/renderer/SceneTextureResources.h
+++ b/renderer/SceneTextureResources.h
@@ -1618,4 +1618,364 @@ namespace Monolith
     return contract;
   }
 
+  enum class RadianceCacheFinalGatherIntegrationPoint : uint8_t
+  {
+    None = 0,
+    SsrMiss = 1u << 0u,
+    SsgiMiss = 1u << 1u,
+    LightingComposite = 1u << 2u,
+    TemporalResolve = 1u << 3u,
+  };
+
+  inline uint8_t RadianceCacheFinalGatherIntegrationMask(
+      RadianceCacheFinalGatherIntegrationPoint point)
+  {
+    return static_cast<uint8_t>(point);
+  }
+
+  enum class RadianceCacheFinalGatherValidationStatus : uint8_t
+  {
+    DisabledBySettings = 0,
+    Valid,
+    MissingCachedHitLightingContract,
+    MissingSceneTracingRepresentation,
+    MissingCacheSurface,
+    BackendMismatch,
+    DimensionMismatch,
+  };
+
+  enum class RadianceCacheFinalGatherState : uint8_t
+  {
+    Disabled = 0,
+    Unavailable,
+    Warmup,
+    Ready,
+  };
+
+  struct RadianceCacheFinalGatherTierExpectation
+  {
+    TemporalQualityTier tier = TemporalQualityTier::Disabled;
+    uint32_t gatherSamplesPerPixel = 0;
+    uint32_t probeUpdateBudget = 0;
+    uint32_t raysPerProbe = 0;
+    float expectedMinCacheHitRatio = 0.0f;
+    float expectedTemporalReuse = 0.0f;
+  };
+
+  inline RadianceCacheFinalGatherTierExpectation
+  BuildRadianceCacheFinalGatherTierExpectation(TemporalQualityTier tier)
+  {
+    RadianceCacheFinalGatherTierExpectation expectation{};
+    expectation.tier = tier;
+    switch (tier)
+    {
+    case TemporalQualityTier::Disabled:
+      expectation.gatherSamplesPerPixel = 0;
+      expectation.probeUpdateBudget = 0;
+      expectation.raysPerProbe = 0;
+      expectation.expectedMinCacheHitRatio = 0.0f;
+      expectation.expectedTemporalReuse = 0.0f;
+      break;
+    case TemporalQualityTier::Low:
+      expectation.gatherSamplesPerPixel = 1;
+      expectation.probeUpdateBudget = 96;
+      expectation.raysPerProbe = 4;
+      expectation.expectedMinCacheHitRatio = 0.20f;
+      expectation.expectedTemporalReuse = 0.10f;
+      break;
+    case TemporalQualityTier::Medium:
+      expectation.gatherSamplesPerPixel = 2;
+      expectation.probeUpdateBudget = 192;
+      expectation.raysPerProbe = 8;
+      expectation.expectedMinCacheHitRatio = 0.35f;
+      expectation.expectedTemporalReuse = 0.30f;
+      break;
+    case TemporalQualityTier::High:
+      expectation.gatherSamplesPerPixel = 4;
+      expectation.probeUpdateBudget = 320;
+      expectation.raysPerProbe = 12;
+      expectation.expectedMinCacheHitRatio = 0.50f;
+      expectation.expectedTemporalReuse = 0.55f;
+      break;
+    case TemporalQualityTier::Ultra:
+      expectation.gatherSamplesPerPixel = 6;
+      expectation.probeUpdateBudget = 512;
+      expectation.raysPerProbe = 16;
+      expectation.expectedMinCacheHitRatio = 0.65f;
+      expectation.expectedTemporalReuse = 0.70f;
+      break;
+    }
+    return expectation;
+  }
+
+  struct RadianceCacheFinalGatherDebugState
+  {
+    bool temporalAccumulationActive = false;
+    bool fallbackActive = false;
+    bool finalGatherReady = false;
+    uint32_t captureBudget = 0;
+    uint32_t capturesCommitted = 0;
+    float cacheResidencyRatio = 0.0f;
+    float estimatedHitRatio = 0.0f;
+    GiHistoryResetReason lastGiHistoryResetReason = GiHistoryResetReason::None;
+    CachedHitLightingInvalidationReason lastCacheInvalidationReason =
+        CachedHitLightingInvalidationReason::None;
+    SsrExecutionStatus ssrExecutionStatus = SsrExecutionStatus::Disabled;
+    SsgiExecutionStatus ssgiExecutionStatus = SsgiExecutionStatus::Disabled;
+    TemporalGiResolveExecutionStatus temporalResolveExecutionStatus =
+        TemporalGiResolveExecutionStatus::Disabled;
+  };
+
+  struct RadianceCacheFinalGatherContract
+  {
+    CachedHitLightingRepresentationContract cachedHitLighting{};
+    SceneTracingRepresentationContract sceneTracing{};
+    BackendResourceHandle radianceCache{};
+    BackendResourceHandle momentsCache{};
+    uint64_t sceneFrameSerial = 0;
+    uint64_t historyRevision = 0;
+    uint64_t cacheRevision = 0;
+    uint8_t integrationMask = 0;
+    RadianceCacheFinalGatherTierExpectation qualityExpectation{};
+    RadianceCacheFinalGatherDebugState debug{};
+    RadianceCacheFinalGatherValidationStatus validationStatus =
+        RadianceCacheFinalGatherValidationStatus::DisabledBySettings;
+    RadianceCacheFinalGatherState state = RadianceCacheFinalGatherState::Unavailable;
+
+    bool UsesIntegrationPoint(RadianceCacheFinalGatherIntegrationPoint point) const
+    {
+      return (integrationMask & RadianceCacheFinalGatherIntegrationMask(point)) != 0u;
+    }
+
+    bool IsValidForFinalGather() const
+    {
+      return validationStatus == RadianceCacheFinalGatherValidationStatus::Valid &&
+             state == RadianceCacheFinalGatherState::Ready;
+    }
+  };
+
+  inline RadianceCacheFinalGatherContract BuildRadianceCacheFinalGatherContract(
+      const CachedHitLightingRepresentationContract& cachedHitLightingContract,
+      TemporalQualityTier tier,
+      bool enabled)
+  {
+    RadianceCacheFinalGatherContract contract{};
+    contract.cachedHitLighting = cachedHitLightingContract;
+    contract.sceneTracing = cachedHitLightingContract.sceneTracing;
+    contract.radianceCache = cachedHitLightingContract.radianceCache;
+    contract.momentsCache = cachedHitLightingContract.momentsCache;
+    contract.sceneFrameSerial = cachedHitLightingContract.sceneFrameSerial;
+    contract.historyRevision = cachedHitLightingContract.historyRevision;
+    contract.cacheRevision = cachedHitLightingContract.cacheRevision;
+    contract.qualityExpectation = BuildRadianceCacheFinalGatherTierExpectation(tier);
+    contract.debug.captureBudget = cachedHitLightingContract.debug.captureBudget;
+    contract.debug.capturesCommitted = cachedHitLightingContract.debug.capturesCommitted;
+    contract.debug.estimatedHitRatio = cachedHitLightingContract.debug.estimatedHitRatio;
+    contract.debug.lastCacheInvalidationReason = cachedHitLightingContract.debug.lastInvalidationReason;
+    contract.debug.lastGiHistoryResetReason =
+        cachedHitLightingContract.sceneTracing.debug.lastHistoryResetReason;
+    contract.debug.ssrExecutionStatus = cachedHitLightingContract.sceneTracing.debug.ssrExecutionStatus;
+    contract.debug.ssgiExecutionStatus = cachedHitLightingContract.sceneTracing.debug.ssgiExecutionStatus;
+    contract.debug.temporalResolveExecutionStatus =
+        cachedHitLightingContract.sceneTracing.debug.temporalResolveExecutionStatus;
+    contract.debug.temporalAccumulationActive =
+        cachedHitLightingContract.sceneTracing.temporalResolve.executionStatus ==
+        TemporalGiResolveExecutionStatus::ResolveAndAccumulate;
+    contract.integrationMask =
+        RadianceCacheFinalGatherIntegrationMask(RadianceCacheFinalGatherIntegrationPoint::LightingComposite) |
+        RadianceCacheFinalGatherIntegrationMask(RadianceCacheFinalGatherIntegrationPoint::TemporalResolve);
+    if (cachedHitLightingContract.lookupPolicy.Uses(CachedHitLightingLookupIntegrationPoint::SsrMiss))
+    {
+      contract.integrationMask |=
+          RadianceCacheFinalGatherIntegrationMask(RadianceCacheFinalGatherIntegrationPoint::SsrMiss);
+    }
+    if (cachedHitLightingContract.lookupPolicy.Uses(CachedHitLightingLookupIntegrationPoint::SsgiMiss))
+    {
+      contract.integrationMask |=
+          RadianceCacheFinalGatherIntegrationMask(RadianceCacheFinalGatherIntegrationPoint::SsgiMiss);
+    }
+
+    if (!enabled || tier == TemporalQualityTier::Disabled)
+    {
+      contract.state = RadianceCacheFinalGatherState::Disabled;
+      contract.validationStatus = RadianceCacheFinalGatherValidationStatus::DisabledBySettings;
+      return contract;
+    }
+
+    if (cachedHitLightingContract.validationStatus !=
+        CachedHitLightingRepresentationValidationStatus::Valid)
+    {
+      contract.state = RadianceCacheFinalGatherState::Unavailable;
+      contract.validationStatus =
+          RadianceCacheFinalGatherValidationStatus::MissingCachedHitLightingContract;
+      return contract;
+    }
+
+    if (!cachedHitLightingContract.sceneTracing.IsValidForOffscreenQueries())
+    {
+      contract.state = RadianceCacheFinalGatherState::Unavailable;
+      contract.validationStatus =
+          RadianceCacheFinalGatherValidationStatus::MissingSceneTracingRepresentation;
+      return contract;
+    }
+
+    if (!contract.radianceCache.IsValid() || !contract.momentsCache.IsValid())
+    {
+      contract.state = RadianceCacheFinalGatherState::Unavailable;
+      contract.validationStatus = RadianceCacheFinalGatherValidationStatus::MissingCacheSurface;
+      return contract;
+    }
+
+    if (contract.sceneTracing.referenceDepth.backendId != contract.radianceCache.backendId ||
+        contract.sceneTracing.referenceDepth.backendId != contract.momentsCache.backendId)
+    {
+      contract.state = RadianceCacheFinalGatherState::Unavailable;
+      contract.validationStatus = RadianceCacheFinalGatherValidationStatus::BackendMismatch;
+      return contract;
+    }
+
+    if (contract.sceneTracing.referenceDepth.width != contract.radianceCache.width ||
+        contract.sceneTracing.referenceDepth.height != contract.radianceCache.height ||
+        contract.sceneTracing.referenceDepth.width != contract.momentsCache.width ||
+        contract.sceneTracing.referenceDepth.height != contract.momentsCache.height)
+    {
+      contract.state = RadianceCacheFinalGatherState::Unavailable;
+      contract.validationStatus = RadianceCacheFinalGatherValidationStatus::DimensionMismatch;
+      return contract;
+    }
+
+    contract.validationStatus = RadianceCacheFinalGatherValidationStatus::Valid;
+    if (cachedHitLightingContract.maxSurfaceCount > 0u)
+    {
+      contract.debug.cacheResidencyRatio =
+          static_cast<float>(cachedHitLightingContract.residentSurfaceCount) /
+          static_cast<float>(cachedHitLightingContract.maxSurfaceCount);
+    }
+    contract.debug.fallbackActive =
+        cachedHitLightingContract.state == CachedHitLightingRepresentationState::Invalidated ||
+        cachedHitLightingContract.state == CachedHitLightingRepresentationState::Warmup;
+    contract.state = contract.debug.fallbackActive
+                         ? RadianceCacheFinalGatherState::Warmup
+                         : RadianceCacheFinalGatherState::Ready;
+    contract.debug.finalGatherReady = contract.state == RadianceCacheFinalGatherState::Ready;
+    return contract;
+  }
+
+  enum class GiReflectionDebugView : uint8_t
+  {
+    None = 0,
+    RadianceCacheResidency = 1u << 0u,
+    ReflectionHistory = 1u << 1u,
+    TemporalStability = 1u << 2u,
+    SceneTracingCoverage = 1u << 3u,
+  };
+
+  inline uint8_t GiReflectionDebugViewMask(GiReflectionDebugView view)
+  {
+    return static_cast<uint8_t>(view);
+  }
+
+  enum class GiReflectionDebugVisualizationValidationStatus : uint8_t
+  {
+    DisabledBySettings = 0,
+    Valid,
+    MissingSceneTracingRepresentation,
+    MissingCachedHitLightingContract,
+  };
+
+  struct GiReflectionDebugVisualizationState
+  {
+    uint8_t availableViews = 0;
+    bool giCacheVisualizationReady = false;
+    bool reflectionVisualizationReady = false;
+    bool temporalBehaviorVisible = false;
+    bool temporalStable = false;
+    CachedHitLightingRepresentationState cacheState = CachedHitLightingRepresentationState::Unavailable;
+    CachedHitLightingInvalidationReason cacheInvalidationReason =
+        CachedHitLightingInvalidationReason::None;
+    GiHistoryResetReason historyResetReason = GiHistoryResetReason::None;
+    SsrExecutionStatus ssrExecutionStatus = SsrExecutionStatus::Disabled;
+    SsgiExecutionStatus ssgiExecutionStatus = SsgiExecutionStatus::Disabled;
+    TemporalGiResolveExecutionStatus temporalResolveExecutionStatus =
+        TemporalGiResolveExecutionStatus::Disabled;
+
+    bool Supports(GiReflectionDebugView view) const
+    {
+      return (availableViews & GiReflectionDebugViewMask(view)) != 0u;
+    }
+  };
+
+  struct GiReflectionDebugVisualizationContract
+  {
+    SceneTracingRepresentationContract sceneTracing{};
+    CachedHitLightingRepresentationContract cachedHitLighting{};
+    RadianceCacheFinalGatherContract finalGather{};
+    GiReflectionDebugVisualizationState state{};
+    GiReflectionDebugVisualizationValidationStatus validationStatus =
+        GiReflectionDebugVisualizationValidationStatus::DisabledBySettings;
+
+    bool IsAnyViewAvailable() const { return state.availableViews != 0u; }
+  };
+
+  inline GiReflectionDebugVisualizationContract BuildGiReflectionDebugVisualizationContract(
+      const SceneTracingRepresentationContract& sceneTracingContract,
+      const CachedHitLightingRepresentationContract& cachedHitLightingContract,
+      const RadianceCacheFinalGatherContract& finalGatherContract,
+      bool enabled)
+  {
+    GiReflectionDebugVisualizationContract contract{};
+    contract.sceneTracing = sceneTracingContract;
+    contract.cachedHitLighting = cachedHitLightingContract;
+    contract.finalGather = finalGatherContract;
+    contract.state.cacheState = cachedHitLightingContract.state;
+    contract.state.cacheInvalidationReason = cachedHitLightingContract.debug.lastInvalidationReason;
+    contract.state.historyResetReason = sceneTracingContract.debug.lastHistoryResetReason;
+    contract.state.ssrExecutionStatus = sceneTracingContract.debug.ssrExecutionStatus;
+    contract.state.ssgiExecutionStatus = sceneTracingContract.debug.ssgiExecutionStatus;
+    contract.state.temporalResolveExecutionStatus =
+        sceneTracingContract.debug.temporalResolveExecutionStatus;
+    contract.state.temporalStable = sceneTracingContract.debug.temporalHistoryStable;
+
+    if (!enabled)
+    {
+      contract.validationStatus = GiReflectionDebugVisualizationValidationStatus::DisabledBySettings;
+      return contract;
+    }
+
+    if (sceneTracingContract.validationStatus != SceneTracingRepresentationValidationStatus::Valid)
+    {
+      contract.validationStatus =
+          GiReflectionDebugVisualizationValidationStatus::MissingSceneTracingRepresentation;
+      return contract;
+    }
+    if (cachedHitLightingContract.validationStatus !=
+        CachedHitLightingRepresentationValidationStatus::Valid)
+    {
+      contract.validationStatus =
+          GiReflectionDebugVisualizationValidationStatus::MissingCachedHitLightingContract;
+      return contract;
+    }
+
+    contract.validationStatus = GiReflectionDebugVisualizationValidationStatus::Valid;
+    contract.state.availableViews =
+        GiReflectionDebugViewMask(GiReflectionDebugView::SceneTracingCoverage) |
+        GiReflectionDebugViewMask(GiReflectionDebugView::ReflectionHistory);
+    if (cachedHitLightingContract.debug.cacheAllocated)
+    {
+      contract.state.availableViews |=
+          GiReflectionDebugViewMask(GiReflectionDebugView::RadianceCacheResidency);
+      contract.state.giCacheVisualizationReady = true;
+    }
+    if (sceneTracingContract.ssr.validationStatus == SsrInputValidationStatus::Valid)
+      contract.state.reflectionVisualizationReady = true;
+    if (sceneTracingContract.temporalResolve.validationStatus ==
+        TemporalGiResolveValidationStatus::Valid)
+    {
+      contract.state.temporalBehaviorVisible = true;
+      contract.state.availableViews |=
+          GiReflectionDebugViewMask(GiReflectionDebugView::TemporalStability);
+    }
+    return contract;
+  }
+
 } // namespace Monolith

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -914,6 +914,10 @@ namespace Monolith
     m_hasSceneTracingRepresentationContract = false;
     m_lastCachedHitLightingRepresentationContract = {};
     m_hasCachedHitLightingRepresentationContract = false;
+    m_lastRadianceCacheFinalGatherContract = {};
+    m_hasRadianceCacheFinalGatherContract = false;
+    m_lastGiReflectionDebugVisualizationContract = {};
+    m_hasGiReflectionDebugVisualizationContract = false;
     return true;
   }
 
@@ -1103,6 +1107,44 @@ namespace Monolith
     return true;
   }
 
+  bool VulkanRenderBackend::TryGetRadianceCacheFinalGatherContract(
+      RadianceCacheFinalGatherContract *outContract,
+      std::string *outError) const
+  {
+    if (!outContract)
+      return false;
+
+    if (!m_hasRadianceCacheFinalGatherContract)
+    {
+      *outContract = {};
+      if (outError)
+        *outError = "Radiance-cache final-gather contract has not been produced for this frame.";
+      return false;
+    }
+
+    *outContract = m_lastRadianceCacheFinalGatherContract;
+    return true;
+  }
+
+  bool VulkanRenderBackend::TryGetGiReflectionDebugVisualizationContract(
+      GiReflectionDebugVisualizationContract *outContract,
+      std::string *outError) const
+  {
+    if (!outContract)
+      return false;
+
+    if (!m_hasGiReflectionDebugVisualizationContract)
+    {
+      *outContract = {};
+      if (outError)
+        *outError = "GI/reflection debug visualization contract has not been produced for this frame.";
+      return false;
+    }
+
+    *outContract = m_lastGiReflectionDebugVisualizationContract;
+    return true;
+  }
+
   bool VulkanRenderBackend::InvalidateGiHistory(GiHistoryResetReason reason,
                                                 std::string *outError)
   {
@@ -1257,6 +1299,20 @@ namespace Monolith
         m_cachedHitLightingInvalidationReason,
         hitLightingEnabled);
     m_hasCachedHitLightingRepresentationContract = true;
+
+    m_lastRadianceCacheFinalGatherContract = BuildRadianceCacheFinalGatherContract(
+        m_lastCachedHitLightingRepresentationContract,
+        m_activeFrame.temporal.jitter.qualityTier,
+        hitLightingEnabled);
+    m_hasRadianceCacheFinalGatherContract = true;
+
+    m_lastGiReflectionDebugVisualizationContract = BuildGiReflectionDebugVisualizationContract(
+        m_lastSceneTracingRepresentationContract,
+        m_lastCachedHitLightingRepresentationContract,
+        m_lastRadianceCacheFinalGatherContract,
+        true);
+    m_hasGiReflectionDebugVisualizationContract = true;
+
     if (m_lastCachedHitLightingRepresentationContract.validationStatus ==
             CachedHitLightingRepresentationValidationStatus::Valid &&
         m_cachedHitLightingInvalidationReason != CachedHitLightingInvalidationReason::None)
@@ -4062,12 +4118,16 @@ namespace Monolith
     m_lastLightingCompositePassContract = {};
     m_lastSceneTracingRepresentationContract = {};
     m_lastCachedHitLightingRepresentationContract = {};
+    m_lastRadianceCacheFinalGatherContract = {};
+    m_lastGiReflectionDebugVisualizationContract = {};
     m_hasSsrPassContract = false;
     m_hasSsgiPassContract = false;
     m_hasTemporalGiResolvePassContract = false;
     m_hasLightingCompositePassContract = false;
     m_hasSceneTracingRepresentationContract = false;
     m_hasCachedHitLightingRepresentationContract = false;
+    m_hasRadianceCacheFinalGatherContract = false;
+    m_hasGiReflectionDebugVisualizationContract = false;
     m_activeView = {};
     if (m_pendingOpaqueDraws.capacity() < 256)
       m_pendingOpaqueDraws.reserve(256);
@@ -4303,6 +4363,18 @@ namespace Monolith
   }
   bool VulkanRenderBackend::TryGetCachedHitLightingRepresentationContract(
       CachedHitLightingRepresentationContract *,
+      std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetRadianceCacheFinalGatherContract(
+      RadianceCacheFinalGatherContract *,
+      std::string *) const
+  {
+    return false;
+  }
+  bool VulkanRenderBackend::TryGetGiReflectionDebugVisualizationContract(
+      GiReflectionDebugVisualizationContract *,
       std::string *) const
   {
     return false;

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -71,6 +71,12 @@ namespace Monolith
     bool TryGetCachedHitLightingRepresentationContract(
         CachedHitLightingRepresentationContract *outContract,
         std::string *outError) const override;
+    bool TryGetRadianceCacheFinalGatherContract(
+        RadianceCacheFinalGatherContract *outContract,
+        std::string *outError) const override;
+    bool TryGetGiReflectionDebugVisualizationContract(
+        GiReflectionDebugVisualizationContract *outContract,
+        std::string *outError) const override;
     bool InvalidateGiHistory(GiHistoryResetReason reason,
                              std::string *outError) override;
 
@@ -211,6 +217,8 @@ namespace Monolith
     GlobalDistanceFieldTracingStructure m_globalDistanceFieldTracingStructure;
     SceneTracingRepresentationContract m_lastSceneTracingRepresentationContract;
     CachedHitLightingRepresentationContract m_lastCachedHitLightingRepresentationContract;
+    RadianceCacheFinalGatherContract m_lastRadianceCacheFinalGatherContract;
+    GiReflectionDebugVisualizationContract m_lastGiReflectionDebugVisualizationContract;
     TemporalHistoryState m_lastTemporalHistoryState;
     BackendResourceHandle m_cachedHitLightingRadianceHandle;
     BackendResourceHandle m_cachedHitLightingMomentsHandle;
@@ -226,6 +234,8 @@ namespace Monolith
     bool m_hasLightingCompositePassContract = false;
     bool m_hasSceneTracingRepresentationContract = false;
     bool m_hasCachedHitLightingRepresentationContract = false;
+    bool m_hasRadianceCacheFinalGatherContract = false;
+    bool m_hasGiReflectionDebugVisualizationContract = false;
   };
 
 } // namespace Monolith

--- a/tests/test_renderer_foundation.cpp
+++ b/tests/test_renderer_foundation.cpp
@@ -13,6 +13,7 @@
 #include "renderer/IRenderBackend.h"
 #include "renderer/Material.h"
 #include "renderer/Mesh.h"
+#include "renderer/OpenGLRenderBackend.h"
 #include "renderer/RenderBackend.h"
 #include "renderer/Renderer.h"
 #include "renderer/RenderTargetHandle.h"
@@ -350,6 +351,51 @@ namespace
           true);
       return true;
     }
+    bool TryGetRadianceCacheFinalGatherContract(
+        RadianceCacheFinalGatherContract *outContract,
+        std::string *outError) const override
+    {
+      if (!outContract)
+        return false;
+
+      CachedHitLightingRepresentationContract cachedHitLighting{};
+      if (!TryGetCachedHitLightingRepresentationContract(&cachedHitLighting, outError))
+      {
+        *outContract = {};
+        return false;
+      }
+
+      *outContract = BuildRadianceCacheFinalGatherContract(
+          cachedHitLighting,
+          TemporalQualityTier::Medium,
+          true);
+      return true;
+    }
+    bool TryGetGiReflectionDebugVisualizationContract(
+        GiReflectionDebugVisualizationContract *outContract,
+        std::string *outError) const override
+    {
+      if (!outContract)
+        return false;
+
+      SceneTracingRepresentationContract tracing{};
+      CachedHitLightingRepresentationContract cachedHitLighting{};
+      RadianceCacheFinalGatherContract finalGather{};
+      if (!TryGetSceneTracingRepresentationContract(&tracing, outError) ||
+          !TryGetCachedHitLightingRepresentationContract(&cachedHitLighting, outError) ||
+          !TryGetRadianceCacheFinalGatherContract(&finalGather, outError))
+      {
+        *outContract = {};
+        return false;
+      }
+
+      *outContract = BuildGiReflectionDebugVisualizationContract(
+          tracing,
+          cachedHitLighting,
+          finalGather,
+          true);
+      return true;
+    }
     bool InvalidateGiHistory(GiHistoryResetReason reason, std::string *outError) override
     {
       if (!giHistory.Has(GiHistorySemantic::DiffuseIrradiance))
@@ -585,6 +631,25 @@ TEST_CASE("Backend capability defaults express the current parity matrix",
   REQUIRE_FALSE(vkCaps.supportsDebugHud);
   REQUIRE(vkCaps.supportsSceneTextureAbstractions);
   REQUIRE(vkCaps.supportsGiHistoryResources);
+}
+
+TEST_CASE("OpenGL backend reports final-gather and debug-visualization seams as unsupported",
+          "[renderer][foundation][backend][fallback]")
+{
+  OpenGLRenderBackend backend;
+  std::string error;
+  RadianceCacheFinalGatherContract finalGather{};
+  GiReflectionDebugVisualizationContract debugVisualization{};
+
+  REQUIRE_FALSE(backend.TryGetRadianceCacheFinalGatherContract(&finalGather, &error));
+  REQUIRE(error.find("unavailable on OpenGL backend") != std::string::npos);
+  REQUIRE(finalGather.validationStatus == RadianceCacheFinalGatherValidationStatus::DisabledBySettings);
+
+  error.clear();
+  REQUIRE_FALSE(backend.TryGetGiReflectionDebugVisualizationContract(&debugVisualization, &error));
+  REQUIRE(error.find("unavailable on OpenGL backend") != std::string::npos);
+  REQUIRE(debugVisualization.validationStatus ==
+          GiReflectionDebugVisualizationValidationStatus::DisabledBySettings);
 }
 
 TEST_CASE("RenderTargetHandle constructors preserve backend-native metadata",
@@ -1132,6 +1197,135 @@ TEST_CASE("Cached hit-lighting contract expresses lifecycle and lookup integrati
   REQUIRE(ready.updatePolicy == CachedHitLightingUpdatePolicy::PerFrameBudgeted);
 }
 
+TEST_CASE("Radiance-cache final-gather contract encodes tier expectations and integration points",
+          "[renderer][foundation][temporal][tracing][cache][final-gather]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Depth, {RenderBackendId::Vulkan, 0x111u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Normal, {RenderBackendId::Vulkan, 0x112u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::RoughnessMetallic,
+                    {RenderBackendId::Vulkan, 0x113u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::BaseColor, {RenderBackendId::Vulkan, 0x114u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Emissive, {RenderBackendId::Vulkan, 0x115u, 1280u, 720u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {RenderBackendId::Vulkan, 0x116u, 1280u, 720u, 1u});
+  sceneTextures.frameSerial = 140u;
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance, {RenderBackendId::Vulkan, 0x121u, 1280u, 720u, 4u});
+  history.Set(GiHistorySemantic::SpecularIrradiance, {RenderBackendId::Vulkan, 0x122u, 1280u, 720u, 4u});
+  history.Set(GiHistorySemantic::Validation, {RenderBackendId::Vulkan, 0x123u, 1280u, 720u, 4u});
+  history.Set(GiHistorySemantic::Moments, {RenderBackendId::Vulkan, 0x124u, 1280u, 720u, 4u});
+  history.revision = 33u;
+  history.validForTemporalReuse = true;
+
+  const ScreenSpaceReflectionPassContract ssr = BuildScreenSpaceReflectionPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true, ScreenSpaceReflectionMissPolicy::ProbeFallback);
+  const ScreenSpaceGlobalIlluminationPassContract ssgi = BuildScreenSpaceGlobalIlluminationPassContract(
+      sceneTextures, history, TemporalQualityTier::High, true);
+  const TemporalGiResolvePassContract resolve = BuildTemporalGiResolvePassContract(ssr, ssgi, history);
+  const LightingCompositePassContract composite = BuildLightingCompositePassContract(sceneTextures, resolve);
+  MeshDistanceFieldTracingStructure mesh{};
+  mesh.atlas = {RenderBackendId::Vulkan, 0x131u, 1280u, 720u, 1u};
+  GlobalDistanceFieldTracingStructure global{};
+  global.volume = {RenderBackendId::Vulkan, 0x132u, 1280u, 720u, 1u};
+  const SceneTracingRepresentationContract tracing = BuildSceneTracingRepresentationContract(
+      ssr, ssgi, resolve, mesh, global,
+      SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+      SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+      true);
+  const CachedHitLightingRepresentationContract cached = BuildCachedHitLightingRepresentationContract(
+      tracing,
+      composite,
+      {RenderBackendId::Vulkan, 0x141u, 1280u, 720u, 3u},
+      {RenderBackendId::Vulkan, 0x142u, 1280u, 720u, 3u},
+      3u,
+      8192u,
+      6144u,
+      CachedHitLightingCapturePolicy::ScreenSpaceMissesAndDisocclusions,
+      CachedHitLightingUpdatePolicy::PerFrameBudgeted,
+      CachedHitLightingInvalidationReason::None,
+      true);
+  REQUIRE(cached.validationStatus == CachedHitLightingRepresentationValidationStatus::Valid);
+
+  const RadianceCacheFinalGatherContract low = BuildRadianceCacheFinalGatherContract(
+      cached, TemporalQualityTier::Low, true);
+  const RadianceCacheFinalGatherContract high = BuildRadianceCacheFinalGatherContract(
+      cached, TemporalQualityTier::High, true);
+  REQUIRE(low.validationStatus == RadianceCacheFinalGatherValidationStatus::Valid);
+  REQUIRE(high.validationStatus == RadianceCacheFinalGatherValidationStatus::Valid);
+  REQUIRE(low.qualityExpectation.gatherSamplesPerPixel < high.qualityExpectation.gatherSamplesPerPixel);
+  REQUIRE(low.qualityExpectation.probeUpdateBudget < high.qualityExpectation.probeUpdateBudget);
+  REQUIRE(low.qualityExpectation.expectedMinCacheHitRatio <
+          high.qualityExpectation.expectedMinCacheHitRatio);
+  REQUIRE(high.UsesIntegrationPoint(RadianceCacheFinalGatherIntegrationPoint::LightingComposite));
+  REQUIRE(high.UsesIntegrationPoint(RadianceCacheFinalGatherIntegrationPoint::TemporalResolve));
+  REQUIRE(high.state == RadianceCacheFinalGatherState::Ready);
+  REQUIRE(high.IsValidForFinalGather());
+}
+
+TEST_CASE("GI/reflection debug visualization tracks cache and temporal view availability",
+          "[renderer][foundation][temporal][tracing][cache][debug]")
+{
+  SceneTextureCatalog sceneTextures{};
+  sceneTextures.Set(SceneTextureSemantic::Depth, {RenderBackendId::Vulkan, 0x211u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Normal, {RenderBackendId::Vulkan, 0x212u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::RoughnessMetallic, {RenderBackendId::Vulkan, 0x213u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::BaseColor, {RenderBackendId::Vulkan, 0x214u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::Emissive, {RenderBackendId::Vulkan, 0x215u, 960u, 540u, 1u});
+  sceneTextures.Set(SceneTextureSemantic::MotionVector, {RenderBackendId::Vulkan, 0x216u, 960u, 540u, 1u});
+  sceneTextures.frameSerial = 12u;
+
+  GiHistoryCatalog history{};
+  history.Set(GiHistorySemantic::DiffuseIrradiance, {RenderBackendId::Vulkan, 0x221u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::SpecularIrradiance, {RenderBackendId::Vulkan, 0x222u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::Validation, {RenderBackendId::Vulkan, 0x223u, 960u, 540u, 2u});
+  history.Set(GiHistorySemantic::Moments, {RenderBackendId::Vulkan, 0x224u, 960u, 540u, 2u});
+  history.revision = 12u;
+  history.validForTemporalReuse = true;
+
+  const ScreenSpaceReflectionPassContract ssr = BuildScreenSpaceReflectionPassContract(
+      sceneTextures, history, TemporalQualityTier::Medium, true, ScreenSpaceReflectionMissPolicy::ProbeFallback);
+  const ScreenSpaceGlobalIlluminationPassContract ssgi = BuildScreenSpaceGlobalIlluminationPassContract(
+      sceneTextures, history, TemporalQualityTier::Medium, true);
+  const TemporalGiResolvePassContract resolve = BuildTemporalGiResolvePassContract(ssr, ssgi, history);
+  const LightingCompositePassContract composite = BuildLightingCompositePassContract(sceneTextures, resolve);
+  MeshDistanceFieldTracingStructure mesh{};
+  mesh.atlas = {RenderBackendId::Vulkan, 0x231u, 960u, 540u, 1u};
+  GlobalDistanceFieldTracingStructure global{};
+  global.volume = {RenderBackendId::Vulkan, 0x232u, 960u, 540u, 1u};
+  const SceneTracingRepresentationContract tracing = BuildSceneTracingRepresentationContract(
+      ssr, ssgi, resolve, mesh, global,
+      SceneTracingRepresentationOwnership::BackendOwnedPersistent,
+      SceneTracingRepresentationUpdatePolicy::PerFrameAndSceneBarrier,
+      true);
+  const CachedHitLightingRepresentationContract cached = BuildCachedHitLightingRepresentationContract(
+      tracing,
+      composite,
+      {RenderBackendId::Vulkan, 0x241u, 960u, 540u, 4u},
+      {RenderBackendId::Vulkan, 0x242u, 960u, 540u, 4u},
+      4u,
+      4096u,
+      3072u,
+      CachedHitLightingCapturePolicy::ScreenSpaceMissesAndDisocclusions,
+      CachedHitLightingUpdatePolicy::PerFrameBudgeted,
+      CachedHitLightingInvalidationReason::None,
+      true);
+  const RadianceCacheFinalGatherContract finalGather = BuildRadianceCacheFinalGatherContract(
+      cached, TemporalQualityTier::Medium, true);
+  const GiReflectionDebugVisualizationContract debug = BuildGiReflectionDebugVisualizationContract(
+      tracing, cached, finalGather, true);
+
+  REQUIRE(debug.validationStatus == GiReflectionDebugVisualizationValidationStatus::Valid);
+  REQUIRE(debug.IsAnyViewAvailable());
+  REQUIRE(debug.state.Supports(GiReflectionDebugView::SceneTracingCoverage));
+  REQUIRE(debug.state.Supports(GiReflectionDebugView::ReflectionHistory));
+  REQUIRE(debug.state.Supports(GiReflectionDebugView::RadianceCacheResidency));
+  REQUIRE(debug.state.Supports(GiReflectionDebugView::TemporalStability));
+  REQUIRE(debug.state.giCacheVisualizationReady);
+  REQUIRE(debug.state.reflectionVisualizationReady);
+  REQUIRE(debug.state.temporalBehaviorVisible);
+}
+
 TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
           "[renderer][foundation][abstractions]")
 {
@@ -1204,6 +1398,16 @@ TEST_CASE("Renderer forwards scene texture and GI history abstraction seams",
   REQUIRE((cachedHitLightingContract.state == CachedHitLightingRepresentationState::Warmup ||
            cachedHitLightingContract.state == CachedHitLightingRepresentationState::Ready ||
            cachedHitLightingContract.state == CachedHitLightingRepresentationState::Invalidated));
+  RadianceCacheFinalGatherContract finalGatherContract{};
+  REQUIRE(Renderer::TryGetRadianceCacheFinalGatherContract(&finalGatherContract, &error));
+  REQUIRE(finalGatherContract.validationStatus == RadianceCacheFinalGatherValidationStatus::Valid);
+  REQUIRE(finalGatherContract.UsesIntegrationPoint(
+      RadianceCacheFinalGatherIntegrationPoint::LightingComposite));
+  GiReflectionDebugVisualizationContract debugVisualization{};
+  REQUIRE(Renderer::TryGetGiReflectionDebugVisualizationContract(&debugVisualization, &error));
+  REQUIRE(debugVisualization.validationStatus ==
+          GiReflectionDebugVisualizationValidationStatus::Valid);
+  REQUIRE(debugVisualization.IsAnyViewAvailable());
   REQUIRE(Renderer::InvalidateGiHistory(GiHistoryResetReason::SceneBarrier, &error));
   REQUIRE(Renderer::TryGetGiHistoryCatalog(&giHistory, &error));
   REQUIRE(giHistory.lastResetReason == GiHistoryResetReason::SceneBarrier);


### PR DESCRIPTION
## Summary
Add radiance-cache final gather contracts, debug views, and tier/perf expectation models.

Closes #173
