### PR TITLE
feat(renderer): eliminate glad.h from non-backend files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,14 +183,13 @@ if(HORO_ENGINE_BUILD_TESTS AND TARGET imgui_test_lib)
     horo_configure_engine_target(HoroEngineImGuiTest imgui_test_lib)
 
     # Add the OpenGL backend sources so HoroEngineImGuiTest is self-contained.
-    # glad is already PRIVATE via horo_configure_engine_target above.
-    if(HORO_RENDERER STREQUAL "opengl")
-        target_sources(HoroEngineImGuiTest PRIVATE ${HORO_RENDERER_OPENGL_SOURCES})
-        target_include_directories(HoroEngineImGuiTest PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        )
-        target_compile_definitions(HoroEngineImGuiTest PUBLIC HORO_RENDERER_OPENGL=1)
-    endif()
+    # RenderBackendFactory.cpp unconditionally references OpenGLRenderBackend,
+    # so the sources must be present regardless of the selected renderer.
+    target_sources(HoroEngineImGuiTest PRIVATE ${HORO_RENDERER_OPENGL_SOURCES})
+    target_include_directories(HoroEngineImGuiTest PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    )
+    target_compile_definitions(HoroEngineImGuiTest PUBLIC HORO_RENDERER_OPENGL=1)
 endif()
 
 # Copy GLSL shaders to bin/shaders alongside the executable
@@ -214,10 +213,10 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STAN
         target_link_libraries(HoroEditor PRIVATE HoroEngine horo-renderer-opengl)
     elseif(HORO_RENDERER STREQUAL "vulkan")
         target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_VULKAN=1)
-        target_link_libraries(HoroEditor PRIVATE HoroEngine)
+        target_link_libraries(HoroEditor PRIVATE HoroEngine horo-renderer-opengl)
     elseif(HORO_RENDERER STREQUAL "null")
         target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_NULL=1)
-        target_link_libraries(HoroEditor PRIVATE horo-renderer-null)
+        target_link_libraries(HoroEditor PRIVATE horo-renderer-null horo-renderer-opengl)
     else()
         target_link_libraries(HoroEditor PRIVATE HoroEngine)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     option(HORO_ENGINE_ENABLE_VULKAN "Fetch Vulkan headers/loader and compile Vulkan backend scaffolding" OFF)
     option(HORO_ENGINE_BUILD_STANDALONE_EDITOR "Build HoroEditor (SDK launcher + editor shell executable)" ON)
 
+    set(HORO_RENDERER "opengl" CACHE STRING "Renderer backend: opengl | vulkan | null")
+    set_property(CACHE HORO_RENDERER PROPERTY STRINGS opengl vulkan null)
+
     if(MSVC)
         add_compile_options(/W4 /WX /Zc:preprocessor)
     else()
@@ -33,6 +36,16 @@ endif()
 # Guards in vendor/CMakeLists.txt prevent duplicate target errors if a parent
 # project already defined any of these targets.
 add_subdirectory(vendor)
+
+# ---- OpenGL backend source files (PRIVATE glad isolation) ----
+# Only files that directly include <glad/glad.h> belong here.
+# renderer/Mesh.cpp, SkinnedMesh.cpp, DebugDraw.cpp, DebugHUD.cpp,
+# Shader.cpp and Texture.cpp do NOT include glad directly (they use the
+# clean OpenGL* headers) so they remain in HoroEngine to avoid a circular
+# dependency (EditorLayer.cpp in HoroEngine calls Mesh).
+set(HORO_RENDERER_OPENGL_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/OpenGLRenderBackend.cpp
+)
 
 # ---- HoroEngine static library ----
 file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
