### PR TITLE
ci: customize release-please and add binary release workflow

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -11,14 +11,13 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
-  actions: read            # needed to query previous workflow runs
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # ── 1. Detect commits since the last successful run ──────────────────────
   report-commits:
     name: Commits since last run
     runs-on: ubuntu-latest
@@ -65,7 +64,6 @@ jobs:
           echo "$COMMITS" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-  # ── 2a. Build — Linux ────────────────────────────────────────────────────
   build-linux:
     name: Build · Linux / GCC
     runs-on: ubuntu-24.04
@@ -127,7 +125,6 @@ jobs:
             build/debug/bin/HoroEditorUiTest
           retention-days: 1
 
-  # ── 2b. Build — macOS ────────────────────────────────────────────────────
   build-macos:
     name: Build · macOS / Clang
     runs-on: macos-latest

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,188 @@
+name: Release Binaries
+
+# Triggered automatically when release-please merges a release PR and
+# publishes a GitHub Release. Builds HoroEditor for all platforms and
+# uploads the archives to the release assets.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to upload binaries to (e.g. HoroEngine-v0.2.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write   # needed to upload release assets
+
+jobs:
+  # ── Linux ─────────────────────────────────────────────────────────────────
+  build-linux:
+    name: Build · Linux / GCC
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: release-linux
+
+      - name: Install system dependencies
+        run: |
+          if ! sudo apt-get update; then
+            sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build \
+            libwayland-dev wayland-protocols libxkbcommon-dev \
+            libx11-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxi-dev libxext-dev \
+            libgl1-mesa-dev libglu1-mesa-dev
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cmake/fetchcontent
+          key: fetchcontent-release-linux-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-release-linux-
+
+      - name: Configure
+        run: >
+          cmake --preset release
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        env:
+          FETCHCONTENT_BASE_DIR: ~/.cmake/fetchcontent
+
+      - name: Build HoroEditor
+        run: cmake --build --preset release --target HoroEditor --parallel
+
+      - name: Package
+        run: |
+          DIST=HoroEngine-linux-x86_64
+          mkdir -p "$DIST"
+          cp build/release/bin/HoroEditor "$DIST/"
+          cp -r build/release/sdk "$DIST/" 2>/dev/null || true
+          tar -czf "${DIST}.tar.gz" "$DIST"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=${{ github.event.release.tag_name || inputs.tag }}
+          gh release upload "$TAG" HoroEngine-linux-x86_64.tar.gz --clobber
+
+  # ── macOS ─────────────────────────────────────────────────────────────────
+  build-macos:
+    name: Build · macOS / Clang
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2.22
+        with:
+          key: release-macos
+
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cmake/fetchcontent
+          key: fetchcontent-release-macos-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-release-macos-
+
+      - name: Configure
+        run: >
+          cmake --preset release
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        env:
+          FETCHCONTENT_BASE_DIR: ~/.cmake/fetchcontent
+
+      - name: Build HoroEditor
+        run: cmake --build --preset release --target HoroEditor --parallel
+
+      - name: Package
+        run: |
+          DIST=HoroEngine-macos-universal
+          mkdir -p "$DIST"
+          cp build/release/bin/HoroEditor "$DIST/"
+          cp -r build/release/sdk "$DIST/" 2>/dev/null || true
+          tar -czf "${DIST}.tar.gz" "$DIST"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=${{ github.event.release.tag_name || inputs.tag }}
+          gh release upload "$TAG" HoroEngine-macos-universal.tar.gz --clobber
+
+  # ── Windows ───────────────────────────────────────────────────────────────
+  build-windows:
+    name: Build · Windows / MSVC
+    runs-on: windows-latest
+    timeout-minutes: 35
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-release-windows-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: sccache-release-windows-
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cmake/fetchcontent
+          key: fetchcontent-release-windows-${{ hashFiles('**/CMakeLists.txt', '**/CMakePresets.json') }}
+          restore-keys: fetchcontent-release-windows-
+
+      - name: Configure
+        run: >
+          cmake --preset release-msvc
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        env:
+          FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.cmake/fetchcontent
+
+      - name: Build HoroEditor
+        run: cmake --build build/release-msvc --config Release --target HoroEditor --parallel
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $dist = "HoroEngine-windows-x64"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          Copy-Item "build\release-msvc\bin\Release\HoroEditor.exe" $dist
+          if (Test-Path "build\release-msvc\sdk") {
+            Copy-Item -Recurse "build\release-msvc\sdk" "$dist\sdk"
+          }
+          Compress-Archive -Path "$dist\*" -DestinationPath "${dist}.zip"
+
+      - name: Upload to release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.event.release.tag_name }}"
+          if (-not $tag) { $tag = "${{ inputs.tag }}" }
+          gh release upload $tag HoroEngine-windows-x64.zip --clobber
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,8 +1,5 @@
 name: Release Binaries
 
-# Triggered automatically when release-please merges a release PR and
-# publishes a GitHub Release. Builds HoroEditor for all platforms and
-# uploads the archives to the release assets.
 on:
   release:
     types: [published]
@@ -14,10 +11,9 @@ on:
         type: string
 
 permissions:
-  contents: write   # needed to upload release assets
+  contents: write
 
 jobs:
-  # ── Linux ─────────────────────────────────────────────────────────────────
   build-linux:
     name: Build · Linux / GCC
     runs-on: ubuntu-24.04
