### PR TITLE
feat(renderer): backend-neutral GPU resource interfaces

### DIFF
--- a/renderer/IFramebuffer.h
+++ b/renderer/IFramebuffer.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace Horo {
+
+enum class FramebufferTextureFormat {
+    None = 0,
+    RGBA8,
+    RED_INTEGER,
+    DEPTH24STENCIL8
+};
+
+struct FramebufferTextureSpec {
+    FramebufferTextureFormat format = FramebufferTextureFormat::None;
+};
+
+struct FramebufferAttachmentSpec {
+    std::vector<FramebufferTextureSpec> attachments;
+};
+
+struct FramebufferSpec {
+    uint32_t                 width           = 0;
+    uint32_t                 height          = 0;
+    uint32_t                 samples         = 1;
+    FramebufferAttachmentSpec attachmentSpec;
+    bool                     swapChainTarget = false;
+};
+
+class IFramebuffer {
+public:
+    virtual ~IFramebuffer() = default;
+
+    virtual void Bind()   = 0;
+    virtual void Unbind() = 0;
+    virtual void Resize(uint32_t width, uint32_t height) = 0;
+
+    // Returns the native texture handle for the given color attachment (e.g.
+    // an OpenGL texture ID cast to uint32_t).
+    virtual uint32_t GetColorAttachmentId(uint32_t index = 0) const = 0;
+
+    virtual int  ReadPixel(uint32_t attachmentIndex, int x, int y)   = 0;
+    virtual void ClearAttachment(uint32_t attachmentIndex, int value) = 0;
+
+    virtual const FramebufferSpec& GetSpec() const = 0;
+};
+
+} // namespace Horo

--- a/renderer/IIndexBuffer.h
+++ b/renderer/IIndexBuffer.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+
+namespace Horo {
+
+class IIndexBuffer {
+public:
+    virtual ~IIndexBuffer() = default;
+
+    virtual void Bind()   const = 0;
+    virtual void Unbind() const = 0;
+
+    virtual uint32_t GetCount() const = 0;
+};
+
+} // namespace Horo

--- a/renderer/IShader.h
+++ b/renderer/IShader.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <string>
+
+#include "math/Mat3.h"
+#include "math/Mat4.h"
+#include "math/Vec3.h"
+#include "math/Vec4.h"
+
+namespace Horo {
+
+class IShader {
+public:
+    virtual ~IShader() = default;
+
+    virtual void Bind()   const = 0;
+    virtual void Unbind() const = 0;
+
+    virtual void SetInt(const std::string& name, int value)         = 0;
+    virtual void SetFloat(const std::string& name, float value)     = 0;
+    virtual void SetVec2(const std::string& name, float x, float y) = 0;
+    virtual void SetVec3(const std::string& name, const Vec3& v)    = 0;
+    virtual void SetVec4(const std::string& name, const Vec4& v)    = 0;
+    virtual void SetMat3(const std::string& name, const Mat3& m)    = 0;
+    virtual void SetMat4(const std::string& name, const Mat4& m)    = 0;
+
+    // Upload count matrices to uniform `name[0]` through `name[count-1]`.
+    virtual void SetMat4Array(const std::string& name, int count, const float* data) = 0;
+
+    virtual bool IsValid() const = 0;
+};
+
+} // namespace Horo

--- a/renderer/ITexture.h
+++ b/renderer/ITexture.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/RenderTargetHandle.h"
+
+namespace Horo {
+
+enum class TextureFormat { RGBA8, RGB8, R8, Depth24Stencil8 };
+enum class TextureFilter { Linear, Nearest };
+enum class TextureWrap   { Repeat, ClampToEdge, MirroredRepeat };
+
+struct TextureSpec {
+    uint32_t      width        = 1;
+    uint32_t      height       = 1;
+    TextureFormat format       = TextureFormat::RGBA8;
+    TextureFilter filter       = TextureFilter::Linear;
+    TextureWrap   wrap         = TextureWrap::Repeat;
+    bool          generateMips = true;
+};
+
+class ITexture {
+public:
+    virtual ~ITexture() = default;
+
+    virtual void Bind(uint32_t slot = 0) const = 0;
+    virtual void Unbind()                const = 0;
+
+    virtual int GetWidth()  const = 0;
+    virtual int GetHeight() const = 0;
+    virtual const TextureSpec& GetSpec() const = 0;
+
+    virtual bool IsValid() const = 0;
+
+    // Upload pixel data after creation.
+    virtual void SetData(const void* data, uint32_t size) = 0;
+
+    // Backend-agnostic handle for ImGui / render-target presentation.
+    virtual RenderTargetHandle GetRenderTargetHandle(bool needsYFlip = false) const = 0;
+
+    virtual bool operator==(const ITexture& other) const = 0;
+};
+
+} // namespace Horo

--- a/renderer/IVertexArray.h
+++ b/renderer/IVertexArray.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <memory>
+#include <vector>
+
+#include "renderer/IIndexBuffer.h"
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+class IVertexArray {
+public:
+    virtual ~IVertexArray() = default;
+
+    virtual void Bind()   const = 0;
+    virtual void Unbind() const = 0;
+
+    virtual void AddVertexBuffer(std::shared_ptr<IVertexBuffer> vertexBuffer) = 0;
+    virtual void SetIndexBuffer(std::shared_ptr<IIndexBuffer>  indexBuffer)   = 0;
+
+    virtual const std::vector<std::shared_ptr<IVertexBuffer>>& GetVertexBuffers() const = 0;
+    virtual const std::shared_ptr<IIndexBuffer>&               GetIndexBuffer()   const = 0;
+};
+
+} // namespace Horo