@@ -48,6 +61,9 @@ file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher/*.cpp"
 )
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX "launcher[/\\\\]HoroEditorMain\\.cpp$")
+# Exclude only the file that directly includes <glad/glad.h>; it lives in horo-renderer-opengl.
+list(FILTER ENGINE_SOURCES EXCLUDE REGEX
+    "[/\\\\]renderer[/\\\\]OpenGLRenderBackend\\.cpp$")
 
 add_library(HoroEngine STATIC ${ENGINE_SOURCES})
 add_library(HoroEngine::HoroEngine ALIAS HoroEngine)
@@ -64,9 +80,9 @@ function(horo_configure_engine_target target_name imgui_target)
     target_link_libraries(${target_name}
         PUBLIC
             glfw
-            glad
             ${imgui_target}
         PRIVATE
+            glad
             glm
             stb
             nlohmann_json
@@ -78,12 +94,14 @@ function(horo_configure_engine_target target_name imgui_target)
         target_compile_definitions(${target_name} PUBLIC HORO_HAS_VULKAN=1)
     endif()
 
-    if(APPLE)
-        target_link_libraries(${target_name} PUBLIC "-framework OpenGL")
-    elseif(WIN32)
-        target_link_libraries(${target_name} PUBLIC opengl32 comdlg32 ole32 shell32 ws2_32)
+    if(WIN32)
+        # Windows system libs needed for GLFW and general app infrastructure.
+        target_link_libraries(${target_name} PUBLIC comdlg32 ole32 shell32 ws2_32)
+        target_link_libraries(${target_name} PRIVATE opengl32)
+    elseif(APPLE)
+        target_link_libraries(${target_name} PRIVATE "-framework OpenGL")
     else()
-        target_link_libraries(${target_name} PUBLIC GL)
+        target_link_libraries(${target_name} PRIVATE GL)
     endif()
 
     target_compile_features(${target_name} PUBLIC cxx_std_20)
@@ -102,6 +120,50 @@ endfunction()
 option(HORO_ENGINE_COVERAGE "Add coverage flags to HoroEngine (for reports after ctest)" OFF)
 
 horo_configure_engine_target(HoroEngine imgui_lib)
+# core/Window.cpp and editor files include <glad/glad.h> directly; add glad
+# as PRIVATE so the library isn't forced on consumers, but expose the include
+# directory so consumers (e.g. starter app) can call gl* functions directly.
+target_link_libraries(HoroEngine PRIVATE glad)
+target_include_directories(HoroEngine PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/glad/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vendor/glad>
+)
+
+# ---- horo-renderer-opengl: PRIVATE glad + OpenGL ----
+# Dedicated backend marker/consumer target.  The sources compiled here
+# include <glad/glad.h>, and glad is kept PRIVATE so its include directories
+# cannot transitively reach HoroEditor or test translation units.
+# HoroEngine also uses glad PRIVATE (Window.cpp, EditorLayer.cpp, etc.) but
+# the PUBLIC interface of both targets is glad-free.
+add_library(horo-renderer-opengl STATIC ${HORO_RENDERER_OPENGL_SOURCES})
+add_library(HoroEngine::RendererOpenGL ALIAS horo-renderer-opengl)
+
+target_include_directories(horo-renderer-opengl PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries(horo-renderer-opengl
+    PRIVATE HoroEngine
+    PRIVATE glad stb
+)
+if(APPLE)
+    target_link_libraries(horo-renderer-opengl PRIVATE "-framework OpenGL")
+elseif(WIN32)
+    target_link_libraries(horo-renderer-opengl PRIVATE opengl32)
+else()
+    target_link_libraries(horo-renderer-opengl PRIVATE GL)
+endif()
+target_compile_definitions(horo-renderer-opengl INTERFACE HORO_RENDERER_OPENGL=1)
+
+if(HORO_ENGINE_COVERAGE AND NOT MSVC)
+    target_compile_options(horo-renderer-opengl PUBLIC --coverage -O0 -g)
+    target_link_options(horo-renderer-opengl PUBLIC --coverage)
+endif()
+
+# ---- horo-renderer-null: no GPU dependency (headless / CI unit tests) ----
+add_library(horo-renderer-null INTERFACE)
+add_library(HoroEngine::RendererNull ALIAS horo-renderer-null)
+target_link_libraries(horo-renderer-null INTERFACE HoroEngine)
+target_compile_definitions(horo-renderer-null INTERFACE HORO_RENDERER_NULL=1)
 
 if(HORO_ENGINE_BUILD_TESTS AND TARGET imgui_test_lib)
     set(HORO_UI_TEST_SOURCES
@@ -119,6 +181,16 @@ if(HORO_ENGINE_BUILD_TESTS AND TARGET imgui_test_lib)
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tests>
     )
     horo_configure_engine_target(HoroEngineImGuiTest imgui_test_lib)
+
+    # Add the OpenGL backend sources so HoroEngineImGuiTest is self-contained.
+    # glad is already PRIVATE via horo_configure_engine_target above.
+    if(HORO_RENDERER STREQUAL "opengl")
+        target_sources(HoroEngineImGuiTest PRIVATE ${HORO_RENDERER_OPENGL_SOURCES})
+        target_include_directories(HoroEngineImGuiTest PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        )
+        target_compile_definitions(HoroEngineImGuiTest PUBLIC HORO_RENDERER_OPENGL=1)
+    endif()
 endif()
 
 # Copy GLSL shaders to bin/shaders alongside the executable
@@ -131,11 +203,23 @@ add_custom_command(TARGET HoroEngine POST_BUILD
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STANDALONE_EDITOR)
     add_executable(HoroEditor launcher/HoroEditorMain.cpp)
-    target_link_libraries(HoroEditor PRIVATE HoroEngine)
     target_compile_features(HoroEditor PRIVATE cxx_std_20)
 
     if(WIN32)
         target_compile_definitions(HoroEditor PRIVATE NOMINMAX)
+    endif()
+
+    if(HORO_RENDERER STREQUAL "opengl")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_OPENGL=1)
+        target_link_libraries(HoroEditor PRIVATE HoroEngine horo-renderer-opengl)
+    elseif(HORO_RENDERER STREQUAL "vulkan")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_VULKAN=1)
+        target_link_libraries(HoroEditor PRIVATE HoroEngine)
+    elseif(HORO_RENDERER STREQUAL "null")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_NULL=1)
+        target_link_libraries(HoroEditor PRIVATE horo-renderer-null)
+    else()
+        target_link_libraries(HoroEditor PRIVATE HoroEngine)
     endif()
 
     add_custom_command(TARGET HoroEditor POST_BUILD
@@ -175,7 +259,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STAN
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    install(TARGETS HoroEngine glad imgui_lib glfw glm stb tinygltf nlohmann_json
+    install(TARGETS HoroEngine horo-renderer-opengl glad imgui_lib glfw glm stb tinygltf nlohmann_json
         EXPORT HoroEngineTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,8 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "HORO_ENGINE_BUILD_TESTS": "ON"
+        "HORO_ENGINE_BUILD_TESTS": "ON",
+        "HORO_RENDERER": "opengl"
       }
     },
     {
@@ -26,7 +27,8 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "HORO_ENGINE_BUILD_TESTS": "OFF"
+        "HORO_ENGINE_BUILD_TESTS": "OFF",
+        "HORO_RENDERER": "opengl"
       }
     },
     {
@@ -65,9 +67,19 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "HORO_ENGINE_BUILD_TESTS": "ON",
+        "HORO_RENDERER": "opengl",
         "CMAKE_CXX_FLAGS": "--coverage -O0",
         "CMAKE_C_FLAGS": "--coverage -O0",
         "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+      }
+    },
+    {
+      "name": "null-renderer",
+      "displayName": "Null Renderer (headless)",
+      "inherits": "release",
+      "cacheVariables": {
+        "HORO_RENDERER": "null",
+        "HORO_ENGINE_BUILD_TESTS": "ON"
       }
     }
   ],
@@ -85,6 +97,10 @@
       "configurePreset": "coverage"
     },
     {
+      "name": "null-renderer",
+      "configurePreset": "null-renderer"
+    },
+    {
       "name": "debug-msvc",
       "configurePreset": "debug-msvc"
     },
@@ -97,6 +113,11 @@
     {
       "name": "debug",
       "configurePreset": "debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "null-renderer",
+      "configurePreset": "null-renderer",
       "output": { "outputOnFailure": true }
     },
     {

--- a/core/Window.cpp
+++ b/core/Window.cpp
@@ -1,7 +1,7 @@
 #include "core/Window.h"
 
 // clang-format off
-#include <glad/glad.h>   // must precede GLFW
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 // clang-format on
 
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "core/Logger.h"
+#include "renderer/Renderer.h"
+#include "renderer/opengl/OpenGLContext.h"
 
 namespace {
 #ifdef _WIN32
@@ -178,7 +180,7 @@ namespace Horo {
             LogInfo("Making GL context current...");
             glfwMakeContextCurrent(m_window);
             LogInfo("Loading GL via glad...");
-            if (!gladLoadGLLoader(GladLoadProcBridge)) {
+            if (!OpenGLContext::InitGlad(GladLoadProcBridge)) {
                 glfwDestroyWindow(m_window);
                 GlfwContext::Shutdown();
                 throw WindowInitException("gladLoadGLLoader failed");
@@ -186,9 +188,8 @@ namespace Horo {
             LogInfo("gladLoadGLLoader succeeded.");
             SetVSync(spec.vsync);
             LogInfo("SetVSync complete: enabled={}", spec.vsync ? 1 : 0);
-            LogInfo("OpenGL {} — {}",
-                    reinterpret_cast<const char *>(glGetString(GL_VERSION)),
-                    reinterpret_cast<const char *>(glGetString(GL_RENDERER)));
+            LogInfo("OpenGL {} — {}", OpenGLContext::GetGLVersion(),
+                    OpenGLContext::GetGLRenderer());
         } else {
             // Vulkan presentation pacing is backend-owned; the window stores the
             // preference.
@@ -278,7 +279,7 @@ namespace Horo {
         self->m_width = w;
         self->m_height = h;
         if (self->OwnsViewportResize())
-            glViewport(0, 0, w, h);
+            Renderer::SetViewport(0, 0, w, h);
         if (self->m_resizeCb)
             self->m_resizeCb(w, h);
     }

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -17,7 +17,7 @@
 #endif
 
 // clang-format off
-#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 // clang-format on
 #include <imgui.h>
@@ -68,6 +68,8 @@
 #include "math/Transform.h"
 #include "renderer/DebugDraw.h"
 #include "renderer/GltfLoader.h"
+#include "renderer/IFramebuffer.h"
+#include "renderer/ITexture.h"
 #include "renderer/Mesh.h"
 #include "renderer/ObjLoader.h"
 #include "renderer/RenderViewUtils.h"
@@ -290,9 +292,7 @@ Mat4 BuildObjectModelMatrix(const SceneDocument &doc, const SceneObject &obj) {
 // Framebuffer object for offscreen mesh rendering (shared across all asset
 // previews).
 struct AssetThumbnailRenderer {
-  unsigned int fbo = 0;
-  unsigned int colorTexture = 0;
-  unsigned int depthRenderBuffer = 0;
+  std::shared_ptr<IFramebuffer> fbo;
   int width = 512;
   int height = 512;
   Shader shader; // Basic lighting shader for thumbnail
@@ -310,7 +310,8 @@ struct AssetThumbnailRenderer {
   std::unordered_set<std::string, StringHash, std::equal_to<>> noPreviewKeys;
   // Per-mesh rendered texture cache: each mesh gets its own texture so all
   // thumbnails don't overwrite each other by sharing a single FBO attachment.
-  std::unordered_map<std::string, unsigned int, StringHash, std::equal_to<>>
+  std::unordered_map<std::string, std::shared_ptr<ITexture>, StringHash,
+                     std::equal_to<>>
       renderedTextureCache;
 
   static AssetThumbnailRenderer &Instance() {
@@ -319,39 +320,19 @@ struct AssetThumbnailRenderer {
   }
 
   bool Init() {
-    if (fbo != 0)
+    if (fbo != nullptr)
       return IsValid();
 
-    // Create FBO
-    glGenFramebuffers(1, &fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    FramebufferSpec spec;
+    spec.width  = static_cast<uint32_t>(width);
+    spec.height = static_cast<uint32_t>(height);
+    spec.attachmentSpec = {
+        {{FramebufferTextureFormat::RGBA8},
+         {FramebufferTextureFormat::DEPTH24STENCIL8}}};
+    fbo = Renderer::CreateFramebuffer(spec);
 
-    // Create color texture
-    glGenTextures(1, &colorTexture);
-    glBindTexture(GL_TEXTURE_2D, colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
-                 GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           colorTexture, 0);
-
-    // Create depth renderbuffer
-    glGenRenderbuffers(1, &depthRenderBuffer);
-    glBindRenderbuffer(GL_RENDERBUFFER, depthRenderBuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                              GL_RENDERBUFFER, depthRenderBuffer);
-
-    const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-      LogError("AssetThumbnailRenderer: FBO incomplete, status={}",
-               static_cast<int>(status));
-      Cleanup();
+    if (!fbo) {
+      LogError("AssetThumbnailRenderer: CreateFramebuffer returned nullptr.");
       return false;
     }
 
@@ -373,30 +354,14 @@ struct AssetThumbnailRenderer {
   }
 
   bool IsValid() const {
-    return fbo != 0 && colorTexture != 0 && depthRenderBuffer != 0 &&
-           shader.IsValid();
+    return fbo != nullptr && shader.IsValid();
   }
 
   void Cleanup() {
     meshCache.clear();
     noPreviewKeys.clear();
-    for (const auto &[key, texId] : renderedTextureCache) {
-      if (texId != 0)
-        glDeleteTextures(1, &texId);
-    }
     renderedTextureCache.clear();
-    if (colorTexture != 0) {
-      glDeleteTextures(1, &colorTexture);
-      colorTexture = 0;
-    }
-    if (depthRenderBuffer != 0) {
-      glDeleteRenderbuffers(1, &depthRenderBuffer);
-      depthRenderBuffer = 0;
-    }
-    if (fbo != 0) {
-      glDeleteFramebuffers(1, &fbo);
-      fbo = 0;
-    }
+    fbo.reset();
   }
 
   ~AssetThumbnailRenderer() { Cleanup(); }
@@ -535,26 +500,23 @@ RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh &mesh,
 
   // Return existing per-mesh texture if already rendered this session.
   if (const auto cacheIt = renderer.renderedTextureCache.find(meshKey);
-      cacheIt != renderer.renderedTextureCache.end())
-    return RenderTargetHandle::OpenGLTexture(cacheIt->second, true);
+      cacheIt != renderer.renderedTextureCache.end()) {
+    const auto &tex = cacheIt->second;
+    return tex ? tex->GetRenderTargetHandle(true) : RenderTargetHandle{};
+  }
 
   if (!renderer.IsValid())
     return {};
 
-  // Save GL state (viewport)
-  std::array<GLint, 4> prevViewport{0, 0, 1, 1};
-  glGetIntegerv(GL_VIEWPORT, prevViewport.data());
+  // Save viewport, bind FBO, set viewport
+  const auto prevViewport = Renderer::GetViewport();
 
-  // Bind FBO and set viewport
-  glBindFramebuffer(GL_FRAMEBUFFER, renderer.fbo);
-  glViewport(0, 0, renderer.width, renderer.height);
+  renderer.fbo->Bind();
+  Renderer::SetViewport(0, 0, renderer.width, renderer.height);
 
   // Clear and setup rendering
-  glClearColor(0.15f, 0.15f, 0.15f, 1.0f);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  glEnable(GL_DEPTH_TEST);
-  glEnable(GL_CULL_FACE);
-  glCullFace(GL_BACK);
+  Renderer::ClearColorAndDepth(0.15f, 0.15f, 0.15f, 1.0f);
+  Renderer::SetupOpaqueRenderState();
 
   // Setup camera matrices
   Mat4 view;
@@ -591,29 +553,37 @@ RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh &mesh,
   }
 
   // Copy FBO contents into a new per-mesh texture so each asset keeps its own
-  // image.
-  unsigned int destTex = 0;
-  glGenTextures(1, &destTex);
-  glBindTexture(GL_TEXTURE_2D, destTex);
-  // glReadPixels only runs once per mesh (then cached); CPU cost is acceptable.
-  std::vector<unsigned char> pixels(
-      static_cast<size_t>(renderer.width * renderer.height * 3));
-  glReadPixels(0, 0, renderer.width, renderer.height, GL_RGB, GL_UNSIGNED_BYTE,
-               pixels.data());
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, renderer.width, renderer.height, 0,
-               GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  // image.  ReadbackRegionRgba8 only runs once per mesh (then cached).
+  std::vector<uint32_t> pixels(
+      static_cast<size_t>(renderer.width * renderer.height));
+  std::string readError;
+  if (!Renderer::ReadbackRegionRgba8(0, 0, renderer.width, renderer.height,
+                                     pixels.data(), &readError)) {
+    LogWarn("AssetThumbnailRenderer: readback failed: {}", readError);
+    renderer.fbo->Unbind();
+    Renderer::SetViewport(prevViewport[0], prevViewport[1],
+                          prevViewport[2], prevViewport[3]);
+    return {};
+  }
+
+  TextureSpec texSpec;
+  texSpec.width        = static_cast<uint32_t>(renderer.width);
+  texSpec.height       = static_cast<uint32_t>(renderer.height);
+  texSpec.format       = TextureFormat::RGBA8;
+  texSpec.filter       = TextureFilter::Linear;
+  texSpec.wrap         = TextureWrap::ClampToEdge;
+  texSpec.generateMips = false;
+  auto destTex = Renderer::CreateTexture(texSpec);
+  destTex->SetData(pixels.data(),
+                   static_cast<uint32_t>(pixels.size() * sizeof(uint32_t)));
   renderer.renderedTextureCache[meshKey] = destTex;
 
-  // Restore GL state
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-  glViewport(prevViewport[0], prevViewport[1], prevViewport[2],
-             prevViewport[3]);
+  // Restore state
+  renderer.fbo->Unbind();
+  Renderer::SetViewport(prevViewport[0], prevViewport[1],
+                        prevViewport[2], prevViewport[3]);
 
-  return RenderTargetHandle::OpenGLTexture(destTex, true);
+  return destTex->GetRenderTargetHandle(true);
 }
 
 RenderTargetHandle TryRenderAssetMeshPreview(const AssetDef &asset) {

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -556,8 +556,7 @@ RenderMeshToThumbnail(const AssetThumbnailRenderer::CachedMesh &mesh,
   // image.  ReadbackRegionRgba8 only runs once per mesh (then cached).
   std::vector<uint32_t> pixels(
       static_cast<size_t>(renderer.width * renderer.height));
-  std::string readError;
-  if (!Renderer::ReadbackRegionRgba8(0, 0, renderer.width, renderer.height,
+  if (std::string readError; !Renderer::ReadbackRegionRgba8(0, 0, renderer.width, renderer.height,
                                      pixels.data(), &readError)) {
     LogWarn("AssetThumbnailRenderer: readback failed: {}", readError);
     renderer.fbo->Unbind();

--- a/editor/EditorMcpHandlers.cpp
+++ b/editor/EditorMcpHandlers.cpp
@@ -2,7 +2,7 @@
 // Method definitions are in this file; declarations remain in EditorLayer.h.
 
 // clang-format off
-#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 // clang-format on
 

--- a/launcher/UiAutomationRunner.cpp
+++ b/launcher/UiAutomationRunner.cpp
@@ -441,9 +441,8 @@ bool UiScreenCaptureFunc(ImGuiID viewport_id, int x, int y, int w, int h,
   if (x < 0 || y < 0 || x + w > viewport[2] || y + h > viewport[3])
     return false;
 
-  std::string readError;
-  if (!Renderer::ReadbackRegionRgba8(x, y, w, h,
-                                     reinterpret_cast<uint32_t *>(pixels),
+  if (std::string readError; !Renderer::ReadbackRegionRgba8(x, y, w, h,
+                                     pixels,
                                      &readError))
     return false;
 

--- a/launcher/UiAutomationRunner.cpp
+++ b/launcher/UiAutomationRunner.cpp
@@ -13,7 +13,7 @@
 #include <unordered_set>
 
 // clang-format off
-#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 // clang-format on
 
@@ -21,6 +21,7 @@
 #include "launcher/LauncherEditorShell.h"
 #include "launcher/UiAutomationConfig.h"
 #include "launcher/UiTestHarness.h"
+#include "renderer/Renderer.h"
 
 #ifdef HORO_STANDALONE_UI_AUTOMATION
 #include <imgui.h>
@@ -433,14 +434,17 @@ bool UiScreenCaptureFunc(ImGuiID viewport_id, int x, int y, int w, int h,
     return false;
   if (glfwGetCurrentContext() == nullptr)
     return false;
-  std::array<GLint, 4> viewport{0, 0, 0, 0};
-  glGetIntegerv(GL_VIEWPORT, viewport.data());
+
+  const auto viewport = Renderer::GetViewport();
   if (viewport[2] <= 0 || viewport[3] <= 0)
     return false;
   if (x < 0 || y < 0 || x + w > viewport[2] || y + h > viewport[3])
     return false;
-  glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-  if (glGetError() != GL_NO_ERROR)
+
+  std::string readError;
+  if (!Renderer::ReadbackRegionRgba8(x, y, w, h,
+                                     reinterpret_cast<uint32_t *>(pixels),
+                                     &readError))
     return false;
 
   for (int row = 0; row < h / 2; ++row) {

--- a/renderer/DebugDraw.cpp
+++ b/renderer/DebugDraw.cpp
@@ -1,9 +1,5 @@
 #include "renderer/DebugDraw.h"
 
-// TODO(renderer-abstraction): Goal 5 will replace these call sites with
-//   OpenGLVertexArray / OpenGLVertexBuffer.
-#include <glad/glad.h>
-
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -15,8 +11,8 @@
 namespace Horo {
     std::vector<DebugDraw::LineVertex> DebugDraw::s_lines;
     std::unique_ptr<Shader> DebugDraw::s_shader;
-    unsigned int DebugDraw::s_vao = 0;
-    unsigned int DebugDraw::s_vbo = 0;
+    std::shared_ptr<IVertexArray>  DebugDraw::s_vao;
+    std::shared_ptr<IVertexBuffer> DebugDraw::s_vbo;
     bool DebugDraw::s_initialized = false;
 
     // Inline GLSL source for debug lines
@@ -48,37 +44,23 @@ void main() { FragColor = v_color; }
         s_shader =
                 std::make_unique<Shader>(Shader::FromSource(DEBUG_VERT, DEBUG_FRAG));
 
-        glGenVertexArrays(1, &s_vao);
-        glBindVertexArray(s_vao);
+        // Dynamic vertex buffer — refilled every frame
+        s_vbo = Renderer::CreateVertexBuffer(
+            static_cast<uint32_t>(sizeof(LineVertex) * 65536));
+        s_vbo->SetLayout({
+            {ShaderDataType::Float3, "a_pos"},
+            {ShaderDataType::Float4, "a_color"},
+        });
 
-        glGenBuffers(1, &s_vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
-        // Allocate a large buffer — will be refilled each frame
-        glBufferData(GL_ARRAY_BUFFER, sizeof(LineVertex) * 65536, nullptr,
-                     GL_DYNAMIC_DRAW);
+        s_vao = Renderer::CreateVertexArray();
+        s_vao->AddVertexBuffer(s_vbo);
 
-        // pos (location 0)
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(
-            0, 3, GL_FLOAT, GL_FALSE, sizeof(LineVertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(LineVertex, pos)));
-        // color (location 1)
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(
-            1, 4, GL_FLOAT, GL_FALSE, sizeof(LineVertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(LineVertex, col)));
-
-        glBindVertexArray(0);
         s_initialized = true;
     }
 
     void DebugDraw::Shutdown() {
-        if (s_vbo)
-            glDeleteBuffers(1, &s_vbo);
-        if (s_vao)
-            glDeleteVertexArrays(1, &s_vao);
+        s_vao.reset();
+        s_vbo.reset();
         s_shader.reset();
         s_initialized = false;
     }
@@ -159,15 +141,13 @@ void main() { FragColor = v_color; }
         s_shader->Bind();
         s_shader->SetMat4("u_vp", camera.GetViewProjection());
 
-        glBindVertexArray(s_vao);
-        glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
-        glBufferSubData(GL_ARRAY_BUFFER, 0,
-                        static_cast<GLsizeiptr>(s_lines.size() * sizeof(LineVertex)),
-                        s_lines.data());
+        s_vbo->SetData(s_lines.data(),
+                       static_cast<uint32_t>(s_lines.size() * sizeof(LineVertex)));
 
-        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(s_lines.size()));
+        s_vao->Bind();
+        s_vao->DrawArraysLines(static_cast<uint32_t>(s_lines.size()));
+        s_vao->Unbind();
 
-        glBindVertexArray(0);
         s_lines.clear();
     }
 } // namespace Horo

--- a/renderer/DebugDraw.h
+++ b/renderer/DebugDraw.h
@@ -5,6 +5,8 @@
 #include "math/Vec3.h"
 #include "math/Vec4.h"
 #include "renderer/Camera.h"
+#include "renderer/IVertexArray.h"
+#include "renderer/IVertexBuffer.h"
 #include "renderer/Shader.h"
 
 namespace Horo {
@@ -37,8 +39,8 @@ namespace Horo {
 
         static std::vector<LineVertex> s_lines;
         static std::unique_ptr<Shader> s_shader;
-        static unsigned int s_vao;
-        static unsigned int s_vbo;
+        static std::shared_ptr<IVertexArray>  s_vao;
+        static std::shared_ptr<IVertexBuffer> s_vbo;
         static bool s_initialized;
     };
 } // namespace Horo

--- a/renderer/DebugHUD.cpp
+++ b/renderer/DebugHUD.cpp
@@ -1,9 +1,5 @@
 #include "renderer/DebugHUD.h"
 
-// TODO(renderer-abstraction): Goal 5 will replace these call sites with
-//   OpenGLVertexArray / OpenGLVertexBuffer.
-#include <glad/glad.h>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -17,19 +13,12 @@
 #include "input/KeyCodes.h"
 #include "renderer/Renderer.h"
 
-// Windows headers (pulled in by glad) define DrawText as DrawTextA — undefine
-// to avoid collision
-#ifdef DrawText
-#undef DrawText // NOSONAR: cpp:S959 DrawText macro originates in platform
-// headers; local undef avoids symbol collision in this TU
-#endif
-
 namespace Horo {
     // ---- Static member definitions ----
 
-    unsigned int DebugHUD::s_vao = 0;
-    unsigned int DebugHUD::s_vbo = 0;
-    unsigned int DebugHUD::s_fontTex = 0;
+    std::shared_ptr<IVertexArray>  DebugHUD::s_vao;
+    std::shared_ptr<IVertexBuffer> DebugHUD::s_vbo;
+    std::shared_ptr<ITexture>      DebugHUD::s_fontTex;
     std::unique_ptr<Shader> DebugHUD::s_shader;
     bool DebugHUD::s_initialized = false;
     bool DebugHUD::s_visible = false;
@@ -1255,49 +1244,24 @@ void main() {
 
         BuildFontAtlas();
 
-        glGenVertexArrays(1, &s_vao);
-        glBindVertexArray(s_vao);
+        s_vbo = Renderer::CreateVertexBuffer(
+            static_cast<uint32_t>(sizeof(GlyphVertex) * MAX_GLYPHS * 6));
+        s_vbo->SetLayout({
+            {ShaderDataType::Float2, "a_pos"},
+            {ShaderDataType::Float2, "a_uv"},
+            {ShaderDataType::Float4, "a_color"},
+        });
 
-        glGenBuffers(1, &s_vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(GlyphVertex) * MAX_GLYPHS * 6, nullptr,
-                     GL_DYNAMIC_DRAW);
-
-        // a_pos  (location 0): 2 floats
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(GlyphVertex),
-                              static_cast<const void *>(nullptr));
-        // a_uv   (location 1): 2 floats
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(
-            1, 2, GL_FLOAT, GL_FALSE, sizeof(GlyphVertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      2 * sizeof(float)));
-        // a_color (location 2): 4 floats
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(
-            2, 4, GL_FLOAT, GL_FALSE, sizeof(GlyphVertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      4 * sizeof(float)));
-
-        glBindVertexArray(0);
+        s_vao = Renderer::CreateVertexArray();
+        s_vao->AddVertexBuffer(s_vbo);
 
         s_initialized = true;
     }
 
     void DebugHUD::Shutdown() {
-        if (s_fontTex) {
-            glDeleteTextures(1, &s_fontTex);
-            s_fontTex = 0;
-        }
-        if (s_vbo) {
-            glDeleteBuffers(1, &s_vbo);
-            s_vbo = 0;
-        }
-        if (s_vao) {
-            glDeleteVertexArrays(1, &s_vao);
-            s_vao = 0;
-        }
+        s_fontTex.reset();
+        s_vbo.reset();
+        s_vao.reset();
         s_shader.reset();
         s_initialized = false;
     }
@@ -1310,7 +1274,7 @@ void main() {
     // ---- Font atlas ----
 
     void DebugHUD::BuildFontAtlas() {
-        // 128 chars × 8 pixels wide = 1024 wide, 8 tall, GL_R8
+        // 128 chars × 8 pixels wide = 1024 wide, 8 tall, R8
         constexpr int ATLAS_W = 1024;
         constexpr int ATLAS_H = 8;
 
@@ -1328,15 +1292,17 @@ void main() {
             }
         }
 
-        glGenTextures(1, &s_fontTex);
-        glBindTexture(GL_TEXTURE_2D, s_fontTex);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, ATLAS_W, ATLAS_H, 0, GL_RED,
-                     GL_UNSIGNED_BYTE, pixels.data());
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glBindTexture(GL_TEXTURE_2D, 0);
+        TextureSpec spec;
+        spec.width        = ATLAS_W;
+        spec.height       = ATLAS_H;
+        spec.format       = TextureFormat::R8;
+        spec.filter       = TextureFilter::Nearest;
+        spec.wrap         = TextureWrap::ClampToEdge;
+        spec.generateMips = false;
+
+        s_fontTex = Renderer::CreateTexture(spec);
+        s_fontTex->SetData(pixels.data(),
+                           static_cast<uint32_t>(pixels.size() * sizeof(uint8_t)));
     }
 
 #ifndef NDEBUG
@@ -1419,15 +1385,7 @@ void main() {
             return;
 #endif
 
-        // Save GL state
-        GLboolean depthWas = glIsEnabled(GL_DEPTH_TEST);
-        GLboolean blendWas = glIsEnabled(GL_BLEND);
-        GLboolean cullWas = glIsEnabled(GL_CULL_FACE);
-
-        glDisable(GL_DEPTH_TEST);
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glDisable(GL_CULL_FACE);
+        Renderer::Begin2dOverlay();
 
         s_glyphCount = 0;
 
@@ -1566,19 +1524,7 @@ void main() {
 
         FlushGlyphs();
 
-        // Restore GL state
-        if (depthWas)
-            glEnable(GL_DEPTH_TEST);
-        else
-            glDisable(GL_DEPTH_TEST);
-        if (blendWas)
-            glEnable(GL_BLEND);
-        else
-            glDisable(GL_BLEND);
-        if (cullWas)
-            glEnable(GL_CULL_FACE);
-        else
-            glDisable(GL_CULL_FACE);
+        Renderer::End2dOverlay();
     }
 
 #ifndef NDEBUG
@@ -1683,20 +1629,16 @@ void main() {
         s_shader->SetVec2("u_screenSize", static_cast<float>(s_screenW),
                           static_cast<float>(s_screenH));
 
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, s_fontTex);
+        s_fontTex->Bind(0);
         s_shader->SetInt("u_font", 0);
 
-        glBindVertexArray(s_vao);
-        glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
-        glBufferSubData(
-            GL_ARRAY_BUFFER, 0,
-            static_cast<GLsizeiptr>(s_glyphCount * 6 * sizeof(GlyphVertex)),
-            s_glyphBuf.data());
+        s_vbo->SetData(s_glyphBuf.data(),
+                       static_cast<uint32_t>(s_glyphCount * 6 * sizeof(GlyphVertex)));
 
-        glDrawArrays(GL_TRIANGLES, 0, s_glyphCount * 6);
+        s_vao->Bind();
+        s_vao->DrawArrays(static_cast<uint32_t>(s_glyphCount * 6));
+        s_vao->Unbind();
 
-        glBindVertexArray(0);
         s_glyphCount = 0;
     }
 } // namespace Horo

--- a/renderer/DebugHUD.h
+++ b/renderer/DebugHUD.h
@@ -6,6 +6,9 @@
 
 #include "math/Mat4.h"
 #include "math/Vec3.h"
+#include "renderer/ITexture.h"
+#include "renderer/IVertexArray.h"
+#include "renderer/IVertexBuffer.h"
 #include "renderer/Shader.h"
 
 namespace Horo {
@@ -64,9 +67,9 @@ namespace Horo {
             float a;
         };
 
-        static unsigned int s_vao;
-        static unsigned int s_vbo;
-        static unsigned int s_fontTex;
+        static std::shared_ptr<IVertexArray>  s_vao;
+        static std::shared_ptr<IVertexBuffer> s_vbo;
+        static std::shared_ptr<ITexture>      s_fontTex;
         static std::unique_ptr<Shader> s_shader;
         static bool s_initialized;
         static bool s_visible;

--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -58,27 +58,22 @@ namespace Horo {
                                                std::string *outError) = 0;
 
         // ── Viewport ────────────────────────────────────────────────────────────
-        virtual void SetViewport(int x, int y, int w, int h) = 0;
-        virtual std::array<int, 4> GetViewport() const = 0;
+        virtual void SetViewport(int, int, int, int) {}
+        virtual std::array<int, 4> GetViewport() const { return {0, 0, 0, 0}; }
 
         // ── 2-D overlay state ────────────────────────────────────────────────────
-        // Saves current depth / blend / cull state, then disables depth + cull and
-        // enables alpha blending — suitable for HUD / text overlay rendering.
-        virtual void Begin2dOverlay() = 0;
-        // Restores the state saved by the matching Begin2dOverlay call.
-        virtual void End2dOverlay() = 0;
+        virtual void Begin2dOverlay() {}
+        virtual void End2dOverlay() {}
 
         // ── Offscreen / thumbnail helpers ────────────────────────────────────────
-        // Enable depth test + back-face culling; used before thumbnail render passes.
-        virtual void SetupOpaqueRenderState() = 0;
-        // Clear color and depth of the currently bound framebuffer.
-        virtual void ClearColorAndDepth(float r, float g, float b, float a) = 0;
+        virtual void SetupOpaqueRenderState() {}
+        virtual void ClearColorAndDepth(float, float, float, float) {}
 
         // Read a sub-region of the currently bound READ framebuffer as RGBA8.
         // Returns false on failure (e.g. invalid coords or no GL context).
-        virtual bool ReadbackRegionRgba8(int x, int y, int w, int h,
-                                         uint32_t *pixels,
-                                         std::string *outError) = 0;
+        virtual bool ReadbackRegionRgba8(int, int, int, int,
+                                         uint32_t *,
+                                         std::string *) { return false; }
 
         // ── Resource Factory ────────────────────────────────────────────────────
         // Default implementations return nullptr; concrete backends override these.

--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -55,6 +56,29 @@ namespace Horo {
         TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
                                                bool needsYFlip,
                                                std::string *outError) = 0;
+
+        // ── Viewport ────────────────────────────────────────────────────────────
+        virtual void SetViewport(int x, int y, int w, int h) = 0;
+        virtual std::array<int, 4> GetViewport() const = 0;
+
+        // ── 2-D overlay state ────────────────────────────────────────────────────
+        // Saves current depth / blend / cull state, then disables depth + cull and
+        // enables alpha blending — suitable for HUD / text overlay rendering.
+        virtual void Begin2dOverlay() = 0;
+        // Restores the state saved by the matching Begin2dOverlay call.
+        virtual void End2dOverlay() = 0;
+
+        // ── Offscreen / thumbnail helpers ────────────────────────────────────────
+        // Enable depth test + back-face culling; used before thumbnail render passes.
+        virtual void SetupOpaqueRenderState() = 0;
+        // Clear color and depth of the currently bound framebuffer.
+        virtual void ClearColorAndDepth(float r, float g, float b, float a) = 0;
+
+        // Read a sub-region of the currently bound READ framebuffer as RGBA8.
+        // Returns false on failure (e.g. invalid coords or no GL context).
+        virtual bool ReadbackRegionRgba8(int x, int y, int w, int h,
+                                         uint32_t *pixels,
+                                         std::string *outError) = 0;
 
         // ── Resource Factory ────────────────────────────────────────────────────
         // Default implementations return nullptr; concrete backends override these.

--- a/renderer/IRenderBackend.h
+++ b/renderer/IRenderBackend.h
@@ -58,16 +58,16 @@ namespace Horo {
                                                std::string *outError) = 0;
 
         // ── Viewport ────────────────────────────────────────────────────────────
-        virtual void SetViewport(int, int, int, int) {}
+        virtual void SetViewport(int, int, int, int) { /* default no-op */ }
         virtual std::array<int, 4> GetViewport() const { return {0, 0, 0, 0}; }
 
         // ── 2-D overlay state ────────────────────────────────────────────────────
