### PR TITLE
feat(ci): add cross-platform UI video recording for macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,20 +164,21 @@ jobs:
       - name: Install Mesa3D (software OpenGL for headless CI)
         shell: pwsh
         run: |
-          # mesa-dist-win 24.x changed opengl32.dll to a 134 KB D3D12 stub —
-          # that requires hardware GPU / D3D12 WARP and hangs on CI runners.
-          # mesa-dist-win 21.x opengl32.dll is the full ~50 MB gallium/llvmpipe
-          # self-contained software renderer with no GPU requirement at all.
-          $ver = "21.3.7"
+          # mesa-dist-win 25.x: opengl32.dll stub → libgallium_wgl.dll (D3D12 backend).
+          # D3D12 WARP (Windows Advanced Rasterization Platform) is Microsoft's
+          # built-in pure-software D3D12 renderer — no GPU or driver required.
+          # DO NOT set GALLIUM_DRIVER=softpipe here; mesa 25.x WGL only has D3D12.
+          $ver = "25.3.6"
           $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
           Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
           7z x mesa3d.7z -omesa3d -y | Out-Null
-          Write-Host "=== mesa3d\x64 contents ==="
-          Get-ChildItem "mesa3d\x64" | Select-Object Name, Length | Format-Table
           $dest = "build\debug-msvc\bin\Debug"
-          Copy-Item "mesa3d\x64\*" $dest -Force
-          Write-Host "=== Mesa DLLs in exe dir ==="
-          Get-ChildItem "$dest\*.dll" | Select-Object Name | Format-Table
+          # Copy all x64 DLLs so transitive dependencies of libgallium_wgl.dll
+          # (e.g. spirv_to_dxil.dll for shader compilation) are available.
+          Copy-Item "mesa3d\x64\*.dll" $dest -Force
+          Write-Host "=== Mesa WGL DLLs installed (opengl32 + libgallium_wgl) ==="
+          Get-ChildItem "$dest\opengl32.dll", "$dest\libgallium_wgl.dll" |
+            Select-Object Name, Length | Format-Table
 
       - name: Run UI Automation
         shell: pwsh
@@ -214,8 +215,9 @@ jobs:
           MONOLITH_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
           MONOLITH_LOG_LEVEL: "debug"
           MONOLITH_GLFW_SAMPLES: "0"
-          GALLIUM_DRIVER: "softpipe"
+          # No GALLIUM_DRIVER — mesa 25.x WGL uses D3D12/WARP by default
           LIBGL_DEBUG: "verbose"
+          MESA_DEBUG: "1"
 
       - name: Setup tmate session
         if: failure() && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,11 @@ jobs:
       - name: Install Mesa3D (software OpenGL for headless CI)
         shell: pwsh
         run: |
-          # mesa-dist-win provides a software OpenGL 4.5 renderer.
-          # We copy ALL x64 DLLs next to the exe so that opengl32.dll can find
-          # its dependencies (libgallium_wgl.dll etc.).  Missing deps cause a
-          # blocking Windows Error Reporting dialog — the silent 10-min hang.
-          $ver = "24.3.3"
+          # mesa-dist-win 24.x changed opengl32.dll to a 134 KB D3D12 stub —
+          # that requires hardware GPU / D3D12 WARP and hangs on CI runners.
+          # mesa-dist-win 21.x opengl32.dll is the full ~50 MB gallium/llvmpipe
+          # self-contained software renderer with no GPU requirement at all.
+          $ver = "21.3.8"
           $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
           Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
           7z x mesa3d.7z -omesa3d -y | Out-Null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Run UI Automation
         shell: pwsh
         run: |
-          .\build\debug-msvc\Debug\HoroEditorUiTest.exe --run-ui-tests
+          .\build\debug-msvc\bin\Debug\HoroEditorUiTest.exe --run-ui-tests
         env:
           MONOLITH_UI_TEST_CAPTURE: "1"
           MONOLITH_UI_TEST_VIDEO: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Run UI Automation
         shell: pwsh
         run: |
-          build\debug-msvc\Debug\HoroEditorUiTest.exe --run-ui-tests
+          .\build\debug-msvc\Debug\HoroEditorUiTest.exe --run-ui-tests
         env:
           MONOLITH_UI_TEST_CAPTURE: "1"
           MONOLITH_UI_TEST_VIDEO: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   test-macos:
     name: Test · macOS / Clang
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +33,9 @@ jobs:
 
       - name: Install Ninja
         run: brew install ninja
