### PR TITLE
feat(renderer): NullRenderBackend for headless testing

### DIFF
--- a/renderer/null/NullRenderBackend.h
+++ b/renderer/null/NullRenderBackend.h
@@ -43,14 +43,14 @@ public:
     bool ReadbackColorBgr8(int w, int h, std::vector<uint8_t> &out,
                            std::string *) override {
         if (w <= 0 || h <= 0) return false;
-        out.assign(static_cast<size_t>(w * h * 3), 0u);
+        out.assign(static_cast<size_t>(w) * static_cast<size_t>(h) * 3u, 0u);
         return true;
     }
 
     bool ReadbackDepth32F(int w, int h, std::vector<float> &out,
                           std::string *) override {
         if (w <= 0 || h <= 0) return false;
-        out.assign(static_cast<size_t>(w * h), 1.0f);
+        out.assign(static_cast<size_t>(w) * static_cast<size_t>(h), 1.0f);
         return true;
     }
 


### PR DESCRIPTION
## NullRenderBackend

Completes the renderer abstraction by proving it works end-to-end with no GPU.

### What's included
- `renderer/null/NullRenderBackend` — implements all of `IRenderBackend` (including resource factory overrides)
- `NullShader`, `NullTexture`, `NullFramebuffer`, `NullVertexBuffer`, `NullIndexBuffer`, `NullVertexArray`
- Call-recording in null resources (`bindCount`, `unbindCount`) for unit test assertions
- `renderer/IVertexBuffer.cpp` — implementations for `ShaderDataTypeSize`, `BufferElement`, `BufferLayout`
- `renderer/IRenderBackend.h` — extended with default resource factory methods (viewport, 2-D overlay, Create*)
- `tests/test_null_renderer.cpp` — 18 headless tests, no GL context required

### Why this matters
If this compiles and the tests pass, the abstraction is provably correct: the engine can be built and tested with zero OpenGL/Vulkan symbols linked.

### Test results
```
100% tests passed, 18 tests (0 failures)
```

Existing tests (test_renderer_foundation, test_renderer_unit, test_math) all pass with no regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-GPU `NullRenderBackend` for headless tests/CI and isolates only `renderer/OpenGLRenderBackend.cpp` into `horo-renderer-opengl` with `glad` kept PRIVATE. Backends are selectable via `HORO_RENDERER` (`opengl | vulkan | null`) across the editor and tests.

- **New Features**
  - `renderer/null/NullRenderBackend` with no-op `IRenderBackend` and `NullShader`/`NullTexture`/`NullFramebuffer`/`NullVertexBuffer`/`NullIndexBuffer`/`NullVertexArray` (tracks bind/unbind; readback: color=0s, depth=1.0; allocation now promotes `w` and `h` to `size_t` to avoid overflow).
  - Implemented `ShaderDataTypeSize`, `BufferElement`, `BufferLayout` in `renderer/IVertexBuffer.cpp`.

- **Build/Test**
  - New `horo-renderer-opengl` static target isolates only `OpenGLRenderBackend.cpp`; `glad` remains PRIVATE; `HoroEngine` now exposes `vendor/glad/include` PUBLIC for consumers.
  - New `horo-renderer-null` INTERFACE target; editor/tests link the selected backend via `HORO_RENDERER`; added `null-renderer` CMake preset; `test_null_renderer` adds 18 headless cases.
  - Removed duplicate `BufferElement`/`BufferLayout` from `renderer/opengl/OpenGLVertexBuffer.cpp`; single source is `renderer/IVertexBuffer.cpp`.

<sup>Written for commit 7034326f35c03203be4255e55fd1c913db91f1bd. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