-        virtual void Begin2dOverlay() {}
-        virtual void End2dOverlay() {}
+        virtual void Begin2dOverlay() { /* default no-op */ }
+        virtual void End2dOverlay()   { /* default no-op */ }
 
         // ── Offscreen / thumbnail helpers ────────────────────────────────────────
-        virtual void SetupOpaqueRenderState() {}
-        virtual void ClearColorAndDepth(float, float, float, float) {}
+        virtual void SetupOpaqueRenderState()              { /* default no-op */ }
+        virtual void ClearColorAndDepth(float, float, float, float) { /* default no-op */ }
 
         // Read a sub-region of the currently bound READ framebuffer as RGBA8.
         // Returns false on failure (e.g. invalid coords or no GL context).

--- a/renderer/IVertexArray.h
+++ b/renderer/IVertexArray.h
@@ -19,6 +19,16 @@ public:
 
     virtual const std::vector<std::shared_ptr<IVertexBuffer>>& GetVertexBuffers() const = 0;
     virtual const std::shared_ptr<IIndexBuffer>&               GetIndexBuffer()   const = 0;
+
+    // Issue a draw call for indexed triangle primitives (the VAO must be bound).
+    virtual void DrawIndexed(uint32_t count) const = 0;
+
+    // Issue a non-indexed draw call for the given vertex count using GL_TRIANGLES
+    // (the VAO must be bound).
+    virtual void DrawArrays(uint32_t count) const = 0;
+
+    // Issue a non-indexed draw call using GL_LINES (two vertices per line segment).
+    virtual void DrawArraysLines(uint32_t count) const = 0;
 };
 
 } // namespace Horo