+
+      - name: Install ffmpeg
+        run: brew install ffmpeg
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4
@@ -56,10 +60,48 @@ jobs:
         env:
           MONOLITH_LOG_LEVEL: "debug"
 
+      - name: Prepare UI test output directory
+        run: mkdir -p ui_test_output
+
+      - name: Build UI Automation Target
+        run: cmake --build --preset debug --target HoroEditorUiTest --parallel
+
+      - name: Resolve ffmpeg path
+        shell: bash
+        run: echo "FFMPEG_PATH=$(which ffmpeg)" >> $GITHUB_ENV
+
+      - name: Run UI Automation
+        shell: bash
+        run: |
+          build/debug/bin/HoroEditorUiTest --run-ui-tests
+        env:
+          MONOLITH_UI_TEST_CAPTURE: "1"
+          MONOLITH_UI_TEST_VIDEO: "1"
+          MONOLITH_UI_TEST_RECORDING: "1"
+          MONOLITH_UI_TEST_FILTER: "launcher/*"
+          MONOLITH_UI_TEST_DELAY_MS: "0"
+          MONOLITH_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
+          MONOLITH_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
+          MONOLITH_LOG_LEVEL: "debug"
+          MONOLITH_GLFW_SAMPLES: "0"
+
+      - name: Setup tmate session
+        if: failure() && github.event_name == 'workflow_dispatch'
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Upload UI Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results-macos
+          path: ui_test_output/
+          if-no-files-found: ignore
+          retention-days: 30
+
   test-windows:
     name: Test · Windows / MSVC
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
 
@@ -94,10 +136,6 @@ jobs:
         env:
           FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.cmake/fetchcontent
 
-      - name: Setup tmate session
-        if: failure() && github.event_name == 'workflow_dispatch'
-        uses: mxschmitt/action-tmate@v3
-
       - name: Build
         run: cmake --build build/debug-msvc --config Debug --parallel
 
@@ -105,6 +143,51 @@ jobs:
         run: ctest --test-dir build/debug-msvc -C Debug --output-on-failure --parallel
         env:
           MONOLITH_LOG_LEVEL: "debug"
+
+      - name: Install ffmpeg
+        run: choco install ffmpeg -y --no-progress
+        shell: pwsh
+
+      - name: Prepare UI test output directory
+        run: New-Item -ItemType Directory -Force -Path ui_test_output
+        shell: pwsh
+
+      - name: Build UI Automation Target
+        run: cmake --build build/debug-msvc --config Debug --target HoroEditorUiTest --parallel
+
+      - name: Resolve ffmpeg path
+        run: |
+          $ffmpeg = (Get-Command ffmpeg).Source
+          echo "FFMPEG_PATH=$ffmpeg" >> $env:GITHUB_ENV
+        shell: pwsh
+
+      - name: Run UI Automation
+        shell: pwsh
+        run: |
+          build\debug-msvc\Debug\HoroEditorUiTest.exe --run-ui-tests
+        env:
+          MONOLITH_UI_TEST_CAPTURE: "1"
+          MONOLITH_UI_TEST_VIDEO: "1"
+          MONOLITH_UI_TEST_RECORDING: "1"
+          MONOLITH_UI_TEST_FILTER: "launcher/*"
+          MONOLITH_UI_TEST_DELAY_MS: "0"
+          MONOLITH_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}\ui_test_output
+          MONOLITH_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
+          MONOLITH_LOG_LEVEL: "debug"
+          MONOLITH_GLFW_SAMPLES: "0"
+
+      - name: Setup tmate session
+        if: failure() && github.event_name == 'workflow_dispatch'
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Upload UI Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results-windows
+          path: ui_test_output\
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Show sccache stats
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           # that requires hardware GPU / D3D12 WARP and hangs on CI runners.
           # mesa-dist-win 21.x opengl32.dll is the full ~50 MB gallium/llvmpipe
           # self-contained software renderer with no GPU requirement at all.
-          $ver = "21.3.8"
+          $ver = "21.3.7"
           $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
           Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
           7z x mesa3d.7z -omesa3d -y | Out-Null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,22 @@ jobs:
           echo "FFMPEG_PATH=$ffmpeg" >> $env:GITHUB_ENV
         shell: pwsh
 
