### PR TITLE
fix: restore HoroEngine in release PR title and fix header placeholder

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,6 @@
       "changelog-path": "CHANGELOG.md",
       "pull-request-title-pattern": "chore: release HoroEngine v${version}",
       "pull-request-header": "## :rocket: HoroEngine Release\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
-      "pull-request-title-pattern": "chore: release v${version}",
-      "pull-request-header": "## Release v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,8 @@
       "release-type": "simple",
       "package-name": "HoroEngine",
       "changelog-path": "CHANGELOG.md",
-      "pull-request-title-pattern": "chore: release v${version}",
-      "pull-request-header": "## Release v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
+      "pull-request-title-pattern": "chore: release HoroEngine v${version}",
+      "pull-request-header": "## :rocket: HoroEngine Release\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,8 @@
       "changelog-path": "CHANGELOG.md",
       "pull-request-title-pattern": "chore: release HoroEngine v${version}",
       "pull-request-header": "## :rocket: HoroEngine Release\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
+      "pull-request-title-pattern": "chore: release v${version}",
+      "pull-request-header": "## Release v${version}\n\nThis is an automated release PR. Review the changelog below, then merge to publish the release on GitHub.\n\nOnce merged, binaries for **Linux**, **macOS**, and **Windows** will be built and attached to the GitHub Release automatically.",
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
Two issues spotted in the release-please PR #195:

**1. Title missing 'HoroEngine'**
PR #195 title was `chore: release v0.2.0` — the pattern had lost `HoroEngine`. Restored to:
`chore: release HoroEngine v${version}`

**2. Header showed `v${version}` literally**
`pull-request-header` does not support `${version}` interpolation (only the title pattern does). Replaced with a static header that renders correctly on every release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `HoroEngine` in release PR titles and switch to a clear static header. Add a release workflow that builds and uploads `HoroEditor` binaries for Linux, macOS, and Windows, with clearer CHANGELOG grouping.

- **New Features**
  - Release Binaries workflow runs on published releases and manual reruns; builds cross‑platform `HoroEditor` and uploads archives to the GitHub Release.
  - Added explicit CHANGELOG sections for consistent grouping.

- **Bug Fixes**
  - Release PR title now uses: "chore: release HoroEngine v${version}" (package set to `HoroEngine`).
  - Header set to "🚀 HoroEngine Release" static text to avoid `${version}` rendering issues.

<sup>Written for commit b07d0970ed01244a8f55f0e168f4c3fff29f89d6. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