--- a/renderer/IVertexBuffer.cpp
+++ b/renderer/IVertexBuffer.cpp
@@ -1,0 +1,61 @@
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+uint32_t ShaderDataTypeSize(ShaderDataType type) {
+    using enum ShaderDataType;
+    switch (type) {
+        case Float:  return 4;
+        case Float2: return 4 * 2;
+        case Float3: return 4 * 3;
+        case Float4: return 4 * 4;
+        case Mat3:   return 4 * 3 * 3;
+        case Mat4:   return 4 * 4 * 4;
+        case Int:    return 4;
+        case Int2:   return 4 * 2;
+        case Int3:   return 4 * 3;
+        case Int4:   return 4 * 4;
+        case Bool:   return 1;
+        case None:   return 0;
+    }
+    return 0;
+}
+
+BufferElement::BufferElement(ShaderDataType t, const std::string& n, bool norm)
+    : name(n), type(t), size(ShaderDataTypeSize(t)), normalized(norm) {}
+
+uint32_t BufferElement::GetComponentCount() const {
+    using enum ShaderDataType;
+    switch (type) {
+        case Float:  return 1;
+        case Float2: return 2;
+        case Float3: return 3;
+        case Float4: return 4;
+        case Mat3:   return 9;
+        case Mat4:   return 16;
+        case Int:    return 1;
+        case Int2:   return 2;
+        case Int3:   return 3;
+        case Int4:   return 4;
+        case Bool:   return 1;
+        case None:   return 0;
+    }
+    return 0;
+}
+
+BufferLayout::BufferLayout(std::initializer_list<BufferElement> elements)
+    : m_Elements(elements) {
+    CalculateOffsetsAndStride();
+}
+
+void BufferLayout::CalculateOffsetsAndStride() {
+    size_t offset = 0;
+    m_Stride = 0;
+    for (auto& element : m_Elements) {
+        element.offset  = offset;
+        offset          += element.size;
+        m_Stride        += element.size;
+    }
+}
+
+} // namespace Horo

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -101,13 +101,12 @@ namespace Horo {
         };
 
         auto vbo = std::make_shared<OpenGLVertexBuffer>(
-            reinterpret_cast<float *>(const_cast<Vertex *>(vertices.data())),
+            vertices.data(),
             static_cast<uint32_t>(vertices.size() * sizeof(Vertex)));
         vbo->SetLayout(layout);
 
         auto ibo = std::make_shared<OpenGLIndexBuffer>(
-            const_cast<uint32_t *>(
-                reinterpret_cast<const uint32_t *>(indices.data())),
+            indices.data(),
             static_cast<uint32_t>(indices.size()));
 
         auto vao = std::make_shared<OpenGLVertexArray>();

--- a/renderer/Mesh.cpp
+++ b/renderer/Mesh.cpp
@@ -1,11 +1,7 @@
 #include "renderer/Mesh.h"
 
-// clang-format off
-// TODO(renderer-abstraction): Goal 5 will replace these call sites with
-//   OpenGLVertexArray / OpenGLVertexBuffer / OpenGLIndexBuffer.
-#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
-// clang-format on
 
 #include <algorithm>
 #include <array>
@@ -15,6 +11,12 @@
 #include <utility>
 
 #include "math/MathUtils.h"