+      - name: Install Mesa3D (software OpenGL for headless CI)
+        shell: pwsh
+        run: |
+          # mesa-dist-win provides a software OpenGL 4.5 renderer (llvmpipe).
+          # Dropping opengl32.dll next to the exe overrides the system driver
+          # (Microsoft Basic Display Adapter supports only OpenGL 1.1) so that
+          # glfwCreateWindow can succeed without a hardware GPU.
+          $ver = "24.3.3"
+          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
+          Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
+          7z x mesa3d.7z -omesa3d -y | Out-Null
+          Copy-Item "mesa3d\x64\opengl32.dll" "build\debug-msvc\bin\Debug\opengl32.dll" -Force
+
       - name: Run UI Automation
         shell: pwsh
+        timeout-minutes: 10
         run: |
           .\build\debug-msvc\bin\Debug\HoroEditorUiTest.exe --run-ui-tests
         env:
@@ -175,6 +189,7 @@ jobs:
           MONOLITH_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
           MONOLITH_LOG_LEVEL: "debug"
           MONOLITH_GLFW_SAMPLES: "0"
+          GALLIUM_DRIVER: "llvmpipe"
 
       - name: Setup tmate session
         if: failure() && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,21 +164,46 @@ jobs:
       - name: Install Mesa3D (software OpenGL for headless CI)
         shell: pwsh
         run: |
-          # mesa-dist-win provides a software OpenGL 4.5 renderer (llvmpipe).
-          # Dropping opengl32.dll next to the exe overrides the system driver
-          # (Microsoft Basic Display Adapter supports only OpenGL 1.1) so that
-          # glfwCreateWindow can succeed without a hardware GPU.
+          # mesa-dist-win provides a software OpenGL 4.5 renderer.
+          # We copy ALL x64 DLLs next to the exe so that opengl32.dll can find
+          # its dependencies (libgallium_wgl.dll etc.).  Missing deps cause a
+          # blocking Windows Error Reporting dialog — the silent 10-min hang.
           $ver = "24.3.3"
           $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
           Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
           7z x mesa3d.7z -omesa3d -y | Out-Null
-          Copy-Item "mesa3d\x64\opengl32.dll" "build\debug-msvc\bin\Debug\opengl32.dll" -Force
+          Write-Host "=== mesa3d\x64 contents ==="
+          Get-ChildItem "mesa3d\x64" | Select-Object Name, Length | Format-Table
+          $dest = "build\debug-msvc\bin\Debug"
+          Copy-Item "mesa3d\x64\*" $dest -Force
+          Write-Host "=== Mesa DLLs in exe dir ==="
+          Get-ChildItem "$dest\*.dll" | Select-Object Name | Format-Table
 
       - name: Run UI Automation
         shell: pwsh
         timeout-minutes: 10
         run: |