--- a/renderer/IVertexBuffer.h
+++ b/renderer/IVertexBuffer.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace Horo {
+
+enum class ShaderDataType {
+    None = 0,
+    Float, Float2, Float3, Float4,
+    Mat3, Mat4,
+    Int, Int2, Int3, Int4,
+    Bool
+};
+
+uint32_t ShaderDataTypeSize(ShaderDataType type);
+
+struct BufferElement {
+    std::string    name;
+    ShaderDataType type       = ShaderDataType::None;
+    uint32_t       size       = 0;
+    size_t         offset     = 0;
+    bool           normalized = false;
+
+    BufferElement() = default;
+    BufferElement(ShaderDataType type, const std::string& name, bool normalized = false);
+
+    uint32_t GetComponentCount() const;
+};
+
+class BufferLayout {
+public:
+    BufferLayout() = default;
+    BufferLayout(std::initializer_list<BufferElement> elements);
+
+    const std::vector<BufferElement>& GetElements() const { return m_Elements; }
+    uint32_t GetStride() const { return m_Stride; }
+
+    std::vector<BufferElement>::iterator       begin()       { return m_Elements.begin(); }
+    std::vector<BufferElement>::iterator       end()         { return m_Elements.end(); }
+    std::vector<BufferElement>::const_iterator begin() const { return m_Elements.begin(); }
+    std::vector<BufferElement>::const_iterator end()   const { return m_Elements.end(); }
+
+private:
+    void CalculateOffsetsAndStride();
+    std::vector<BufferElement> m_Elements;
+    uint32_t m_Stride = 0;
+};
+
+class IVertexBuffer {
+public:
+    virtual ~IVertexBuffer() = default;
+
+    virtual void Bind()   const = 0;
+    virtual void Unbind() const = 0;
+
+    virtual void SetData(const void* data, uint32_t size)  = 0;
+    virtual const BufferLayout& GetLayout()                const = 0;
+    virtual void SetLayout(const BufferLayout& layout)     = 0;
+};
+
+} // namespace Horo


### PR DESCRIPTION
## Backend-neutral GPU resource interfaces

Adds six pure-virtual C++ interfaces that define the contract every render backend must satisfy for GPU resource management. No OpenGL or Vulkan headers are included — these are API-agnostic contracts.

### New interfaces
| Interface | Replaces |
|-----------|---------|
| `IShader` | `Shader` (glad + glUniform* calls) |
| `ITexture` | `Texture` (glGenTextures + glad) |
| `IFramebuffer` | FBO code in `EditorLayer` |
| `IVertexBuffer` | VAO/VBO setup in `Mesh`, `DebugDraw`, `DebugHUD` |
| `IIndexBuffer` | EBO setup in `Mesh` |
| `IVertexArray` | Full VAO in `Mesh`, `SkinnedMesh` |

### Deviations from spec (to match codebase conventions)
- **Math types**: `IShader` uses project-native `math/Vec3.h`, `Vec4.h`, `Mat3.h`, `Mat4.h` instead of `glm`, matching existing `Shader.h` exactly.
- **Uniform setters**: `SetVec2(name, float x, float y)`, `SetVec3(name, const Vec3&)`, `SetVec4(name, const Vec4&)` — matches `Shader.h` signatures. Added `SetMat4Array` for bone palettes (used by `SkinnedMesh`).
- **`ITexture::GetWidth/GetHeight`** return `int` (not `uint32_t`) to match `Texture.h`.
- **`ITexture`** includes `GetRenderTargetHandle()` to preserve the existing backend-agnostic ImGui presentation path.

### What comes next
The OpenGL implementations of each interface move to `renderer/opengl/` in the following step, after which `glad.h` will be strictly confined to that subdirectory.

Depends on: audit in #197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce backend‑neutral GPU resource interfaces to decouple the renderer from OpenGL and define a stable contract for all backends. API‑agnostic headers only; OpenGL moves to `renderer/opengl/` next.

- **New Features**
  - Added `IShader`, `ITexture`, `IFramebuffer`, `IVertexBuffer`, `IIndexBuffer`, `IVertexArray`.
  - `IShader` uses project math types and adds `SetMat4Array`.
  - `ITexture` keeps `GetRenderTargetHandle`; `GetWidth/Height` return `int`; adds `TextureSpec` with `TextureFormat/Filter/Wrap`.
  - `IFramebuffer` adds `FramebufferSpec` with attachment formats, resize/readback, and `GetColorAttachmentId`.
  - Vertex input helpers: `ShaderDataType`, `BufferElement`, `BufferLayout`.

- **Migration**
  - No runtime changes yet; backends implement these interfaces to integrate with the renderer.
  - OpenGL implementations follow next in `renderer/opengl/`.

<sup>Written for commit 9ef7226948cff195eb922c5de7b5c16db3403fda. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