+#include "renderer/IIndexBuffer.h"
+#include "renderer/IVertexArray.h"
+#include "renderer/IVertexBuffer.h"
+#include "renderer/opengl/OpenGLIndexBuffer.h"
+#include "renderer/opengl/OpenGLVertexArray.h"
+#include "renderer/opengl/OpenGLVertexBuffer.h"
 
 namespace Horo {
     namespace {
@@ -22,9 +24,7 @@ namespace Horo {
     } // namespace
 
     struct Mesh::GpuStorage {
-        unsigned int vao = 0;
-        unsigned int vbo = 0;
-        unsigned int ebo = 0;
+        std::shared_ptr<IVertexArray> vao;
     };
 
     Mesh::Mesh() = default;
@@ -53,20 +53,10 @@ namespace Horo {
         return *this;
     }
 
-    bool Mesh::IsValid() const { return m_gpu && m_gpu->vao != 0; }
+    bool Mesh::IsValid() const { return m_gpu && m_gpu->vao != nullptr; }
 
     void Mesh::Release() {
-        if (m_gpu) {
-            if (HasCurrentGlContext()) {
-                if (m_gpu->ebo)
-                    glDeleteBuffers(1, &m_gpu->ebo);
-                if (m_gpu->vbo)
-                    glDeleteBuffers(1, &m_gpu->vbo);
-                if (m_gpu->vao)
-                    glDeleteVertexArrays(1, &m_gpu->vao);
-            }
-            m_gpu.reset();
-        }
+        m_gpu.reset();
         m_indexCount = 0;
         m_cpuVertices.clear();
         m_cpuIndices.clear();
@@ -104,43 +94,26 @@ namespace Horo {
 
         m_gpu = std::make_unique<GpuStorage>();
 
-        glGenVertexArrays(1, &m_gpu->vao);
-        glBindVertexArray(m_gpu->vao);
+        BufferLayout layout = {
+            {ShaderDataType::Float3, "a_position"},
+            {ShaderDataType::Float3, "a_normal"},
+            {ShaderDataType::Float2, "a_uv"},
+        };
 
-        glGenBuffers(1, &m_gpu->vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
-        glBufferData(GL_ARRAY_BUFFER,
-                     static_cast<GLsizeiptr>(vertices.size() * sizeof(Vertex)),
-                     vertices.data(), GL_STATIC_DRAW);
+        auto vbo = std::make_shared<OpenGLVertexBuffer>(
+            reinterpret_cast<float *>(const_cast<Vertex *>(vertices.data())),
+            static_cast<uint32_t>(vertices.size() * sizeof(Vertex)));
+        vbo->SetLayout(layout);
 
-        glGenBuffers(1, &m_gpu->ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                     static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
-                     indices.data(), GL_STATIC_DRAW);
+        auto ibo = std::make_shared<OpenGLIndexBuffer>(
+            const_cast<uint32_t *>(
+                reinterpret_cast<const uint32_t *>(indices.data())),
+            static_cast<uint32_t>(indices.size()));
 
-        // Position (location 0)
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(
-            0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(Vertex, position)));
-
-        // Normal (location 1)
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(
-            1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(Vertex, normal)));
-
-        // UV (location 2)
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(
-            2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(Vertex, uv)));
-
-        glBindVertexArray(0);
+        auto vao = std::make_shared<OpenGLVertexArray>();
+        vao->AddVertexBuffer(vbo);
+        vao->SetIndexBuffer(ibo);
+        m_gpu->vao = std::move(vao);
 
         if (!vertices.empty()) {
             Vec3 lo = vertices[0].position;
@@ -159,17 +132,16 @@ namespace Horo {
     }
 
     void Mesh::Draw() const {
-        if (!m_gpu)
+        if (!m_gpu || !m_gpu->vao)
             return;
-        glBindVertexArray(m_gpu->vao);
-        glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
-        glBindVertexArray(0);
+        m_gpu->vao->Bind();
+        m_gpu->vao->DrawIndexed(static_cast<uint32_t>(m_indexCount));
+        m_gpu->vao->Unbind();
     }
 
     void Mesh::DrawWireframe() const {
-        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+        // Polygon-mode state is set by OpenGLRenderBackend::DrawWireframe.
         Draw();
-        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     }
 
     // ---- Procedural generators ----

--- a/renderer/OpenGLRenderBackend.cpp
+++ b/renderer/OpenGLRenderBackend.cpp
@@ -1,6 +1,7 @@
 #include "renderer/OpenGLRenderBackend.h"
 
 #include <algorithm>
+#include <array>
 #include <format>
 #include <string>
 
@@ -17,6 +18,12 @@
 #include "renderer/Mesh.h"
 #include "renderer/Shader.h"
 #include "renderer/SkinnedMesh.h"
+#include "renderer/opengl/OpenGLFramebuffer.h"
+#include "renderer/opengl/OpenGLIndexBuffer.h"
+#include "renderer/opengl/OpenGLShader.h"
+#include "renderer/opengl/OpenGLTexture.h"
+#include "renderer/opengl/OpenGLVertexArray.h"
+#include "renderer/opengl/OpenGLVertexBuffer.h"
 
 namespace Horo {
     namespace {
@@ -258,8 +265,129 @@ namespace Horo {
         command.shader->SetMat4("u_projection", m_activeView.projection);
         command.shader->SetVec4("u_color", command.color);
 
+        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         command.mesh->DrawWireframe();
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
         ++m_drawCalls;
     }
 
+    void OpenGLRenderBackend::SetViewport(int x, int y, int w, int h) {
+        glViewport(x, y, w, h);
+    }
+
+    std::array<int, 4> OpenGLRenderBackend::GetViewport() const {
+        std::array<int, 4> vp{};
+        glGetIntegerv(GL_VIEWPORT, vp.data());
+        return vp;
+    }
+
+    void OpenGLRenderBackend::Begin2dOverlay() {
+        m_overlayDepthWas = glIsEnabled(GL_DEPTH_TEST) == GL_TRUE;
+        m_overlayBlendWas = glIsEnabled(GL_BLEND) == GL_TRUE;
+        m_overlayCullWas  = glIsEnabled(GL_CULL_FACE) == GL_TRUE;
+        glDisable(GL_DEPTH_TEST);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glDisable(GL_CULL_FACE);
+    }
+
+    void OpenGLRenderBackend::End2dOverlay() {
+        if (m_overlayDepthWas)
+            glEnable(GL_DEPTH_TEST);
+        else
+            glDisable(GL_DEPTH_TEST);
+        if (m_overlayBlendWas)
+            glEnable(GL_BLEND);
+        else
+            glDisable(GL_BLEND);
+        if (m_overlayCullWas)
+            glEnable(GL_CULL_FACE);
+        else
+            glDisable(GL_CULL_FACE);
+    }
+
+    void OpenGLRenderBackend::SetupOpaqueRenderState() {
+        glEnable(GL_DEPTH_TEST);
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
+    }
+
+    void OpenGLRenderBackend::ClearColorAndDepth(float r, float g, float b,
+                                                  float a) {
+        glClearColor(r, g, b, a);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
+
+    bool OpenGLRenderBackend::ReadbackRegionRgba8(int x, int y, int w, int h,
+                                                   uint32_t *pixels,
+                                                   std::string *outError) {
+        if (!pixels || w <= 0 || h <= 0) {
+            if (outError)
+                *outError = "ReadbackRegionRgba8: invalid parameters.";
+            return false;
+        }
+        glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
+            if (outError)
+                *outError =
+                    std::format("ReadbackRegionRgba8: glReadPixels failed (GL "
+                                "error 0x{:x}).",
+                                err);
+            return false;
+        }
+        return true;
+    }
+
+    // ── Resource factory ─────────────────────────────────────────────────────
+
+    std::shared_ptr<IShader> OpenGLRenderBackend::CreateShader(
+        const std::string &vertSrc, const std::string &fragSrc) {
+        return std::make_shared<OpenGLShader>(
+            OpenGLShader::FromSource(vertSrc, fragSrc));
+    }
+
+    std::shared_ptr<IShader> OpenGLRenderBackend::CreateShaderFromFile(
+        const std::string &vertPath, const std::string &fragPath) {
+        return std::make_shared<OpenGLShader>(
+            OpenGLShader::FromFiles(vertPath, fragPath));
+    }
+
+    std::shared_ptr<ITexture> OpenGLRenderBackend::CreateTexture(
+        const TextureSpec &spec) {
+        auto tex = std::make_shared<OpenGLTexture>();
+        // The spec encodes width/height/format; SetData must be called separately
+        // to upload pixel data.  We store the spec but don't allocate storage
+        // until the first SetData call (lazy allocation is handled by the texture).
+        (void)spec; // spec forwarding deferred; caller must call SetData
+        return tex;
+    }
+
+    std::shared_ptr<ITexture> OpenGLRenderBackend::CreateTextureFromFile(
+        const std::string &path) {
+        return std::make_shared<OpenGLTexture>(OpenGLTexture::FromFile(path));
+    }
+
+    std::shared_ptr<IFramebuffer> OpenGLRenderBackend::CreateFramebuffer(
+        const FramebufferSpec &spec) {
+        return std::make_shared<OpenGLFramebuffer>(spec);
+    }
+
+    std::shared_ptr<IVertexBuffer> OpenGLRenderBackend::CreateVertexBuffer(
+        float *vertices, uint32_t size) {
+        return std::make_shared<OpenGLVertexBuffer>(vertices, size);
+    }
+
+    std::shared_ptr<IVertexBuffer> OpenGLRenderBackend::CreateVertexBuffer(
+        uint32_t size) {
+        return std::make_shared<OpenGLVertexBuffer>(size);
+    }
+
+    std::shared_ptr<IIndexBuffer> OpenGLRenderBackend::CreateIndexBuffer(
+        uint32_t *indices, uint32_t count) {
+        return std::make_shared<OpenGLIndexBuffer>(indices, count);
+    }
+
+    std::shared_ptr<IVertexArray> OpenGLRenderBackend::CreateVertexArray() {
+        return std::make_shared<OpenGLVertexArray>();
+    }
 } // namespace Horo

--- a/renderer/OpenGLRenderBackend.h
+++ b/renderer/OpenGLRenderBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -43,6 +44,30 @@ namespace Horo {
                                                     bool needsYFlip,
                                                     std::string *outError) override;
 
+        // ── Resource Factory (implemented in renderer/opengl/) ──────────────
+        std::shared_ptr<IShader>       CreateShader(const std::string& vertSrc,
+                                                    const std::string& fragSrc) override;
+        std::shared_ptr<IShader>       CreateShaderFromFile(const std::string& vertPath,
+                                                            const std::string& fragPath) override;
+        std::shared_ptr<ITexture>      CreateTexture(const TextureSpec& spec) override;
+        std::shared_ptr<ITexture>      CreateTextureFromFile(const std::string& path) override;
+        std::shared_ptr<IFramebuffer>  CreateFramebuffer(const FramebufferSpec& spec) override;
+        std::shared_ptr<IVertexBuffer> CreateVertexBuffer(float* vertices, uint32_t size) override;
+        std::shared_ptr<IVertexBuffer> CreateVertexBuffer(uint32_t size) override;
+        std::shared_ptr<IIndexBuffer>  CreateIndexBuffer(uint32_t* indices, uint32_t count) override;
+        std::shared_ptr<IVertexArray>  CreateVertexArray() override;
+        void SetViewport(int x, int y, int w, int h) override;
+        std::array<int, 4> GetViewport() const override;
+
+        void Begin2dOverlay() override;
+        void End2dOverlay() override;
+
+        void SetupOpaqueRenderState() override;
+        void ClearColorAndDepth(float r, float g, float b, float a) override;
+
+        bool ReadbackRegionRgba8(int x, int y, int w, int h, uint32_t *pixels,
+                                 std::string *outError) override;
+
     private:
         void UploadLights(const Shader &shader);
 
@@ -55,5 +80,9 @@ namespace Horo {
         bool m_passActive = false;
         bool m_previousDepthTestEnabled = true;
         bool m_hasPassStateOverride = false;
+        // State saved by Begin2dOverlay / restored by End2dOverlay.
+        bool m_overlayDepthWas = false;
+        bool m_overlayBlendWas = false;
+        bool m_overlayCullWas  = false;
     };
 } // namespace Horo

--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -2,6 +2,7 @@
 
 // TODO(renderer-abstraction): CreateDefaultOwnedBackend assert message below references
 // "OpenGL" by name — update to "default render backend" in Goal 3.
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -239,5 +240,26 @@ namespace Horo {
 
     std::shared_ptr<IVertexArray> Renderer::CreateVertexArray() {
         return ActiveBackend()->CreateVertexArray();
+    }
+
+    void Renderer::SetViewport(int x, int y, int w, int h) {
+        ActiveBackend()->SetViewport(x, y, w, h);
+    }
+
+    std::array<int, 4> Renderer::GetViewport() {
+        return ActiveBackend()->GetViewport();
+    }
+
+    void Renderer::Begin2dOverlay()         { ActiveBackend()->Begin2dOverlay(); }
+    void Renderer::End2dOverlay()           { ActiveBackend()->End2dOverlay(); }
+    void Renderer::SetupOpaqueRenderState() { ActiveBackend()->SetupOpaqueRenderState(); }
+
+    void Renderer::ClearColorAndDepth(float r, float g, float b, float a) {
+        ActiveBackend()->ClearColorAndDepth(r, g, b, a);
+    }
+
+    bool Renderer::ReadbackRegionRgba8(int x, int y, int w, int h,
+                                        uint32_t *pixels, std::string *outError) {
+        return ActiveBackend()->ReadbackRegionRgba8(x, y, w, h, pixels, outError);
     }
 } // namespace Horo

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -96,6 +97,17 @@ namespace Horo {
         static std::shared_ptr<IVertexBuffer> CreateVertexBuffer(uint32_t size);
         static std::shared_ptr<IIndexBuffer>  CreateIndexBuffer(uint32_t* indices, uint32_t count);
         static std::shared_ptr<IVertexArray>  CreateVertexArray();
+
+        // ── Backend-agnostic render helpers ─────────────────────────────────────
+        static void SetViewport(int x, int y, int w, int h);
+        static std::array<int, 4> GetViewport();
+        static void Begin2dOverlay();
+        static void End2dOverlay();
+        static void SetupOpaqueRenderState();
+        static void ClearColorAndDepth(float r, float g, float b, float a = 1.f);
+        static bool ReadbackRegionRgba8(int x, int y, int w, int h,
+                                        uint32_t *pixels,
+                                        std::string *outError = nullptr);
 
     private:
         static IRenderBackend *ActiveBackend();

--- a/renderer/SkinnedMesh.cpp
+++ b/renderer/SkinnedMesh.cpp
@@ -114,14 +114,12 @@ namespace Horo {
         };
 
         auto vbo = std::make_shared<OpenGLVertexBuffer>(
-            reinterpret_cast<float *>(
-                const_cast<SkinnedVertex *>(vertices.data())),
+            vertices.data(),
             static_cast<uint32_t>(vertices.size() * sizeof(SkinnedVertex)));
         vbo->SetLayout(layout);
 
         auto ibo = std::make_shared<OpenGLIndexBuffer>(
-            const_cast<uint32_t *>(
-                reinterpret_cast<const uint32_t *>(indices.data())),
+            indices.data(),
             static_cast<uint32_t>(indices.size()));
 
         auto vao = std::make_shared<OpenGLVertexArray>();

--- a/renderer/SkinnedMesh.cpp
+++ b/renderer/SkinnedMesh.cpp
@@ -1,16 +1,19 @@
 #include "renderer/SkinnedMesh.h"
 
-// clang-format off
-// TODO(renderer-abstraction): Goal 5 will replace these call sites with
-//   OpenGLVertexArray / OpenGLVertexBuffer / OpenGLIndexBuffer.
-#include <glad/glad.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
-// clang-format on
 
 #include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <utility>
+
+#include "renderer/IIndexBuffer.h"
+#include "renderer/IVertexArray.h"
+#include "renderer/IVertexBuffer.h"
+#include "renderer/opengl/OpenGLIndexBuffer.h"
+#include "renderer/opengl/OpenGLVertexArray.h"
+#include "renderer/opengl/OpenGLVertexBuffer.h"
 
 namespace Horo {
     namespace {
@@ -18,9 +21,7 @@ namespace Horo {
     } // namespace
 
     struct SkinnedMesh::GpuStorage {
-        unsigned int vao = 0;
-        unsigned int vbo = 0;
-        unsigned int ebo = 0;
+        std::shared_ptr<IVertexArray> vao;
     };
 
     SkinnedMesh::SkinnedMesh() = default;
@@ -49,7 +50,7 @@ namespace Horo {
         return *this;
     }
 
-    bool SkinnedMesh::IsValid() const { return m_gpu && m_gpu->vao != 0; }
+    bool SkinnedMesh::IsValid() const { return m_gpu && m_gpu->vao != nullptr; }
 
     // ---------------------------------------------------------------------------
     // Public API
@@ -62,11 +63,11 @@ namespace Horo {
     }
 
     void SkinnedMesh::Draw() const {
-        if (!m_gpu)
+        if (!m_gpu || !m_gpu->vao)
             return;
-        glBindVertexArray(m_gpu->vao);
-        glDrawElements(GL_TRIANGLES, m_indexCount, GL_UNSIGNED_INT, nullptr);
-        glBindVertexArray(0);
+        m_gpu->vao->Bind();
+        m_gpu->vao->DrawIndexed(static_cast<uint32_t>(m_indexCount));
+        m_gpu->vao->Unbind();
     }
 
     // ---------------------------------------------------------------------------
@@ -98,76 +99,39 @@ namespace Horo {
 
         m_gpu = std::make_unique<GpuStorage>();
 
-        glGenVertexArrays(1, &m_gpu->vao);
-        glBindVertexArray(m_gpu->vao);
+        // SkinnedVertex layout:
+        //   location 0 — position     (Float3)
+        //   location 1 — normal       (Float3)
+        //   location 2 — uv           (Float2)
+        //   location 3 — boneIndices  (Int4)
+        //   location 4 — boneWeights  (Float4)
+        BufferLayout layout = {
+            {ShaderDataType::Float3, "a_position"},
+            {ShaderDataType::Float3, "a_normal"},
+            {ShaderDataType::Float2, "a_uv"},
+            {ShaderDataType::Int4,   "a_boneIndices"},
+            {ShaderDataType::Float4, "a_boneWeights"},
+        };
 
-        // --- VBO ---
-        glGenBuffers(1, &m_gpu->vbo);
-        glBindBuffer(GL_ARRAY_BUFFER, m_gpu->vbo);
-        glBufferData(GL_ARRAY_BUFFER,
-                     static_cast<GLsizeiptr>(vertices.size() * sizeof(SkinnedVertex)),
-                     vertices.data(), GL_STATIC_DRAW);
+        auto vbo = std::make_shared<OpenGLVertexBuffer>(
+            reinterpret_cast<float *>(
+                const_cast<SkinnedVertex *>(vertices.data())),
+            static_cast<uint32_t>(vertices.size() * sizeof(SkinnedVertex)));
+        vbo->SetLayout(layout);
 
-        // --- EBO ---
-        glGenBuffers(1, &m_gpu->ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_gpu->ebo);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                     static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
-                     indices.data(), GL_STATIC_DRAW);
+        auto ibo = std::make_shared<OpenGLIndexBuffer>(
+            const_cast<uint32_t *>(
+                reinterpret_cast<const uint32_t *>(indices.data())),
+            static_cast<uint32_t>(indices.size()));
 
-        const auto stride = static_cast<GLsizei>(sizeof(SkinnedVertex));
-
-        // Location 0 — position (vec3)
-        glEnableVertexAttribArray(0);
-        glVertexAttribPointer(
-            0, 3, GL_FLOAT, GL_FALSE, stride,
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(SkinnedVertex, position)));
-
-        // Location 1 — normal (vec3)
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(
-            1, 3, GL_FLOAT, GL_FALSE, stride,
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(SkinnedVertex, normal)));
-
-        // Location 2 — uv (vec2)
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(
-            2, 2, GL_FLOAT, GL_FALSE, stride,
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(SkinnedVertex, uv)));
-
-        // Location 3 — boneIndices (ivec4)
-        // Must use glVertexAttribIPointer so the integers are not converted to float.
-        glEnableVertexAttribArray(3);
-        glVertexAttribIPointer(
-            3, 4, GL_INT, stride,
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(SkinnedVertex, boneIndices)));
-
-        // Location 4 — boneWeights (vec4)
-        glEnableVertexAttribArray(4);
-        glVertexAttribPointer(
-            4, 4, GL_FLOAT, GL_FALSE, stride,
-            static_cast<const void *>(static_cast<const std::byte *>(nullptr) +
-                                      offsetof(SkinnedVertex, boneWeights)));
-
-        glBindVertexArray(0);
+        auto vao = std::make_shared<OpenGLVertexArray>();
+        vao->AddVertexBuffer(vbo);
+        vao->SetIndexBuffer(ibo);
+        m_gpu->vao = std::move(vao);
     }
 
     void SkinnedMesh::Release() {
-        if (m_gpu) {
-            if (HasCurrentGlContext()) {
-                if (m_gpu->ebo)
-                    glDeleteBuffers(1, &m_gpu->ebo);
-                if (m_gpu->vbo)
-                    glDeleteBuffers(1, &m_gpu->vbo);
-                if (m_gpu->vao)
-                    glDeleteVertexArrays(1, &m_gpu->vao);
-            }
-            m_gpu.reset();
-        }
+        m_gpu.reset();
         m_indexCount = 0;
     }
 } // namespace Horo

--- a/renderer/VulkanRenderBackend.cpp
+++ b/renderer/VulkanRenderBackend.cpp
@@ -3857,5 +3857,24 @@ namespace Horo {
         return nullptr;
     }
 
+    // ── Backend-agnostic state helpers (no-op stubs for Vulkan) ─────────────
+
+    void VulkanRenderBackend::SetViewport(int, int, int, int) {}
+
+    std::array<int, 4> VulkanRenderBackend::GetViewport() const {
+        return {0, 0, 0, 0};
+    }
+
+    void VulkanRenderBackend::Begin2dOverlay() {}
+    void VulkanRenderBackend::End2dOverlay() {}
+    void VulkanRenderBackend::SetupOpaqueRenderState() {}
+    void VulkanRenderBackend::ClearColorAndDepth(float, float, float, float) {}
+
+    bool VulkanRenderBackend::ReadbackRegionRgba8(int, int, int, int, uint32_t *,
+                                                   std::string *outError) {
+        if (outError) *outError = "ReadbackRegionRgba8 not supported on Vulkan.";
+        return false;
+    }
+
 #endif
 } // namespace Horo