-          .\build\debug-msvc\bin\Debug\HoroEditorUiTest.exe --run-ui-tests
+          # Redirect stdout/stderr to files so output survives a timeout kill.
+          # (PowerShell loses buffered child stdout when it kills by timeout.)
+          $out = "ui_test_output\stdout.txt"
+          $err = "ui_test_output\stderr.txt"
+          $proc = Start-Process `
+              -FilePath ".\build\debug-msvc\bin\Debug\HoroEditorUiTest.exe" `
+              -ArgumentList "--run-ui-tests" `
+              -NoNewWindow -PassThru `
+              -RedirectStandardOutput $out `
+              -RedirectStandardError  $err
+          Write-Host "HoroEditorUiTest PID=$($proc.Id) — waiting up to 8 min..."
+          $exited = $proc.WaitForExit(480000)
+          if (-not $exited) {
+              Write-Warning "Process did not exit — killing"
+              $proc.Kill()
+              Start-Sleep -Seconds 2
+          }
+          if (Test-Path $out) { Write-Host "=== stdout ==="; Get-Content $out }
+          if (Test-Path $err) { Write-Host "=== stderr ==="; Get-Content $err }
+          $code = if ($proc.HasExited) { $proc.ExitCode } else { -1 }
+          if ($code -ne 0) { Write-Error "HoroEditorUiTest exited $code"; exit 1 }
         env:
           MONOLITH_UI_TEST_CAPTURE: "1"
           MONOLITH_UI_TEST_VIDEO: "1"
@@ -189,7 +214,8 @@ jobs:
           MONOLITH_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
           MONOLITH_LOG_LEVEL: "debug"
           MONOLITH_GLFW_SAMPLES: "0"
-          GALLIUM_DRIVER: "llvmpipe"
+          GALLIUM_DRIVER: "softpipe"
+          LIBGL_DEBUG: "verbose"
 
       - name: Setup tmate session
         if: failure() && github.event_name == 'workflow_dispatch'

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -133,6 +133,11 @@ Window::Window(const WindowSpec& spec)
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #ifdef __APPLE__
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+    // Allow the system to fall back to a software (offline) renderer when no
+    // hardware-accelerated OpenGL is available, e.g. on headless CI runners.
+    // NSOpenGLPFAAllowOfflineRenderers is set via this hint; the GPU is still
+    // preferred when present.
+    glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, GLFW_TRUE);
 #endif
   } else {
     // Vulkan path: no client graphics context should be created by GLFW.

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -13,6 +13,52 @@ if(NOT TARGET glfw)
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_INSTALL        OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(glfw)
+
+    # ---- macOS: patch nsgl_context.m so hardware acceleration is not required
+    #      when GLFW_COCOA_GRAPHICS_SWITCHING is enabled.
+    #
+    # By default GLFW unconditionally adds NSOpenGLPFAAccelerated to the pixel
+    # format attribute list, which requires a hardware-backed renderer.  On
+    # headless CI runners (GitHub Actions macOS) there is no display connection
+    # that satisfies NSOpenGL's hardware requirement, causing glfwCreateWindow
+    # to throw "NSGL: Failed to find a suitable pixel format".
+    #
+    # GLFW already gates NSOpenGLPFAAllowOfflineRenderers on ctxconfig->nsgl.offline
+    # (set via GLFW_COCOA_GRAPHICS_SWITCHING = GLFW_TRUE).  We extend that guard to
+    # also skip NSOpenGLPFAAccelerated in offline mode so any available renderer
+    # (hardware or software) is accepted.  Hardware is still preferred on machines
+    # that expose a GPU; this only adds a fallback path.
+    if(APPLE)
+        set(_glfw_nsgl "${glfw_SOURCE_DIR}/src/nsgl_context.m")
+        if(EXISTS "${_glfw_nsgl}")
+            execute_process(
+                COMMAND python3 -c
+                    "import sys\n\
+path = sys.argv[1]\n\
+with open(path) as f:\n\
+    src = f.read()\n\
+old = '    ADD_ATTRIB(NSOpenGLPFAAccelerated);'\n\
+new = '    if (!ctxconfig->nsgl.offline)\\n        ADD_ATTRIB(NSOpenGLPFAAccelerated);'\n\
+patched = src.replace(old, new, 1)\n\
+if patched != src:\n\
+    with open(path, 'w') as f:\n\
+        f.write(patched)\n\
+    print('GLFW nsgl_context.m: patched NSOpenGLPFAAccelerated guard')\n\
+else:\n\
+    print('GLFW nsgl_context.m: already patched or pattern not found')"
+                    "${_glfw_nsgl}"
+                OUTPUT_VARIABLE _glfw_patch_out
+                ERROR_VARIABLE  _glfw_patch_err
+                RESULT_VARIABLE _glfw_patch_result
+            )
+            if(_glfw_patch_result EQUAL 0)
+                message(STATUS "${_glfw_patch_out}")
+            else()
+                message(WARNING "GLFW nsgl patch failed: ${_glfw_patch_err}")
+            endif()
+        endif()
+    endif()
+
     target_include_directories(glfw PUBLIC
         $<BUILD_INTERFACE:${glfw_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/vendor/glfw>


### PR DESCRIPTION
- macOS: resolve ffmpeg via which, run HoroEditorUiTest with avfoundation-capable ffmpeg
- Windows: install ffmpeg via choco, run HoroEditorUiTest via pwsh, resolve path via Get-Command
- Both platforms: upload ui_test_output/ artifacts unconditionally
- Increase Windows timeout to 45 min; add macOS timeout of 30 min

## Summary
- What problem does this PR solve?
- What changed at a high level?

## Motivation
- Why was this change needed?

## Implementation Notes
- Key design choices
- Important tradeoffs
- Intentionally deferred work

## Validation
- [ ] Build passed
- [ ] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
# exact commands
```

## Risks
- Regressions to watch for
- Areas not fully validated

## Issue Links
Closes #

## Reviewer Notes
- Best review order
- Non-obvious files or behaviors
