### PR TITLE
feat(scripts): add run-editor and run-play subcommands for submodule use

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -1,0 +1,439 @@
+name: UI Automation
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 hours
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  actions: read            # needed to query previous workflow runs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── 1. Detect commits since the last successful run ──────────────────────
+  report-commits:
+    name: Commits since last run
+    runs-on: ubuntu-latest
+    outputs:
+      commit_list: ${{ steps.commits.outputs.commit_list }}
+      since_sha:   ${{ steps.commits.outputs.since_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find commits since last successful run
+        id: commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find the SHA of the last successful UI Automation run on this branch
+          LAST_SHA=$(
+            gh run list \
+              --workflow ci-ui.yml \
+              --branch main \
+              --status success \
+              --limit 1 \
+              --json headSha \
+              --jq '.[0].headSha // ""'
+          )
+
+          if [ -z "$LAST_SHA" ]; then
+            echo "No previous successful run found — showing last 10 commits."
+            COMMITS=$(git log --oneline -10)
+            LAST_SHA="$(git rev-list --max-parents=0 HEAD)"
+          else
+            echo "Last successful run was at: $LAST_SHA"
+            COMMITS=$(git log --oneline "${LAST_SHA}..HEAD" 2>/dev/null || git log --oneline -10)
+          fi
+
+          # Escape newlines for GITHUB_OUTPUT multiline value
+          COMMITS_ESCAPED="${COMMITS//$'\n'/'%0A'}"
+          echo "commit_list=$COMMITS_ESCAPED" >> "$GITHUB_OUTPUT"
+          echo "since_sha=$LAST_SHA"          >> "$GITHUB_OUTPUT"
+
+          echo "### Commits to test" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "$COMMITS" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  # ── 2a. Build — Linux ────────────────────────────────────────────────────
+  build-linux:
+    name: Build · Linux / GCC
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    needs: report-commits
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ui-build-linux
+
+      - name: Install system dependencies
+        run: |
+          if ! sudo apt-get update; then
+            sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build \
+            xvfb \
+            ffmpeg \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxext-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cmake/fetchcontent
+          key: fetchcontent-ui-linux-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-ui-linux-
+
+      - name: Configure
+        run: >
+          cmake --preset debug
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        env:
+          FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.cmake/fetchcontent
+
+      - name: Build UI Automation Target
+        run: cmake --build --preset debug --target HoroEditorUiTest --parallel
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-binary-linux
+          path: |
+            build/debug/bin/HoroEditorUiTest
+          retention-days: 1
+
+  # ── 2b. Build — macOS ────────────────────────────────────────────────────
+  build-macos:
+    name: Build · macOS / Clang
+    runs-on: macos-latest
+    timeout-minutes: 25
+    needs: report-commits
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: ui-build-macos
+
+      - name: Install ffmpeg
+        run: brew install ffmpeg ninja
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cmake/fetchcontent
+          key: fetchcontent-ui-macos-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-ui-macos-
+
+      - name: Configure
+        run: >
+          cmake --preset debug
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        env:
+          FETCHCONTENT_BASE_DIR: ~/.cmake/fetchcontent
+
+      - name: Build UI Automation Target
+        run: cmake --build --preset debug --target HoroEditorUiTest --parallel
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-binary-macos
+          path: |
+            build/debug/bin/HoroEditorUiTest
+          retention-days: 1
+
+  # ── 2c. Build — Windows ──────────────────────────────────────────────────
+  build-windows:
+    name: Build · Windows / MSVC
+    runs-on: windows-latest
+    timeout-minutes: 30
+    needs: report-commits
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-ui-windows-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: sccache-ui-windows-
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cmake/fetchcontent
+          key: fetchcontent-ui-windows-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-ui-windows-
+
+      - name: Configure
+        run: >
+          cmake --preset debug-msvc
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_EXE_LINKER_FLAGS_DEBUG=/DEBUG:FASTLINK
+          -DCMAKE_SHARED_LINKER_FLAGS_DEBUG=/DEBUG:FASTLINK
+          -DCMAKE_MODULE_LINKER_FLAGS_DEBUG=/DEBUG:FASTLINK
+        env:
+          FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.cmake/fetchcontent
+
+      - name: Build UI Automation Target
+        run: cmake --build build/debug-msvc --config Debug --target HoroEditorUiTest --parallel
+
+      - name: Install Mesa3D (software OpenGL for headless CI)
+        shell: pwsh
+        run: |
+          $ver = "25.3.6"
+          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
+          Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
+          7z x mesa3d.7z -omesa3d -y | Out-Null
+          $dest = "build\debug-msvc\bin\Debug"
+          Copy-Item "mesa3d\x64\*.dll" $dest -Force
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-binary-windows
+          path: |
+            build/debug-msvc/bin/Debug/HoroEditorUiTest.exe
+            build/debug-msvc/bin/Debug/*.dll
+          retention-days: 1
+
+  # ── 3a. UI suites — Linux ─────────────────────────────────────────────────
+  ui-linux:
+    name: "UI · Linux / ${{ matrix.suite }}"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: build-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - launcher-basic
+          - properties-workflows
+          - mcp-project
+          - modals-mcp
+          - properties-close
+    steps:
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            xvfb ffmpeg \
+            libwayland-dev libxkbcommon-dev \
+            libx11-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxi-dev libxext-dev \
+            libgl1-mesa-dev libglu1-mesa-dev
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-binary-linux
+          path: bin
+
+      - name: Make binary executable
+        run: chmod +x bin/HoroEditorUiTest
+
+      - name: Run suite
+        run: |
+          mkdir -p ui_test_output
+          xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
+            bin/HoroEditorUiTest --run-ui-tests
+        env:
+          HORO_UI_TEST_SUITE: ${{ matrix.suite }}
+          HORO_UI_TEST_CAPTURE: "1"
+          HORO_UI_TEST_VIDEO: "1"
+          HORO_UI_TEST_RECORDING: "1"
+          HORO_UI_TEST_DELAY_MS: "0"
+          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
+          HORO_UI_TEST_FFMPEG_PATH: "/usr/bin/ffmpeg"
+          HORO_LOG_LEVEL: "debug"
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          GALLIUM_DRIVER: "llvmpipe"
+          HORO_GLFW_SAMPLES: "0"
+
+      - name: Upload suite artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-results-linux-${{ matrix.suite }}
+          path: ui_test_output/
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ── 3b. UI suites — macOS ─────────────────────────────────────────────────
+  ui-macos:
+    name: "UI · macOS / ${{ matrix.suite }}"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    needs: build-macos
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - launcher-basic
+          - properties-workflows
+          - mcp-project
+          - modals-mcp
+          - properties-close
+    steps:
+      - name: Install ffmpeg
+        run: brew install ffmpeg
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-binary-macos
+          path: bin
+
+      - name: Make binary executable
+        run: chmod +x bin/HoroEditorUiTest
+
+      - name: Run suite
+        run: |
+          mkdir -p ui_test_output
+          bin/HoroEditorUiTest --run-ui-tests
+        env:
+          HORO_UI_TEST_SUITE: ${{ matrix.suite }}
+          HORO_UI_TEST_CAPTURE: "1"
+          HORO_UI_TEST_VIDEO: "1"
+          HORO_UI_TEST_RECORDING: "1"
+          HORO_UI_TEST_DELAY_MS: "0"
+          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
+          HORO_UI_TEST_FFMPEG_PATH: ${{ steps.ffmpeg.outputs.path }}
+          HORO_LOG_LEVEL: "debug"
+          HORO_GLFW_SAMPLES: "0"
+
+      - name: Upload suite artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-results-macos-${{ matrix.suite }}
+          path: ui_test_output/
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ── 3c. UI suites — Windows ───────────────────────────────────────────────
+  ui-windows:
+    name: "UI · Windows / ${{ matrix.suite }}"
+    runs-on: windows-latest
+    timeout-minutes: 15
+    needs: build-windows
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - launcher-basic
+          - properties-workflows
+          - mcp-project
+          - modals-mcp
+          - properties-close
+    steps:
+      - name: Install ffmpeg
+        run: choco install ffmpeg -y --no-progress
+        shell: pwsh
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-binary-windows
+          path: bin
+
+      - name: Run suite
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ui_test_output | Out-Null
+          .\bin\HoroEditorUiTest.exe --run-ui-tests
+          exit $LASTEXITCODE
+        env:
+          HORO_UI_TEST_SUITE: ${{ matrix.suite }}
+          HORO_UI_TEST_CAPTURE: "1"
+          HORO_UI_TEST_VIDEO: "1"
+          HORO_UI_TEST_RECORDING: "1"
+          HORO_UI_TEST_DELAY_MS: "0"
+          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}\ui_test_output
+          HORO_LOG_LEVEL: "debug"
+          HORO_GLFW_SAMPLES: "0"
+          LIBGL_DEBUG: "verbose"
+          MESA_DEBUG: "1"
+
+      - name: Upload suite artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-results-windows-${{ matrix.suite }}
+          path: ui_test_output\
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ── 4. Summary ─────────────────────────────────────────────────────────────
+  summary:
+    name: UI Test Summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - report-commits
+      - ui-linux
+      - ui-macos
+      - ui-windows
+    steps:
+      - name: Write summary
+        env:
+          COMMIT_LIST: ${{ needs.report-commits.outputs.commit_list }}
+          RESULT_LINUX:   ${{ needs.ui-linux.result }}
+          RESULT_MACOS:   ${{ needs.ui-macos.result }}
+          RESULT_WINDOWS: ${{ needs.ui-windows.result }}
+        run: |
+          icon() { [ "$1" = "success" ] && echo "✅" || echo "❌"; }
+
+          {
+            echo "## UI Automation — $(date -u '+%Y-%m-%d %H:%M UTC')"
+            echo ""
+            echo "### Commits tested"
+            echo '```'
+            echo "${COMMIT_LIST//%0A/$'\n'}"
+            echo '```'
+            echo ""
+            echo "### Platform results"
+            echo ""
+            echo "| Platform | Result |"
+            echo "|----------|--------|"
+            echo "| Linux / GCC   | $(icon "$RESULT_LINUX") $RESULT_LINUX |"
+            echo "| macOS / Clang | $(icon "$RESULT_MACOS") $RESULT_MACOS |"
+            echo "| Windows / MSVC | $(icon "$RESULT_WINDOWS") $RESULT_WINDOWS |"
+            echo ""
+            echo "> Artifacts: per-suite videos and screenshots are attached to this run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -321,6 +321,9 @@ jobs:
       - name: Make binary executable
         run: chmod +x bin/HoroEditorUiTest
 
+      - name: Resolve ffmpeg path
+        run: echo "FFMPEG_PATH=$(which ffmpeg)" >> "$GITHUB_ENV"
+
       - name: Run suite
         run: |
           mkdir -p ui_test_output
@@ -332,7 +335,7 @@ jobs:
           HORO_UI_TEST_RECORDING: "1"
           HORO_UI_TEST_DELAY_MS: "0"
           HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
-          HORO_UI_TEST_FFMPEG_PATH: ${{ steps.ffmpeg.outputs.path }}
+          HORO_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
           HORO_LOG_LEVEL: "debug"
           HORO_GLFW_SAMPLES: "0"
 
@@ -371,6 +374,12 @@ jobs:
           name: ui-binary-windows
           path: bin
 
+      - name: Resolve ffmpeg path
+        shell: pwsh
+        run: |
+          $ffmpeg = (Get-Command ffmpeg).Source
+          echo "FFMPEG_PATH=$ffmpeg" >> $env:GITHUB_ENV
+
       - name: Run suite
         shell: pwsh
         run: |
@@ -384,6 +393,7 @@ jobs:
           HORO_UI_TEST_RECORDING: "1"
           HORO_UI_TEST_DELAY_MS: "0"
           HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}\ui_test_output
+          HORO_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
           HORO_LOG_LEVEL: "debug"
           HORO_GLFW_SAMPLES: "0"
           LIBGL_DEBUG: "verbose"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   test-macos:
     name: Test · macOS / Clang
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -42,9 +42,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ github.job }}-${{ runner.os }}
-
-      - name: Install ffmpeg
-        run: brew install ffmpeg
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4
@@ -98,56 +95,14 @@ jobs:
           path: build/debug/test-results/
           retention-days: 14
 
-      - name: Prepare UI test output directory
-        run: mkdir -p ui_test_output
-
-      - name: Build UI Automation Target
-        run: cmake --build --preset debug --target HoroEditorUiTest --parallel
-
-      - name: Resolve ffmpeg path
-        shell: bash
-        run: echo "FFMPEG_PATH=$(which ffmpeg)" >> $GITHUB_ENV
-
-      - name: Run UI Automation
-        shell: bash
-        run: |
-          set -euo pipefail
-          suites=(launcher-basic properties-workflows mcp-project modals-mcp properties-close)
-          for suite in "${suites[@]}"; do
-            echo "::group::UI test suite ${suite}"
-            mkdir -p "ui_test_output/${suite}"
-            HORO_UI_TEST_SUITE="${suite}" \
-              HORO_UI_TEST_OUTPUT_DIR="${{ github.workspace }}/ui_test_output/${suite}" \
-              build/debug/bin/HoroEditorUiTest --run-ui-tests
-            echo "::endgroup::"
-          done
-        env:
-          HORO_UI_TEST_CAPTURE: "1"
-          HORO_UI_TEST_VIDEO: "1"
-          HORO_UI_TEST_RECORDING: "1"
-          HORO_UI_TEST_DELAY_MS: "0"
-          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
-          HORO_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
-          HORO_LOG_LEVEL: "debug"
-          HORO_GLFW_SAMPLES: "0"
-
       - name: Setup tmate session
         if: failure() && github.event_name == 'workflow_dispatch'
         uses: mxschmitt/action-tmate@v3
 
-      - name: Upload UI Test Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-test-results-macos
-          path: ui_test_output/
-          if-no-files-found: ignore
-          retention-days: 30
-
   test-windows:
     name: Test · Windows / MSVC
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     env:
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
 
@@ -220,88 +175,9 @@ jobs:
           path: build/debug-msvc/test-results/
           retention-days: 14
 
-      - name: Install ffmpeg
-        run: choco install ffmpeg -y --no-progress
-        shell: pwsh
-
-      - name: Prepare UI test output directory
-        run: New-Item -ItemType Directory -Force -Path ui_test_output
-        shell: pwsh
-
-      - name: Build UI Automation Target
-        run: cmake --build build/debug-msvc --config Debug --target HoroEditorUiTest --parallel
-
-      - name: Resolve ffmpeg path
-        run: |
-          $ffmpeg = (Get-Command ffmpeg).Source
-          echo "FFMPEG_PATH=$ffmpeg" >> $env:GITHUB_ENV
-        shell: pwsh
-
-      - name: Install Mesa3D (software OpenGL for headless CI)
-        shell: pwsh
-        run: |
-          # mesa-dist-win 25.x: opengl32.dll stub → libgallium_wgl.dll (D3D12 backend).
-          # D3D12 WARP (Windows Advanced Rasterization Platform) is Microsoft's
-          # built-in pure-software D3D12 renderer — no GPU or driver required.
-          # DO NOT set GALLIUM_DRIVER=softpipe here; mesa 25.x WGL only has D3D12.
-          $ver = "25.3.6"
-          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
-          Invoke-WebRequest -Uri $url -OutFile mesa3d.7z -UseBasicParsing
-          7z x mesa3d.7z -omesa3d -y | Out-Null
-          $dest = "build\debug-msvc\bin\Debug"
-          # Copy all x64 DLLs so transitive dependencies of libgallium_wgl.dll
-          # (e.g. spirv_to_dxil.dll for shader compilation) are available.
-          Copy-Item "mesa3d\x64\*.dll" $dest -Force
-          Write-Host "=== Mesa WGL DLLs installed (opengl32 + libgallium_wgl) ==="
-          Get-ChildItem "$dest\opengl32.dll", "$dest\libgallium_wgl.dll" |
-            Select-Object Name, Length | Format-Table
-
-      - name: Run UI Automation
-        shell: pwsh
-        timeout-minutes: 20
-        run: |
-          $suites = @(
-            "launcher-basic",
-            "properties-workflows",
-            "mcp-project",
-            "modals-mcp",
-            "properties-close"
-          )
-          foreach ($suite in $suites) {
-            Write-Host "::group::UI test suite $suite"
-            $env:HORO_UI_TEST_SUITE = $suite
-            $env:HORO_UI_TEST_OUTPUT_DIR = "${{ github.workspace }}\ui_test_output\$suite"
-            New-Item -ItemType Directory -Force -Path $env:HORO_UI_TEST_OUTPUT_DIR | Out-Null
-            .\build\debug-msvc\bin\Debug\HoroEditorUiTest.exe --run-ui-tests
-            $code = $LASTEXITCODE
-            Write-Host "::endgroup::"
-            if ($code -ne 0) { exit $code }
-          }
-        env:
-          HORO_UI_TEST_CAPTURE: "1"
-          HORO_UI_TEST_VIDEO: "1"
-          HORO_UI_TEST_RECORDING: "1"
-          HORO_UI_TEST_DELAY_MS: "0"
-          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}\ui_test_output
-          HORO_UI_TEST_FFMPEG_PATH: ${{ env.FFMPEG_PATH }}
-          HORO_LOG_LEVEL: "debug"
-          HORO_GLFW_SAMPLES: "0"
-          # No GALLIUM_DRIVER — mesa 25.x WGL uses D3D12/WARP by default
-          LIBGL_DEBUG: "verbose"
-          MESA_DEBUG: "1"
-
       - name: Setup tmate session
         if: failure() && github.event_name == 'workflow_dispatch'
         uses: mxschmitt/action-tmate@v3
-
-      - name: Upload UI Test Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-test-results-windows
-          path: ui_test_output\
-          if-no-files-found: ignore
-          retention-days: 30
 
       - name: Show sccache stats
         if: always()
@@ -310,7 +186,7 @@ jobs:
   test-linux:
     name: Test · Linux / GCC
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 25
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       BUILD_WRAPPER_OUT_DIR: bw-output
@@ -333,8 +209,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             ninja-build \
             gcovr \
-            xvfb \
-            ffmpeg \
             libwayland-dev \
             wayland-protocols \
             libxkbcommon-dev \
@@ -402,53 +276,9 @@ jobs:
           path: build/debug/test-results/
           retention-days: 14
 
-      - name: Prepare UI test output directory
-        run: mkdir -p ui_test_output
-
-      - name: Build UI Automation Target
-        run: cmake --build --preset debug --target HoroEditorUiTest --parallel
-
-      - name: Run UI Automation
-        run: |
-          set -euo pipefail
-          suites=(launcher-basic properties-workflows mcp-project modals-mcp properties-close)
-          status=0
-          for suite in "${suites[@]}"; do
-            echo "::group::UI test suite ${suite}"
-            mkdir -p "ui_test_output/${suite}"
-            if ! HORO_UI_TEST_SUITE="${suite}" \
-              HORO_UI_TEST_OUTPUT_DIR="${{ github.workspace }}/ui_test_output/${suite}" \
-              xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-                build/debug/bin/HoroEditorUiTest --run-ui-tests; then
-              status=1
-            fi
-            echo "::endgroup::"
-          done
-          exit "${status}"
-        env:
-          HORO_UI_TEST_CAPTURE: "1"
-          HORO_UI_TEST_VIDEO: "1"
-          HORO_UI_TEST_RECORDING: "1"
-          HORO_UI_TEST_DELAY_MS: "0"
-          HORO_UI_TEST_OUTPUT_DIR: ${{ github.workspace }}/ui_test_output
-          HORO_UI_TEST_FFMPEG_PATH: "/usr/bin/ffmpeg"
-          HORO_LOG_LEVEL: "debug"
-          LIBGL_ALWAYS_SOFTWARE: "1"
-          GALLIUM_DRIVER: "llvmpipe"
-          HORO_GLFW_SAMPLES: "0"
-
       - name: Setup tmate session on failure
         if: failure() && github.event_name == 'workflow_dispatch'
         uses: mxschmitt/action-tmate@v3
-
-      - name: Upload UI Test Artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-test-results-linux
-          path: ui_test_output/
-          if-no-files-found: ignore
-          retention-days: 30
 
       - name: Install Build Wrapper
         if: ${{ env.SONAR_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -235,6 +235,33 @@ def cmd_coverage_source_summary(_: argparse.Namespace) -> int:
         cwd=REPO_ROOT,
     )
 
+def _starter_binary(config_name: str) -> Path:
+    """Resolves the starter app binary when engine is used as a submodule.
+
+    Assumes this script lives at <starter_root>/engine/scripts/dev.py,
+    so REPO_ROOT.parent == starter_root.
+    """
+    suffix = ".exe" if IS_WINDOWS else ""
+    return REPO_ROOT.parent / "build" / config_name / "bin" / f"HoroStarterApp{suffix}"
+
+def cmd_run_editor(args: argparse.Namespace) -> int:
+    config = args.config if args.config else _preset_debug()
+    binary = _starter_binary(config)
+    if not binary.exists():
+        print(f"Binary not found: {binary}", file=sys.stderr)
+        print("Build first: make build CONFIG=" + config, file=sys.stderr)
+        return 1
+    return _run([binary, "--editor"])
+
+def cmd_run_play(args: argparse.Namespace) -> int:
+    config = args.config if args.config else _preset_debug()
+    binary = _starter_binary(config)
+    if not binary.exists():
+        print(f"Binary not found: {binary}", file=sys.stderr)
+        print("Build first: make build CONFIG=" + config, file=sys.stderr)
+        return 1
+    return _run([binary, "--play"])
+
 def cmd_clean(_: argparse.Namespace) -> int:
     return _run(["cmake", "-E", "rm", "-rf", _build_dir(_preset_debug())], cwd=REPO_ROOT)
 
@@ -286,11 +313,16 @@ UI automation vars:
         "clean-all": (cmd_clean_all, "Remove all build dirs"),
         "format": (cmd_format, "Format all tracked C++ sources"),
         "format-check": (cmd_format_check, "Check formatting"),
+        "run-editor": (cmd_run_editor, "Run starter app in editor mode (submodule use)"),
+        "run-play": (cmd_run_play, "Run starter app in play mode (submodule use)"),
     }
 
     for name, (func, help_text) in commands.items():
         p = sub.add_parser(name, help=help_text)
         p.set_defaults(func=func)
+        if name in ("run-editor", "run-play"):
+            p.add_argument("--config", default=None,
+                           help="Build config name (default: debug / debug-msvc on Windows)")
 
     # Automatically print help if no arguments are provided
     if len(sys.argv) == 1:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -240,9 +240,13 @@ def _starter_binary(config_name: str) -> Path:
 
     Assumes this script lives at <starter_root>/engine/scripts/dev.py,
     so REPO_ROOT.parent == starter_root.
+
+    On Windows (MSVC multi-config), CMake places the binary under bin/Debug/
+    or bin/Release/ rather than directly under bin/.
     """
     suffix = ".exe" if IS_WINDOWS else ""
-    return REPO_ROOT.parent / "build" / config_name / "bin" / f"HoroStarterApp{suffix}"
+    msvc_subdir = "Debug" if IS_WINDOWS else ""
+    return REPO_ROOT.parent / "build" / config_name / "bin" / msvc_subdir / f"HoroStarterApp{suffix}"
 
 def cmd_run_editor(args: argparse.Namespace) -> int:
     config = args.config if args.config else _preset_debug()


### PR DESCRIPTION
## Summary

When `horo-engine` is used as a git submodule inside a starter/game project, these new commands in `scripts/dev.py` let the starter's `Makefile` launch the built binary directly without needing a separate launcher script in the starter repo.

## Changes

- Added `_starter_binary(config_name)` helper — resolves `REPO_ROOT.parent/build/<config>/bin/HoroStarterApp`
- Added `cmd_run_editor` — launches starter binary with `--editor`
- Added `cmd_run_play` — launches starter binary with `--play`
- Both commands accept `--config` argument (default: `debug`, auto-detects `debug-msvc` on Windows)

## Usage (from starter Makefile)

```bash
python3 engine/scripts/dev.py run-editor --config debug
python3 engine/scripts/dev.py run-play   --config debug
```

## Context

Related change in [horo-engine-starter](https://github.com/abdullahbodur/horo-engine-starter): the starter `Makefile` now auto-detects whether the engine submodule is present and delegates to this script, or falls back to a locally installed `HoroEngine` IDE binary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `run-editor` and `run-play` to `scripts/dev.py` so starters using the engine as a submodule can launch the starter app directly. Move UI automation to a scheduled `ci-ui.yml` workflow and trim `ci.yml` to speed up main CI.

- **New Features**
  - `_starter_binary(config)` resolves `REPO_ROOT.parent/build/<config>/bin/` (Windows MSVC adds `Debug/`) to find `HoroStarterApp[.exe]`.
  - `run-editor` runs the starter with `--editor`; `run-play` runs with `--play`.
  - Both accept `--config` (default: `debug`; auto-detects `debug-msvc` on Windows).

- **Bug Fixes**
  - In `ci-ui.yml`, resolve `ffmpeg` path on macOS and Windows to set `HORO_UI_TEST_FFMPEG_PATH` correctly for UI recording.

<sup>Written for commit b57b506e670fdd6423f4f1dfd7ae4c378c4fe083. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