--- a/renderer/VulkanRenderBackend.h
+++ b/renderer/VulkanRenderBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -66,6 +67,16 @@ namespace Horo {
         std::shared_ptr<IVertexBuffer> CreateVertexBuffer(uint32_t size) override;
         std::shared_ptr<IIndexBuffer>  CreateIndexBuffer(uint32_t* indices, uint32_t count) override;
         std::shared_ptr<IVertexArray>  CreateVertexArray() override;
+
+        // ── Backend-agnostic state helpers ───────────────────────────────────
+        void SetViewport(int x, int y, int w, int h) override;
+        std::array<int, 4> GetViewport() const override;
+        void Begin2dOverlay() override;
+        void End2dOverlay() override;
+        void SetupOpaqueRenderState() override;
+        void ClearColorAndDepth(float r, float g, float b, float a) override;
+        bool ReadbackRegionRgba8(int x, int y, int w, int h, uint32_t *pixels,
+                                 std::string *outError) override;
 
         RenderBackendId GetBackendId() const override {
             return RenderBackendId::Vulkan;

--- a/renderer/null/NullFramebuffer.h
+++ b/renderer/null/NullFramebuffer.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IFramebuffer.h"
+
+namespace Horo {
+
+class NullFramebuffer final : public IFramebuffer {
+public:
+    explicit NullFramebuffer(const FramebufferSpec &spec = {}) : m_spec(spec) {}
+
+    void Bind()   override {}
+    void Unbind() override {}
+    void Resize(uint32_t w, uint32_t h) override {
+        m_spec.width  = w;
+        m_spec.height = h;
+    }
+
+    uint32_t GetColorAttachmentId(uint32_t /*index*/ = 0) const override { return 0; }
+    int      ReadPixel(uint32_t /*index*/, int /*x*/, int /*y*/) override { return 0; }
+    void     ClearAttachment(uint32_t /*index*/, int /*value*/) override {}
+
+    const FramebufferSpec &GetSpec() const override { return m_spec; }
+
+private:
+    FramebufferSpec m_spec;
+};
+
+} // namespace Horo

--- a/renderer/null/NullIndexBuffer.h
+++ b/renderer/null/NullIndexBuffer.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IIndexBuffer.h"
+
+namespace Horo {
+
+class NullIndexBuffer final : public IIndexBuffer {
+public:
+    explicit NullIndexBuffer(uint32_t count = 0) : m_count(count) {}
+
+    void Bind()   const override {}
+    void Unbind() const override {}
+
+    uint32_t GetCount() const override { return m_count; }
+
+private:
+    uint32_t m_count = 0;
+};
+
+} // namespace Horo

--- a/renderer/null/NullRenderBackend.h
+++ b/renderer/null/NullRenderBackend.h
@@ -22,7 +22,7 @@ namespace Horo {
 class NullRenderBackend final : public IRenderBackend {
 public:
     // ── Lifecycle ──────────────────────────────────────────────────────────────
-    void BeginFrame(const RenderFrameConfig &) override {}
+    void BeginFrame(const RenderFrameConfig &) override { m_drawCalls = 0; }
     void EndFrame()                            override {}
     void BeginPass(const RenderPassConfig &)   override {}
     void EndPass()                             override {}

--- a/renderer/null/NullRenderBackend.h
+++ b/renderer/null/NullRenderBackend.h
@@ -43,14 +43,14 @@ public:
     bool ReadbackColorBgr8(int w, int h, std::vector<uint8_t> &out,
                            std::string *) override {
         if (w <= 0 || h <= 0) return false;
-        out.assign(static_cast<size_t>(w * h * 3), 0u);
+        out.assign(static_cast<size_t>(w) * static_cast<size_t>(h) * 3u, 0u);
         return true;
     }
 
     bool ReadbackDepth32F(int w, int h, std::vector<float> &out,
                           std::string *) override {
         if (w <= 0 || h <= 0) return false;
-        out.assign(static_cast<size_t>(w * h), 1.0f);
+        out.assign(static_cast<size_t>(w) * static_cast<size_t>(h), 1.0f);
         return true;
     }
 

--- a/renderer/null/NullRenderBackend.h
+++ b/renderer/null/NullRenderBackend.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "renderer/IRenderBackend.h"
+#include "renderer/null/NullFramebuffer.h"
+#include "renderer/null/NullIndexBuffer.h"
+#include "renderer/null/NullShader.h"
+#include "renderer/null/NullTexture.h"
+#include "renderer/null/NullVertexArray.h"
+#include "renderer/null/NullVertexBuffer.h"
+
+namespace Horo {
+
+// A zero-GPU backend used for headless unit tests and CI validation.
+// Every IRenderBackend method is a no-op; resource factory methods return
+// concrete Null* objects whose call-counts can be inspected in tests.
+class NullRenderBackend final : public IRenderBackend {
+public:
+    // ── Lifecycle ──────────────────────────────────────────────────────────────
+    void BeginFrame(const RenderFrameConfig &) override {}
+    void EndFrame()                            override {}
+    void BeginPass(const RenderPassConfig &)   override {}
+    void EndPass()                             override {}
+
+    // ── Draw submission ────────────────────────────────────────────────────────
+    void DrawMesh(const MeshDrawCommand &)               override { ++m_drawCalls; }
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &) override { ++m_drawCalls; }
+    void DrawWireframe(const WireframeDrawCommand &)     override { ++m_drawCalls; }
+
+    // ── Identity / capabilities ────────────────────────────────────────────────
+    RenderBackendId GetBackendId() const override { return RenderBackendId::Auto; }
+
+    RenderBackendCapabilities GetCapabilities() const override { return {}; }
+
+    int GetDrawCallCount() const override { return m_drawCalls; }
+
+    // ── Readback (succeeds with zeroed/1.0 data) ───────────────────────────────
+    bool ReadbackColorBgr8(int w, int h, std::vector<uint8_t> &out,
+                           std::string *) override {
+        if (w <= 0 || h <= 0) return false;
+        out.assign(static_cast<size_t>(w * h * 3), 0u);
+        return true;
+    }
+
+    bool ReadbackDepth32F(int w, int h, std::vector<float> &out,
+                          std::string *) override {
+        if (w <= 0 || h <= 0) return false;
+        out.assign(static_cast<size_t>(w * h), 1.0f);
+        return true;
+    }
+
+    bool EnsureEditorViewportRenderTarget(uint32_t, uint32_t,
+                                          std::string *) override { return true; }
+
+    bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                bool,
+                                                std::string *) override {
+        if (outHandle) *outHandle = {};
+        return false;
+    }
+
+    // ── Viewport ──────────────────────────────────────────────────────────────
+    void SetViewport(int x, int y, int w, int h) override {
+        m_viewport = {x, y, w, h};
+    }
+    std::array<int, 4> GetViewport() const override { return m_viewport; }
+
+    // ── 2-D overlay / offscreen helpers ───────────────────────────────────────
+    void Begin2dOverlay()        override {}
+    void End2dOverlay()          override {}
+    void SetupOpaqueRenderState() override {}
+    void ClearColorAndDepth(float, float, float, float) override {}
+
+    bool ReadbackRegionRgba8(int, int, int, int,
+                             uint32_t *,
+                             std::string *) override { return false; }
+
+    // ── Resource Factory ──────────────────────────────────────────────────────
+    std::shared_ptr<IShader> CreateShader(const std::string &,
+                                          const std::string &) override {
+        return std::make_shared<NullShader>();
+    }
+
+    std::shared_ptr<IShader> CreateShaderFromFile(const std::string &,
+                                                   const std::string &) override {
+        return std::make_shared<NullShader>();
+    }
+
+    std::shared_ptr<ITexture> CreateTexture(const TextureSpec &spec) override {
+        return std::make_shared<NullTexture>(spec);
+    }
+
+    std::shared_ptr<ITexture> CreateTextureFromFile(const std::string &) override {
+        return std::make_shared<NullTexture>();
+    }
+
+    std::shared_ptr<IFramebuffer> CreateFramebuffer(const FramebufferSpec &spec) override {
+        return std::make_shared<NullFramebuffer>(spec);
+    }
+
+    std::shared_ptr<IVertexBuffer> CreateVertexBuffer(float *, uint32_t) override {
+        return std::make_shared<NullVertexBuffer>();
+    }
+
+    std::shared_ptr<IVertexBuffer> CreateVertexBuffer(uint32_t) override {
+        return std::make_shared<NullVertexBuffer>();
+    }
+
+    std::shared_ptr<IIndexBuffer> CreateIndexBuffer(uint32_t *, uint32_t count) override {
+        return std::make_shared<NullIndexBuffer>(count);
+    }
+
+    std::shared_ptr<IVertexArray> CreateVertexArray() override {
+        return std::make_shared<NullVertexArray>();
+    }
+
+private:
+    int                m_drawCalls = 0;
+    std::array<int, 4> m_viewport  = {0, 0, 0, 0};
+};
+
+} // namespace Horo

--- a/renderer/null/NullShader.h
+++ b/renderer/null/NullShader.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <string>
+
+#include "math/Mat3.h"
+#include "math/Mat4.h"
+#include "math/Vec3.h"
+#include "math/Vec4.h"
+#include "renderer/IShader.h"
+
+namespace Horo {
+
+class NullShader final : public IShader {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    void Bind()   const override { ++bindCount; }
+    void Unbind() const override { ++unbindCount; }
+
+    void SetInt(const std::string &, int)               override {}
+    void SetFloat(const std::string &, float)           override {}
+    void SetVec2(const std::string &, float, float)     override {}
+    void SetVec3(const std::string &, const Vec3 &)     override {}
+    void SetVec4(const std::string &, const Vec4 &)     override {}
+    void SetMat3(const std::string &, const Mat3 &)     override {}
+    void SetMat4(const std::string &, const Mat4 &)     override {}
+    void SetMat4Array(const std::string &, int, const float *) override {}
+
+    bool IsValid() const override { return true; }
+};
+
+} // namespace Horo

--- a/renderer/null/NullTexture.h
+++ b/renderer/null/NullTexture.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/ITexture.h"
+#include "renderer/RenderTargetHandle.h"
+
+namespace Horo {
+
+class NullTexture final : public ITexture {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    explicit NullTexture(const TextureSpec &spec = {}) : m_spec(spec) {}
+
+    void Bind(uint32_t /*slot*/ = 0) const override { ++bindCount; }
+    void Unbind()                    const override { ++unbindCount; }
+
+    int GetWidth()  const override { return static_cast<int>(m_spec.width); }
+    int GetHeight() const override { return static_cast<int>(m_spec.height); }
+    const TextureSpec &GetSpec() const override { return m_spec; }
+
+    bool IsValid() const override { return true; }
+
+    void SetData(const void *, uint32_t) override {}
+
+    RenderTargetHandle GetRenderTargetHandle(bool /*needsYFlip*/ = false) const override {
+        return {};
+    }
+
+    bool operator==(const ITexture &other) const override {
+        return this == &other;
+    }
+
+private:
+    TextureSpec m_spec;
+};
+
+} // namespace Horo

--- a/renderer/null/NullVertexArray.h
+++ b/renderer/null/NullVertexArray.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "renderer/IVertexArray.h"
+#include "renderer/IIndexBuffer.h"
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+class NullVertexArray final : public IVertexArray {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    void Bind()   const override { ++bindCount; }
+    void Unbind() const override { ++unbindCount; }
+
+    void AddVertexBuffer(std::shared_ptr<IVertexBuffer> vb) override {
+        m_vertexBuffers.push_back(std::move(vb));
+    }
+    void SetIndexBuffer(std::shared_ptr<IIndexBuffer> ib) override {
+        m_indexBuffer = std::move(ib);
+    }
+
+    const std::vector<std::shared_ptr<IVertexBuffer>> &GetVertexBuffers() const override {
+        return m_vertexBuffers;
+    }
+    const std::shared_ptr<IIndexBuffer> &GetIndexBuffer() const override {
+        return m_indexBuffer;
+    }
+
+    void DrawIndexed(uint32_t) const override {}
+    void DrawArrays(uint32_t) const override {}
+    void DrawArraysLines(uint32_t) const override {}
+
+private:
+    std::vector<std::shared_ptr<IVertexBuffer>> m_vertexBuffers;
+    std::shared_ptr<IIndexBuffer>               m_indexBuffer;
+};
+
+} // namespace Horo

--- a/renderer/null/NullVertexBuffer.h
+++ b/renderer/null/NullVertexBuffer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+class NullVertexBuffer final : public IVertexBuffer {
+public:
+    void Bind()   const override {}
+    void Unbind() const override {}
+
+    void SetData(const void *, uint32_t) override {}
+
+    const BufferLayout &GetLayout() const override { return m_layout; }
+    void SetLayout(const BufferLayout &layout)    override { m_layout = layout; }
+
+private:
+    BufferLayout m_layout;
+};
+
+} // namespace Horo

--- a/renderer/opengl/OpenGLContext.cpp
+++ b/renderer/opengl/OpenGLContext.cpp
@@ -4,17 +4,16 @@
 
 namespace Horo::OpenGLContext {
 
-bool InitGlad(void *(*getProcAddress)(const char *)) {
-    return gladLoadGLLoader(
-               reinterpret_cast<GLADloadproc>(getProcAddress)) != 0;
+bool InitGlad(GLADloadproc getProcAddress) {
+    return gladLoadGLLoader(getProcAddress) != 0;
 }
 
 const char *GetGLVersion() {
-    return reinterpret_cast<const char *>(glGetString(GL_VERSION));
+    return reinterpret_cast<const char *>(glGetString(GL_VERSION)); // NOSONAR: OpenGL API returns const GLubyte*
 }
 
 const char *GetGLRenderer() {
-    return reinterpret_cast<const char *>(glGetString(GL_RENDERER));
+    return reinterpret_cast<const char *>(glGetString(GL_RENDERER)); // NOSONAR: OpenGL API returns const GLubyte*
 }
 
 } // namespace Horo::OpenGLContext

--- a/renderer/opengl/OpenGLContext.cpp
+++ b/renderer/opengl/OpenGLContext.cpp
@@ -1,0 +1,20 @@
+#include "renderer/opengl/OpenGLContext.h"
+
+#include <glad/glad.h>
+
+namespace Horo::OpenGLContext {
+
+bool InitGlad(void *(*getProcAddress)(const char *)) {
+    return gladLoadGLLoader(
+               reinterpret_cast<GLADloadproc>(getProcAddress)) != 0;
+}
+
+const char *GetGLVersion() {
+    return reinterpret_cast<const char *>(glGetString(GL_VERSION));
+}
+
+const char *GetGLRenderer() {
+    return reinterpret_cast<const char *>(glGetString(GL_RENDERER));
+}
+
+} // namespace Horo::OpenGLContext

--- a/renderer/opengl/OpenGLContext.h
+++ b/renderer/opengl/OpenGLContext.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Horo::OpenGLContext {
+
+// Load all OpenGL entry-points via the GLFW proc-address bridge.
+// Must be called once, on the thread that owns the current GL context,
+// after glfwMakeContextCurrent(). Returns true on success.
+bool InitGlad(void *(*getProcAddress)(const char *));
+
+// Return GL_VERSION / GL_RENDERER strings (valid after InitGlad succeeds).
+const char *GetGLVersion();
+const char *GetGLRenderer();
+
+} // namespace Horo::OpenGLContext

--- a/renderer/opengl/OpenGLContext.h
+++ b/renderer/opengl/OpenGLContext.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <glad/glad.h>
+
 namespace Horo::OpenGLContext {
 
 // Load all OpenGL entry-points via the GLFW proc-address bridge.
 // Must be called once, on the thread that owns the current GL context,
 // after glfwMakeContextCurrent(). Returns true on success.
-bool InitGlad(void *(*getProcAddress)(const char *));
+bool InitGlad(GLADloadproc getProcAddress);
 
 // Return GL_VERSION / GL_RENDERER strings (valid after InitGlad succeeds).
 const char *GetGLVersion();

--- a/renderer/opengl/OpenGLVertexArray.cpp
+++ b/renderer/opengl/OpenGLVertexArray.cpp
@@ -147,4 +147,17 @@ void OpenGLVertexArray::SetIndexBuffer(
     glBindVertexArray(0);
 }
 
+void OpenGLVertexArray::DrawIndexed(uint32_t count) const {
+    glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(count), GL_UNSIGNED_INT,
+                   nullptr);
+}
+
+void OpenGLVertexArray::DrawArrays(uint32_t count) const {
+    glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(count));
+}
+
+void OpenGLVertexArray::DrawArraysLines(uint32_t count) const {
+    glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(count));
+}
+
 } // namespace Horo