@@ -76,7 +72,6 @@ jobs:
           TAG=${{ github.event.release.tag_name || inputs.tag }}
           gh release upload "$TAG" HoroEngine-linux-x86_64.tar.gz --clobber
 
-  # ── macOS ─────────────────────────────────────────────────────────────────
   build-macos:
     name: Build · macOS / Clang
     runs-on: macos-latest
@@ -125,7 +120,6 @@ jobs:
           TAG=${{ github.event.release.tag_name || inputs.tag }}
           gh release upload "$TAG" HoroEngine-macos-universal.tar.gz --clobber
 
-  # ── Windows ───────────────────────────────────────────────────────────────
   build-windows:
     name: Build · Windows / MSVC
     runs-on: windows-latest

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          TAG=${{ github.event.release.tag_name || inputs.tag }}
-          gh release upload "$TAG" HoroEngine-linux-x86_64.tar.gz --clobber
+          gh release upload "$RELEASE_TAG" HoroEngine-linux-x86_64.tar.gz --clobber
 
   build-macos:
     name: Build · macOS / Clang
@@ -107,7 +107,7 @@ jobs:
 
       - name: Package
         run: |
-          DIST=HoroEngine-macos-universal
+          DIST=HoroEngine-macos-arm64
           mkdir -p "$DIST"
           cp build/release/bin/HoroEditor "$DIST/"
           cp -r build/release/sdk "$DIST/" 2>/dev/null || true
@@ -116,9 +116,9 @@ jobs:
       - name: Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          TAG=${{ github.event.release.tag_name || inputs.tag }}
-          gh release upload "$TAG" HoroEngine-macos-universal.tar.gz --clobber
+          gh release upload "$RELEASE_TAG" HoroEngine-macos-arm64.tar.gz --clobber
 
   build-windows:
     name: Build · Windows / MSVC
@@ -172,10 +172,9 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
-          if (-not $tag) { $tag = "${{ inputs.tag }}" }
-          gh release upload $tag HoroEngine-windows-x64.zip --clobber
+          gh release upload $env:RELEASE_TAG HoroEngine-windows-x64.zip --clobber
 
       - name: Show sccache stats
         if: always()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,18 @@
       "release-type": "simple",
       "package-name": "HoroEngine",
       "changelog-path": "CHANGELOG.md",
-      "pull-request-title-pattern": "chore: release HoroEngine v${version}",
-      "pull-request-header": "## :rocket: Release HoroEngine v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
+      "pull-request-title-pattern": "chore: release v${version}",
+      "pull-request-header": "## Release v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features" },
+        { "type": "fix",      "section": "Bug Fixes" },
+        { "type": "refactor", "section": "Refactoring" },
+        { "type": "revert",   "section": "Reverts" },
+        { "type": "chore",    "section": "Miscellaneous", "hidden": true },
+        { "type": "ci",       "section": "CI",            "hidden": true },
+        { "type": "docs",     "section": "Documentation", "hidden": true },
+        { "type": "test",     "section": "Tests",         "hidden": true }
+      ],
       "extra-files": [
         "CMakeLists.txt"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,10 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "horo-engine",
+      "package-name": "HoroEngine",
       "changelog-path": "CHANGELOG.md",
+      "pull-request-title-pattern": "chore: release HoroEngine v${version}",
+      "pull-request-header": "## :rocket: Release HoroEngine v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
       "extra-files": [
         "CMakeLists.txt"
       ]


### PR DESCRIPTION
## Summary

### Release Please — PR title fix
The current release PR title `chore(main): release horo-engine 0.2.0` is wrong on two counts:
- `(main)` scope is noisy (auto-inserted from branch name)
- Package name was lowercase `horo-engine` instead of `HoroEngine`

**After this PR**, the next release PR will be titled:
`chore: release HoroEngine v0.2.0`

The PR description header also now explains the release flow and mentions that binaries will be attached automatically.

### Release Binaries — new `release-binaries.yml`

When a release PR is merged and release-please publishes the GitHub Release, this workflow automatically:

1. Builds `HoroEditor` (standalone IDE binary) in release mode on 3 platforms in parallel
2. Packages binary + SDK assets (`sdk/`) into platform archives
3. Uploads archives to the GitHub Release:

| Asset | Platform |
|-------|----------|
| `HoroEngine-linux-x86_64.tar.gz` | Linux / GCC |
| `HoroEngine-macos-universal.tar.gz` | macOS / Clang |
| `HoroEngine-windows-x64.zip` | Windows / MSVC |

Also supports `workflow_dispatch` with a tag input for manual re-runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Customized `release-please` for `HoroEngine`, added changelog sections, and added a workflow to build and upload `HoroEditor` binaries on each GitHub Release. Also hardened upload steps to prevent script injection and cleaned up CI comments.

- **New Features**
  - Customized `release-please`: package is `HoroEngine`, PR title is "chore: release v${version}", PR header explains the release flow; added changelog sections for consistent grouping.
  - Added `release-binaries.yml`: runs on release publish or manual tag; builds `HoroEditor` on Linux/macOS/Windows; packages binary + `sdk/`; uploads `HoroEngine-linux-x86_64.tar.gz`, `HoroEngine-macos-arm64.tar.gz`, `HoroEngine-windows-x64.zip`; uses ccache/sccache and FetchContent caching.

- **Bug Fixes**
  - Prevented script injection in upload steps by using `RELEASE_TAG`/`$env:RELEASE_TAG` instead of inline shell interpolation.

<sup>Written for commit ef58fa4903cf6cd90b7cf7042bf9eef09d95ca99. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