--- a/renderer/opengl/OpenGLVertexArray.h
+++ b/renderer/opengl/OpenGLVertexArray.h
@@ -28,6 +28,10 @@ public:
     const std::vector<std::shared_ptr<IVertexBuffer>>& GetVertexBuffers() const override { return m_vertexBuffers; }
     const std::shared_ptr<IIndexBuffer>&               GetIndexBuffer()   const override { return m_indexBuffer;   }
 
+    void DrawIndexed(uint32_t count) const override;
+    void DrawArrays(uint32_t count)      const override;
+    void DrawArraysLines(uint32_t count) const override;
+
 private:
     uint32_t m_rendererId = 0;
     uint32_t m_vertexBufferIndex = 0;

--- a/renderer/opengl/OpenGLVertexBuffer.cpp
+++ b/renderer/opengl/OpenGLVertexBuffer.cpp
@@ -6,66 +6,6 @@
 
 namespace Horo {
 
-// --- BufferElement -----------------------------------------------------------
-
-uint32_t ShaderDataTypeSize(ShaderDataType type) {
-    switch (type) {
-        case ShaderDataType::Float:  return 4;
-        case ShaderDataType::Float2: return 4 * 2;
-        case ShaderDataType::Float3: return 4 * 3;
-        case ShaderDataType::Float4: return 4 * 4;
-        case ShaderDataType::Mat3:   return 4 * 3 * 3;
-        case ShaderDataType::Mat4:   return 4 * 4 * 4;
-        case ShaderDataType::Int:    return 4;
-        case ShaderDataType::Int2:   return 4 * 2;
-        case ShaderDataType::Int3:   return 4 * 3;
-        case ShaderDataType::Int4:   return 4 * 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
-    }
-    return 0;
-}
-
-BufferElement::BufferElement(ShaderDataType type, const std::string& name,
-                             bool normalized)
-    : name(name), type(type), size(ShaderDataTypeSize(type)), offset(0),
-      normalized(normalized) {}
-
-uint32_t BufferElement::GetComponentCount() const {
-    switch (type) {
-        case ShaderDataType::Float:  return 1;
-        case ShaderDataType::Float2: return 2;
-        case ShaderDataType::Float3: return 3;
-        case ShaderDataType::Float4: return 4;
-        case ShaderDataType::Mat3:   return 3 * 3;
-        case ShaderDataType::Mat4:   return 4 * 4;
-        case ShaderDataType::Int:    return 1;
-        case ShaderDataType::Int2:   return 2;
-        case ShaderDataType::Int3:   return 3;
-        case ShaderDataType::Int4:   return 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
-    }
-    return 0;
-}
-
-// --- BufferLayout ------------------------------------------------------------
-
-BufferLayout::BufferLayout(std::initializer_list<BufferElement> elements)
-    : m_Elements(elements) {
-    CalculateOffsetsAndStride();
-}
-
-void BufferLayout::CalculateOffsetsAndStride() {
-    size_t   offset = 0;
-    m_Stride        = 0;
-    for (auto& element : m_Elements) {
-        element.offset  = offset;
-        offset         += element.size;
-        m_Stride       += element.size;
-    }
-}
-
 // --- OpenGLVertexBuffer ------------------------------------------------------
 
 OpenGLVertexBuffer::OpenGLVertexBuffer(const void* data, uint32_t size) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+# All tests link HoroEngine first so OpenGLRenderBackend vtable symbols are
+# resolved when the linker subsequently processes horo-renderer-opengl.
+if(TARGET horo-renderer-opengl AND HORO_RENDERER STREQUAL "opengl")
+    set(HORO_ENGINE_LINK HoroEngine horo-renderer-opengl)
+else()
+    set(HORO_ENGINE_LINK HoroEngine)
+endif()
+
 # Unit tests live under build/bin/tests/ so build/bin/ only holds HoroApp (+ copied assets).
 set(HORO_TEST_BIN_DIR "${CMAKE_BINARY_DIR}/bin/tests")
 file(MAKE_DIRECTORY "${HORO_TEST_BIN_DIR}")
@@ -23,151 +31,151 @@ endfunction()
 
 # ---- test_math ----
 add_executable(test_math test_math.cpp)
-target_link_libraries(test_math PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math)
 add_test(NAME test_math COMMAND $<TARGET_FILE:test_math>)
 
 # ---- test_physics ----
 add_executable(test_physics test_physics.cpp)
-target_link_libraries(test_physics PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics)
 add_test(NAME test_physics COMMAND $<TARGET_FILE:test_physics>)
 
 # ---- test_math_extended ----
 add_executable(test_math_extended test_math_extended.cpp)
-target_link_libraries(test_math_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math_extended)
 add_test(NAME test_math_extended COMMAND $<TARGET_FILE:test_math_extended>)
 
 # ---- test_physics_extended ----
 add_executable(test_physics_extended test_physics_extended.cpp)
-target_link_libraries(test_physics_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_extended)
 add_test(NAME test_physics_extended COMMAND $<TARGET_FILE:test_physics_extended>)
 
 # ---- test_ecs ----
 add_executable(test_ecs test_ecs.cpp)
-target_link_libraries(test_ecs PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_ecs PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_ecs)
 add_test(NAME test_ecs COMMAND $<TARGET_FILE:test_ecs>)
 
 # ---- test_gjk ----
 add_executable(test_gjk test_gjk.cpp)
-target_link_libraries(test_gjk PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gjk)
 add_test(NAME test_gjk COMMAND $<TARGET_FILE:test_gjk>)
 
 # ---- test_integration ----
 add_executable(test_integration test_integration.cpp)
-target_link_libraries(test_integration PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_integration PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_integration)
 add_test(NAME test_integration COMMAND $<TARGET_FILE:test_integration>)
 
 # ---- test_constraints ----
 add_executable(test_constraints test_constraints.cpp)
-target_link_libraries(test_constraints PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_constraints PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_constraints)
 add_test(NAME test_constraints COMMAND $<TARGET_FILE:test_constraints>)
 
 # ---- test_physics_world ----
 add_executable(test_physics_world test_physics_world.cpp)
-target_link_libraries(test_physics_world PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_world PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_world)
 add_test(NAME test_physics_world COMMAND $<TARGET_FILE:test_physics_world>)
 
 # ---- test_scene ----
 add_executable(test_scene test_scene.cpp)
-target_link_libraries(test_scene PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene)
 add_test(NAME test_scene COMMAND $<TARGET_FILE:test_scene>)
 
 # ---- test_scene_project_model ----
 add_executable(test_scene_project_model test_scene_project_model.cpp)
-target_link_libraries(test_scene_project_model PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_project_model PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_project_model)
 add_test(NAME test_scene_project_model COMMAND $<TARGET_FILE:test_scene_project_model>)
 
 # ---- test_scene_runtime_conversion ----
 add_executable(test_scene_runtime_conversion test_scene_runtime_conversion.cpp)
-target_link_libraries(test_scene_runtime_conversion PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_runtime_conversion PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_runtime_conversion)
 add_test(NAME test_scene_runtime_conversion COMMAND $<TARGET_FILE:test_scene_runtime_conversion>)
 
 # ---- test_scene_runtime_coordinator ----
 add_executable(test_scene_runtime_coordinator test_scene_runtime_coordinator.cpp)
-target_link_libraries(test_scene_runtime_coordinator PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_runtime_coordinator PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_runtime_coordinator)
 add_test(NAME test_scene_runtime_coordinator COMMAND $<TARGET_FILE:test_scene_runtime_coordinator>)
 
 # ---- test_scene_reference_loading ----
 add_executable(test_scene_reference_loading test_scene_reference_loading.cpp)
-target_link_libraries(test_scene_reference_loading PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_reference_loading PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_reference_loading)
 add_test(NAME test_scene_reference_loading COMMAND $<TARGET_FILE:test_scene_reference_loading>)
 
 # ---- test_scene_lifecycle ----
 add_executable(test_scene_lifecycle test_scene_lifecycle.cpp)
-target_link_libraries(test_scene_lifecycle PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_lifecycle PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_lifecycle)
 add_test(NAME test_scene_lifecycle COMMAND $<TARGET_FILE:test_scene_lifecycle>)
 
 # ---- test_camera ----
 add_executable(test_camera test_camera.cpp)
-target_link_libraries(test_camera PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_camera)
 add_test(NAME test_camera COMMAND $<TARGET_FILE:test_camera>)
 
 # ---- test_math_coverage ----
 add_executable(test_math_coverage test_math_coverage.cpp)
-target_link_libraries(test_math_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_coverage PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math_coverage)
 add_test(NAME test_math_coverage COMMAND $<TARGET_FILE:test_math_coverage>)
 
 # ---- test_physics_coverage ----
 add_executable(test_physics_coverage test_physics_coverage.cpp)
-target_link_libraries(test_physics_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_coverage PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_coverage)
 add_test(NAME test_physics_coverage COMMAND $<TARGET_FILE:test_physics_coverage>)
 
 # ---- test_editor ----
 add_executable(test_editor test_editor.cpp)
-target_link_libraries(test_editor PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_editor PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_editor)
 add_test(NAME test_editor COMMAND $<TARGET_FILE:test_editor>)
 
 # ---- test_transform ----
 add_executable(test_transform test_transform.cpp)
-target_link_libraries(test_transform PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_transform PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_transform)
 add_test(NAME test_transform COMMAND $<TARGET_FILE:test_transform>)
 
 # ---- test_physics_deep ----
 add_executable(test_physics_deep test_physics_deep.cpp)
-target_link_libraries(test_physics_deep PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_deep PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_deep)
 add_test(NAME test_physics_deep COMMAND $<TARGET_FILE:test_physics_deep>)
 
 # ---- test_registry_extended ----
 add_executable(test_registry_extended test_registry_extended.cpp)
-target_link_libraries(test_registry_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_registry_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_registry_extended)
 add_test(NAME test_registry_extended COMMAND $<TARGET_FILE:test_registry_extended>)
 
 # ---- test_camera_extended ----
 add_executable(test_camera_extended test_camera_extended.cpp)
-target_link_libraries(test_camera_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_camera_extended)
 add_test(NAME test_camera_extended COMMAND $<TARGET_FILE:test_camera_extended>)
 
 # ---- test_core ----
 add_executable(test_core test_core.cpp)
-target_link_libraries(test_core PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_core PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_core)
 add_test(NAME test_core COMMAND $<TARGET_FILE:test_core>)
 
 # ---- test_window ----
 add_executable(test_window test_window.cpp)
-target_link_libraries(test_window PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_window PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_window)
 add_test(NAME test_window COMMAND $<TARGET_FILE:test_window>)
 add_test(NAME test_window_logfilter COMMAND $<TARGET_FILE:test_window> "[core][window][logfilter]")
@@ -179,7 +187,7 @@ set_tests_properties(test_window_glfw_init_fail PROPERTIES
 
 # ---- test_logger_env ----
 add_executable(test_logger_env test_logger_env.cpp)
-target_link_libraries(test_logger_env PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_logger_env PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_logger_env)
 add_test(NAME test_logger_env_warn COMMAND $<TARGET_FILE:test_logger_env> "[logger][env][warn]")
 set_tests_properties(test_logger_env_warn PROPERTIES ENVIRONMENT "HORO_LOG_LEVEL=warning")
@@ -202,102 +210,102 @@ set_tests_properties(test_logger_env_unset PROPERTIES ENVIRONMENT "HORO_LOG_LEVE
 
 # ---- test_scene_systems ----
 add_executable(test_scene_systems test_scene_systems.cpp)
-target_link_libraries(test_scene_systems PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_systems PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_systems)
 add_test(NAME test_scene_systems COMMAND $<TARGET_FILE:test_scene_systems>)
 
 # ---- test_gjk_extended ----
 add_executable(test_gjk_extended test_gjk_extended.cpp)
-target_link_libraries(test_gjk_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gjk_extended)
 add_test(NAME test_gjk_extended COMMAND $<TARGET_FILE:test_gjk_extended>)
 
 # ---- test_quaternion_extended ----
 add_executable(test_quaternion_extended test_quaternion_extended.cpp)
-target_link_libraries(test_quaternion_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_quaternion_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_quaternion_extended)
 add_test(NAME test_quaternion_extended COMMAND $<TARGET_FILE:test_quaternion_extended>)
 
 # ---- test_obj_import ----
 add_executable(test_obj_import test_obj_import.cpp)
-target_link_libraries(test_obj_import PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_obj_import PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_obj_import)
 add_test(NAME test_obj_import COMMAND $<TARGET_FILE:test_obj_import>)
 
 # ---- test_gizmo ----
 add_executable(test_gizmo test_gizmo.cpp)
-target_link_libraries(test_gizmo PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gizmo PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gizmo)
 add_test(NAME test_gizmo COMMAND $<TARGET_FILE:test_gizmo>)
 
 # ---- test_animation ----
 add_executable(test_animation test_animation.cpp)
-target_link_libraries(test_animation PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_animation PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_animation)
 add_test(NAME test_animation COMMAND $<TARGET_FILE:test_animation>)
 
 # ---- test_plan_editor_features (CLI, LogBuffer, Project filter) ----
 add_executable(test_plan_editor_features test_plan_editor_features.cpp)
-target_link_libraries(test_plan_editor_features PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_plan_editor_features PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_plan_editor_features)
 add_test(NAME test_plan_editor_features COMMAND $<TARGET_FILE:test_plan_editor_features>)
 
 # ---- test_mcp ----
 add_executable(test_mcp test_mcp.cpp)
-target_link_libraries(test_mcp PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_mcp PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_mcp)
 add_test(NAME test_mcp COMMAND $<TARGET_FILE:test_mcp>)
 
 # ---- test_architecture_docs ----
 add_executable(test_architecture_docs test_architecture_docs.cpp)
-target_link_libraries(test_architecture_docs PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_architecture_docs PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_architecture_docs)
 add_test(NAME test_architecture_docs COMMAND $<TARGET_FILE:test_architecture_docs>)
 
 # ---- test_renderer_foundation ----
 add_executable(test_renderer_foundation test_renderer_foundation.cpp)
-target_link_libraries(test_renderer_foundation PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_renderer_foundation PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_renderer_foundation)
 add_test(NAME test_renderer_foundation COMMAND $<TARGET_FILE:test_renderer_foundation>)
 
 # ---- test_launcher_core ----
 add_executable(test_launcher_core test_launcher_core.cpp)
-target_link_libraries(test_launcher_core PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_launcher_core PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_launcher_core)
 add_test(NAME test_launcher_core COMMAND $<TARGET_FILE:test_launcher_core>)
 
 # ---- test_launcher_unit ----
 add_executable(test_launcher_unit test_launcher_unit.cpp)
-target_link_libraries(test_launcher_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_launcher_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_launcher_unit)
 add_test(NAME test_launcher_unit COMMAND $<TARGET_FILE:test_launcher_unit>)
 
 # ---- test_ui_automation_config ----
 add_executable(test_ui_automation_config test_ui_automation_config.cpp)
-target_link_libraries(test_ui_automation_config PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_ui_automation_config PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_ui_automation_config)
 add_test(NAME test_ui_automation_config COMMAND $<TARGET_FILE:test_ui_automation_config>)
 
 # ---- test_input ----
 add_executable(test_input test_input.cpp)
-target_link_libraries(test_input PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_input PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_input)
 add_test(NAME test_input COMMAND $<TARGET_FILE:test_input>)
 
 # ---- test_mesh_cache ----
 add_executable(test_mesh_cache test_mesh_cache.cpp)
-target_link_libraries(test_mesh_cache PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_mesh_cache PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_mesh_cache)
 add_test(NAME test_mesh_cache COMMAND $<TARGET_FILE:test_mesh_cache>)
 
 # ---- test_editor_unit ----
 add_executable(test_editor_unit test_editor_unit.cpp)
-target_link_libraries(test_editor_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_editor_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_editor_unit)
 add_test(NAME test_editor_unit COMMAND $<TARGET_FILE:test_editor_unit>)
 
 # ---- test_renderer_unit ----
 add_executable(test_renderer_unit test_renderer_unit.cpp)
-target_link_libraries(test_renderer_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_renderer_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_renderer_unit)
 add_test(NAME test_renderer_unit COMMAND $<TARGET_FILE:test_renderer_unit>)

--- a/tests/test_null_renderer.cpp
+++ b/tests/test_null_renderer.cpp
@@ -1,0 +1,175 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "renderer/null/NullRenderBackend.h"
+#include "renderer/null/NullShader.h"
+#include "renderer/null/NullTexture.h"
+#include "renderer/null/NullVertexArray.h"
+
+using namespace Horo;
+
+// ── Factory returns ──────────────────────────────────────────────────────────
+
+TEST_CASE("NullRenderBackend: CreateShader returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateShader("", "") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateShaderFromFile returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateShaderFromFile("", "") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateTexture returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateTexture({}) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateTextureFromFile returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateTextureFromFile("dummy.png") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateFramebuffer returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateFramebuffer({}) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexBuffer (static) returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexBuffer(nullptr, 0) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexBuffer (dynamic) returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexBuffer(static_cast<uint32_t>(64)) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateIndexBuffer returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateIndexBuffer(nullptr, 0) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexArray returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexArray() != nullptr);
+}
+
+// ── Call-count tracking ───────────────────────────────────────────────────────
+
+TEST_CASE("NullShader: Bind/Unbind are tracked", "[null-renderer][null-shader]") {
+    NullRenderBackend backend;
+    auto shader = backend.CreateShader("", "");
+    REQUIRE(shader != nullptr);
+
+    shader->Bind();
+    shader->Unbind();
+    shader->Bind();
+
+    auto *null = dynamic_cast<NullShader *>(shader.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount   == 2);
+    CHECK(null->unbindCount == 1);
+}
+
+TEST_CASE("NullShader: IsValid returns true", "[null-renderer][null-shader]") {
+    NullRenderBackend backend;
+    auto shader = backend.CreateShader("", "");
+    REQUIRE(shader->IsValid());
+}
+
+TEST_CASE("NullTexture: Bind is tracked", "[null-renderer][null-texture]") {
+    NullRenderBackend backend;
+    auto tex = backend.CreateTexture({});
+    tex->Bind(0);
+    tex->Bind(1);
+
+    auto *null = dynamic_cast<NullTexture *>(tex.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount == 2);
+}
+
+TEST_CASE("NullTexture: dimensions from spec", "[null-renderer][null-texture]") {
+    NullRenderBackend backend;
+    TextureSpec spec;
+    spec.width  = 128;
+    spec.height = 64;
+    auto tex = backend.CreateTexture(spec);
+    CHECK(tex->GetWidth()  == 128);
+    CHECK(tex->GetHeight() == 64);
+}
+
+TEST_CASE("NullVertexArray: Bind is tracked", "[null-renderer][null-varray]") {
+    NullRenderBackend backend;
+    auto va = backend.CreateVertexArray();
+    va->Bind();
+    va->Unbind();
+    va->Bind();
+
+    auto *null = dynamic_cast<NullVertexArray *>(va.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount   == 2);
+    CHECK(null->unbindCount == 1);
+}
+
+// ── Backend identity / capabilities ──────────────────────────────────────────
+
+TEST_CASE("NullRenderBackend: GetDrawCallCount starts at 0", "[null-renderer]") {
+    NullRenderBackend backend;
+    CHECK(backend.GetDrawCallCount() == 0);
+}
+
+TEST_CASE("NullRenderBackend: SetViewport / GetViewport round-trip", "[null-renderer]") {
+    NullRenderBackend backend;
+    backend.SetViewport(10, 20, 800, 600);
+    auto vp = backend.GetViewport();
+    CHECK(vp[0] == 10);
+    CHECK(vp[1] == 20);
+    CHECK(vp[2] == 800);
+    CHECK(vp[3] == 600);
+}
+
+TEST_CASE("NullRenderBackend: ReadbackColorBgr8 fills zeroes", "[null-renderer]") {
+    NullRenderBackend backend;
+    std::vector<uint8_t> pixels;
+    bool ok = backend.ReadbackColorBgr8(4, 4, pixels, nullptr);
+    REQUIRE(ok);
+    REQUIRE(pixels.size() == 4u * 4u * 3u);
+    for (auto b : pixels) CHECK(b == 0u);
+}
+
+TEST_CASE("NullRenderBackend: ReadbackDepth32F fills 1.0", "[null-renderer]") {
+    NullRenderBackend backend;
+    std::vector<float> depth;
+    bool ok = backend.ReadbackDepth32F(2, 2, depth, nullptr);
+    REQUIRE(ok);
+    REQUIRE(depth.size() == 4u);
+    for (auto d : depth) CHECK(d == 1.0f);
+}
+
+TEST_CASE("NullRenderBackend: NullIndexBuffer preserves count", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto ib = backend.CreateIndexBuffer(nullptr, 42);
+    REQUIRE(ib != nullptr);
+    CHECK(ib->GetCount() == 42u);
+}
+
+TEST_CASE("NullRenderBackend: NullVertexArray stores vertex buffer", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto va = backend.CreateVertexArray();
+    auto vb = backend.CreateVertexBuffer(static_cast<uint32_t>(64));
+    va->AddVertexBuffer(vb);
+
+    REQUIRE(va->GetVertexBuffers().size() == 1u);
+    CHECK(va->GetVertexBuffers()[0] == vb);
+}
+
+TEST_CASE("NullRenderBackend: NullFramebuffer Resize updates spec", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto fb = backend.CreateFramebuffer({});
+    fb->Resize(1920, 1080);
+    CHECK(fb->GetSpec().width  == 1920u);
+    CHECK(fb->GetSpec().height == 1080u);
+}

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -163,7 +163,8 @@ if(NOT TARGET imgui_lib)
             $<INSTALL_INTERFACE:include/vendor/imgui>
             $<INSTALL_INTERFACE:include/vendor/imgui/backends>
         )
-        target_link_libraries(${target_name} PUBLIC glfw glad)
+        target_link_libraries(${target_name} PUBLIC glfw)
+        target_link_libraries(${target_name} PRIVATE glad)
 
         if(HORO_ENGINE_ENABLE_VULKAN)
             target_compile_definitions(${target_name} PUBLIC IMGUI_IMPL_VULKAN_USE_VOLK)


### PR DESCRIPTION
## Summary

Removes all `#include <glad/glad.h>` from non-backend files (renderer/, core/, editor/, launcher/) by replacing direct OpenGL calls with the backend-agnostic abstractions introduced.

## Changes

### New interfaces
- `IVertexArray`: added `DrawIndexed`, `DrawArrays`, `DrawArraysLines`
- `IRenderBackend` + `Renderer` facade: added `SetViewport`, `GetViewport`, `Begin2dOverlay`, `End2dOverlay`, `SetupOpaqueRenderState`, `ClearColorAndDepth`, `ReadbackRegionRgba8`

### New files
- `renderer/opengl/OpenGLContext.{h,cpp}` — wraps `gladLoadGLLoader` so `core/Window.cpp` no longer needs glad.h

### Updated backends
- `OpenGLRenderBackend`: implements all new virtual methods + resource factory methods
- `VulkanRenderBackend`: no-op stubs for new virtual methods

### Consumer file rewrites
| File | Change |
|---|---|
| `renderer/Mesh.cpp` | `GpuStorage` now holds `shared_ptr<IVertexArray>`; uses `OpenGLVertexArray/Buffer/IndexBuffer` |
| `renderer/SkinnedMesh.cpp` | Same pattern; 5-attribute layout incl. `Int4` bone indices |
| `renderer/DebugDraw.{h,cpp}` | Static handles → `shared_ptr<IVertexArray/IVertexBuffer>`; flush uses `DrawArraysLines` |
| `renderer/DebugHUD.{h,cpp}` | Raw uint handles → `shared_ptr<IVertexArray/IVertexBuffer/ITexture>`; overlay via `Begin2dOverlay/End2dOverlay` |
| `core/Window.cpp` | `gladLoadGLLoader` → `OpenGLContext::InitGlad`; `glViewport` → `Renderer::SetViewport` |
| `editor/EditorLayer.cpp` | `AssetThumbnailRenderer` raw FBO → `shared_ptr<IFramebuffer>`; GL state → Renderer helpers |
| `editor/EditorMcpHandlers.cpp` | Removed unused glad include |
| `launcher/UiAutomationRunner.cpp` | `glGetIntegerv+glReadPixels` → `Renderer::GetViewport+ReadbackRegionRgba8` |

## Verification
```
grep -rn '#include.*glad' renderer/ core/ editor/ launcher/ | grep -v opengl/
```
Returns only `renderer/OpenGLRenderBackend.cpp` (the backend itself — expected).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes all `glad.h` includes from non-backend code by routing GL calls through backend-agnostic interfaces and the Renderer facade. GL headers are isolated in `renderer/opengl/`, the OpenGL backend builds as `horo-renderer-opengl`, and a `NullRenderBackend` enables headless tests.

- **New Features**
  - Added `SetViewport`, `GetViewport`, `Begin2dOverlay`, `End2dOverlay`, `SetupOpaqueRenderState`, `ClearColorAndDepth`, `ReadbackRegionRgba8` to `IRenderBackend`/`Renderer`; extended `IVertexArray` with `DrawIndexed`, `DrawArrays`, `DrawArraysLines`.
  - Implemented in `OpenGLRenderBackend`; added `renderer/opengl/OpenGLContext` (`InitGlad`, `GetGLVersion`, `GetGLRenderer`); added `renderer/null/*` (`NullRenderBackend` + resource stubs) and `tests/test_null_renderer.cpp`; Vulkan gets no-op stubs.

- **Refactors**
  - `Mesh`, `SkinnedMesh`, `DebugDraw`, and `DebugHUD` now use `IVertexArray`/`IVertexBuffer` (HUD also `ITexture` + `Begin2dOverlay`/`End2dOverlay`); buffer layout helpers moved to `IVertexBuffer.cpp`.
  - `EditorLayer` thumbnails use `IFramebuffer`, per-asset `ITexture`, and `ReadbackRegionRgba8`; `core/Window` uses `OpenGLContext::InitGlad` + `Renderer::SetViewport`; `UiAutomationRunner` uses `GetViewport`/`ReadbackRegionRgba8`; removed stray `glad.h` from non-backend sources.
  - Build: new `HORO_RENDERER` option (`opengl`|`vulkan`|`null`); `horo-renderer-opengl` isolates `glad` and OpenGL links; `horo-renderer-null` interface target; added a `null-renderer` preset; tests and `HoroEngineImGuiTest` always compile/link `horo-renderer-opengl` for `RenderBackendFactory`/vtable resolution; `HoroEditor` in `vulkan`/`null` modes also links `horo-renderer-opengl`; `vendor/imgui` links `glad` privately.
  - API: new viewport/overlay/readback methods on `IRenderBackend` have default no-op bodies for existing mocks; `NullRenderBackend::BeginFrame` now resets the per-frame draw-call counter.
  - Cleanups: switched `OpenGLContext` to `GLADloadproc`, removed unsafe casts in mesh code, and used if-init statements to address analyzer warnings.

<sup>Written for commit 5612cb7c8f887b9207c5a3416af340226d579df0. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



