### PR TITLE
build: isolate glad/OpenGL to renderer-opengl CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ target_include_directories(horo-renderer-opengl PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 target_link_libraries(horo-renderer-opengl
-    PUBLIC  HoroEngine
+    PRIVATE HoroEngine
     PRIVATE glad stb
 )
 if(APPLE)
@@ -206,7 +206,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STAN
 
     if(HORO_RENDERER STREQUAL "opengl")
         target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_OPENGL=1)
-        target_link_libraries(HoroEditor PRIVATE horo-renderer-opengl)
+        target_link_libraries(HoroEditor PRIVATE HoroEngine horo-renderer-opengl)
     elseif(HORO_RENDERER STREQUAL "vulkan")
         target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_VULKAN=1)
         target_link_libraries(HoroEditor PRIVATE HoroEngine)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     option(HORO_ENGINE_ENABLE_VULKAN "Fetch Vulkan headers/loader and compile Vulkan backend scaffolding" OFF)
     option(HORO_ENGINE_BUILD_STANDALONE_EDITOR "Build HoroEditor (SDK launcher + editor shell executable)" ON)
 
+    set(HORO_RENDERER "opengl" CACHE STRING "Renderer backend: opengl | vulkan | null")
+    set_property(CACHE HORO_RENDERER PROPERTY STRINGS opengl vulkan null)
+
     if(MSVC)
         add_compile_options(/W4 /WX /Zc:preprocessor)
     else()
@@ -33,6 +36,21 @@ endif()
 # Guards in vendor/CMakeLists.txt prevent duplicate target errors if a parent
 # project already defined any of these targets.
 add_subdirectory(vendor)
+
+# ---- OpenGL backend source files (PRIVATE glad isolation) ----
+# These are the renderer translation units that include <glad/glad.h>.
+# They are compiled into the dedicated horo-renderer-opengl STATIC target so
+# that glad's include directories are PRIVATE to that target and cannot reach
+# the core-engine or editor translation units.
+set(HORO_RENDERER_OPENGL_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/DebugDraw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/DebugHUD.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Mesh.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/OpenGLRenderBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Shader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/SkinnedMesh.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Texture.cpp
+)
 
 # ---- HoroEngine static library ----
 file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
@@ -48,6 +66,9 @@ file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher/*.cpp"
 )
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX "launcher[/\\\\]HoroEditorMain\\.cpp$")
+# Exclude the OpenGL backend files; they live in horo-renderer-opengl.
+list(FILTER ENGINE_SOURCES EXCLUDE REGEX
+    "[/\\\\]renderer[/\\\\](DebugDraw|DebugHUD|Mesh|OpenGLRenderBackend|Shader|SkinnedMesh|Texture)\\.cpp$")
 
 add_library(HoroEngine STATIC ${ENGINE_SOURCES})
 add_library(HoroEngine::HoroEngine ALIAS HoroEngine)
@@ -64,9 +85,9 @@ function(horo_configure_engine_target target_name imgui_target)
     target_link_libraries(${target_name}
         PUBLIC
             glfw
-            glad
             ${imgui_target}
         PRIVATE
+            glad
             glm
             stb
             nlohmann_json
@@ -78,12 +99,14 @@ function(horo_configure_engine_target target_name imgui_target)
         target_compile_definitions(${target_name} PUBLIC HORO_HAS_VULKAN=1)
     endif()
 
-    if(APPLE)
-        target_link_libraries(${target_name} PUBLIC "-framework OpenGL")
-    elseif(WIN32)
-        target_link_libraries(${target_name} PUBLIC opengl32 comdlg32 ole32 shell32 ws2_32)
+    if(WIN32)
+        # Windows system libs needed for GLFW and general app infrastructure.
+        target_link_libraries(${target_name} PUBLIC comdlg32 ole32 shell32 ws2_32)
+        target_link_libraries(${target_name} PRIVATE opengl32)
+    elseif(APPLE)
+        target_link_libraries(${target_name} PRIVATE "-framework OpenGL")
     else()
-        target_link_libraries(${target_name} PUBLIC GL)
+        target_link_libraries(${target_name} PRIVATE GL)
     endif()
 
     target_compile_features(${target_name} PUBLIC cxx_std_20)
@@ -102,6 +125,45 @@ endfunction()
 option(HORO_ENGINE_COVERAGE "Add coverage flags to HoroEngine (for reports after ctest)" OFF)
 
 horo_configure_engine_target(HoroEngine imgui_lib)
+# core/Window.cpp and editor files include <glad/glad.h> directly; add glad
+# as PRIVATE so its headers are available at compile time but not re-exported.
+target_link_libraries(HoroEngine PRIVATE glad)
+
+# ---- horo-renderer-opengl: PRIVATE glad + OpenGL ----
+# Dedicated backend marker/consumer target.  The sources compiled here
+# include <glad/glad.h>, and glad is kept PRIVATE so its include directories
+# cannot transitively reach HoroEditor or test translation units.
+# HoroEngine also uses glad PRIVATE (Window.cpp, EditorLayer.cpp, etc.) but
+# the PUBLIC interface of both targets is glad-free.
+add_library(horo-renderer-opengl STATIC ${HORO_RENDERER_OPENGL_SOURCES})
+add_library(HoroEngine::RendererOpenGL ALIAS horo-renderer-opengl)
+
+target_include_directories(horo-renderer-opengl PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries(horo-renderer-opengl
+    PUBLIC  HoroEngine
+    PRIVATE glad stb
+)
+if(APPLE)
+    target_link_libraries(horo-renderer-opengl PRIVATE "-framework OpenGL")
+elseif(WIN32)
+    target_link_libraries(horo-renderer-opengl PRIVATE opengl32)
+else()
+    target_link_libraries(horo-renderer-opengl PRIVATE GL)
+endif()
+target_compile_definitions(horo-renderer-opengl INTERFACE HORO_RENDERER_OPENGL=1)
+
+if(HORO_ENGINE_COVERAGE AND NOT MSVC)
+    target_compile_options(horo-renderer-opengl PUBLIC --coverage -O0 -g)
+    target_link_options(horo-renderer-opengl PUBLIC --coverage)
+endif()
+
+# ---- horo-renderer-null: no GPU dependency (headless / CI unit tests) ----
+add_library(horo-renderer-null INTERFACE)
+add_library(HoroEngine::RendererNull ALIAS horo-renderer-null)
+target_link_libraries(horo-renderer-null INTERFACE HoroEngine)
+target_compile_definitions(horo-renderer-null INTERFACE HORO_RENDERER_NULL=1)
 
 if(HORO_ENGINE_BUILD_TESTS AND TARGET imgui_test_lib)
     set(HORO_UI_TEST_SOURCES
@@ -119,6 +181,16 @@ if(HORO_ENGINE_BUILD_TESTS AND TARGET imgui_test_lib)
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tests>
     )
     horo_configure_engine_target(HoroEngineImGuiTest imgui_test_lib)
+
+    # Add the OpenGL backend sources so HoroEngineImGuiTest is self-contained.
+    # glad is already PRIVATE via horo_configure_engine_target above.
+    if(HORO_RENDERER STREQUAL "opengl")
+        target_sources(HoroEngineImGuiTest PRIVATE ${HORO_RENDERER_OPENGL_SOURCES})
+        target_include_directories(HoroEngineImGuiTest PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        )
+        target_compile_definitions(HoroEngineImGuiTest PUBLIC HORO_RENDERER_OPENGL=1)
+    endif()
 endif()
 
 # Copy GLSL shaders to bin/shaders alongside the executable
@@ -131,11 +203,23 @@ add_custom_command(TARGET HoroEngine POST_BUILD
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STANDALONE_EDITOR)
     add_executable(HoroEditor launcher/HoroEditorMain.cpp)
-    target_link_libraries(HoroEditor PRIVATE HoroEngine)
     target_compile_features(HoroEditor PRIVATE cxx_std_20)
 
     if(WIN32)
         target_compile_definitions(HoroEditor PRIVATE NOMINMAX)
+    endif()
+
+    if(HORO_RENDERER STREQUAL "opengl")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_OPENGL=1)
+        target_link_libraries(HoroEditor PRIVATE horo-renderer-opengl)
+    elseif(HORO_RENDERER STREQUAL "vulkan")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_VULKAN=1)
+        target_link_libraries(HoroEditor PRIVATE HoroEngine)
+    elseif(HORO_RENDERER STREQUAL "null")
+        target_compile_definitions(HoroEditor PRIVATE HORO_RENDERER_NULL=1)
+        target_link_libraries(HoroEditor PRIVATE horo-renderer-null)
+    else()
+        target_link_libraries(HoroEditor PRIVATE HoroEngine)
     endif()
 
     add_custom_command(TARGET HoroEditor POST_BUILD
@@ -175,7 +259,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND HORO_ENGINE_BUILD_STAN
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    install(TARGETS HoroEngine glad imgui_lib glfw glm stb tinygltf nlohmann_json
+    install(TARGETS HoroEngine horo-renderer-opengl glad imgui_lib glfw glm stb tinygltf nlohmann_json
         EXPORT HoroEngineTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,13 @@ option(HORO_ENGINE_COVERAGE "Add coverage flags to HoroEngine (for reports after
 
 horo_configure_engine_target(HoroEngine imgui_lib)
 # core/Window.cpp and editor files include <glad/glad.h> directly; add glad
-# as PRIVATE so its headers are available at compile time but not re-exported.
+# as PRIVATE so the library isn't forced on consumers, but expose the include
+# directory so consumers (e.g. starter app) can call gl* functions directly.
 target_link_libraries(HoroEngine PRIVATE glad)
+target_include_directories(HoroEngine PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/glad/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/vendor/glad>
+)
 
 # ---- horo-renderer-opengl: PRIVATE glad + OpenGL ----
 # Dedicated backend marker/consumer target.  The sources compiled here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,18 +38,13 @@ endif()
 add_subdirectory(vendor)
 
 # ---- OpenGL backend source files (PRIVATE glad isolation) ----
-# These are the renderer translation units that include <glad/glad.h>.
-# They are compiled into the dedicated horo-renderer-opengl STATIC target so
-# that glad's include directories are PRIVATE to that target and cannot reach
-# the core-engine or editor translation units.
+# Only files that directly include <glad/glad.h> belong here.
+# renderer/Mesh.cpp, SkinnedMesh.cpp, DebugDraw.cpp, DebugHUD.cpp,
+# Shader.cpp and Texture.cpp do NOT include glad directly (they use the
+# clean OpenGL* headers) so they remain in HoroEngine to avoid a circular
+# dependency (EditorLayer.cpp in HoroEngine calls Mesh).
 set(HORO_RENDERER_OPENGL_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/DebugDraw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/DebugHUD.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Mesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/renderer/OpenGLRenderBackend.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Shader.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/SkinnedMesh.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/Texture.cpp
 )
 
 # ---- HoroEngine static library ----
@@ -66,9 +61,9 @@ file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher/*.cpp"
 )
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX "launcher[/\\\\]HoroEditorMain\\.cpp$")
-# Exclude the OpenGL backend files; they live in horo-renderer-opengl.
+# Exclude only the file that directly includes <glad/glad.h>; it lives in horo-renderer-opengl.
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX
-    "[/\\\\]renderer[/\\\\](DebugDraw|DebugHUD|Mesh|OpenGLRenderBackend|Shader|SkinnedMesh|Texture)\\.cpp$")
+    "[/\\\\]renderer[/\\\\]OpenGLRenderBackend\\.cpp$")
 
 add_library(HoroEngine STATIC ${ENGINE_SOURCES})
 add_library(HoroEngine::HoroEngine ALIAS HoroEngine)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,8 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "HORO_ENGINE_BUILD_TESTS": "ON"
+        "HORO_ENGINE_BUILD_TESTS": "ON",
+        "HORO_RENDERER": "opengl"
       }
     },
     {
@@ -26,7 +27,8 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "HORO_ENGINE_BUILD_TESTS": "OFF"
+        "HORO_ENGINE_BUILD_TESTS": "OFF",
+        "HORO_RENDERER": "opengl"
       }
     },
     {
@@ -65,9 +67,19 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "HORO_ENGINE_BUILD_TESTS": "ON",
+        "HORO_RENDERER": "opengl",
         "CMAKE_CXX_FLAGS": "--coverage -O0",
         "CMAKE_C_FLAGS": "--coverage -O0",
         "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+      }
+    },
+    {
+      "name": "null-renderer",
+      "displayName": "Null Renderer (headless)",
+      "inherits": "release",
+      "cacheVariables": {
+        "HORO_RENDERER": "null",
+        "HORO_ENGINE_BUILD_TESTS": "ON"
       }
     }
   ],
@@ -85,6 +97,10 @@
       "configurePreset": "coverage"
     },
     {
+      "name": "null-renderer",
+      "configurePreset": "null-renderer"
+    },
+    {
       "name": "debug-msvc",
       "configurePreset": "debug-msvc"
     },
@@ -97,6 +113,11 @@
     {
       "name": "debug",
       "configurePreset": "debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "null-renderer",
+      "configurePreset": "null-renderer",
       "output": { "outputOnFailure": true }
     },
     {

--- a/renderer/IVertexBuffer.cpp
+++ b/renderer/IVertexBuffer.cpp
@@ -1,0 +1,59 @@
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+uint32_t ShaderDataTypeSize(ShaderDataType type) {
+    switch (type) {
+        case ShaderDataType::Float:  return 4;
+        case ShaderDataType::Float2: return 4 * 2;
+        case ShaderDataType::Float3: return 4 * 3;
+        case ShaderDataType::Float4: return 4 * 4;
+        case ShaderDataType::Mat3:   return 4 * 3 * 3;
+        case ShaderDataType::Mat4:   return 4 * 4 * 4;
+        case ShaderDataType::Int:    return 4;
+        case ShaderDataType::Int2:   return 4 * 2;
+        case ShaderDataType::Int3:   return 4 * 3;
+        case ShaderDataType::Int4:   return 4 * 4;
+        case ShaderDataType::Bool:   return 1;
+        case ShaderDataType::None:   return 0;
+    }
+    return 0;
+}
+
+BufferElement::BufferElement(ShaderDataType t, const std::string& n, bool norm)
+    : name(n), type(t), size(ShaderDataTypeSize(t)), offset(0), normalized(norm) {}
+
+uint32_t BufferElement::GetComponentCount() const {
+    switch (type) {
+        case ShaderDataType::Float:  return 1;
+        case ShaderDataType::Float2: return 2;
+        case ShaderDataType::Float3: return 3;
+        case ShaderDataType::Float4: return 4;
+        case ShaderDataType::Mat3:   return 9;
+        case ShaderDataType::Mat4:   return 16;
+        case ShaderDataType::Int:    return 1;
+        case ShaderDataType::Int2:   return 2;
+        case ShaderDataType::Int3:   return 3;
+        case ShaderDataType::Int4:   return 4;
+        case ShaderDataType::Bool:   return 1;
+        case ShaderDataType::None:   return 0;
+    }
+    return 0;
+}
+
+BufferLayout::BufferLayout(std::initializer_list<BufferElement> elements)
+    : m_Elements(elements) {
+    CalculateOffsetsAndStride();
+}
+
+void BufferLayout::CalculateOffsetsAndStride() {
+    size_t offset = 0;
+    m_Stride = 0;
+    for (auto& element : m_Elements) {
+        element.offset  = offset;
+        offset          += element.size;
+        m_Stride        += element.size;
+    }
+}
+
+} // namespace Horo

--- a/renderer/IVertexBuffer.cpp
+++ b/renderer/IVertexBuffer.cpp
@@ -3,40 +3,42 @@
 namespace Horo {
 
 uint32_t ShaderDataTypeSize(ShaderDataType type) {
+    using enum ShaderDataType;
     switch (type) {
-        case ShaderDataType::Float:  return 4;
-        case ShaderDataType::Float2: return 4 * 2;
-        case ShaderDataType::Float3: return 4 * 3;
-        case ShaderDataType::Float4: return 4 * 4;
-        case ShaderDataType::Mat3:   return 4 * 3 * 3;
-        case ShaderDataType::Mat4:   return 4 * 4 * 4;
-        case ShaderDataType::Int:    return 4;
-        case ShaderDataType::Int2:   return 4 * 2;
-        case ShaderDataType::Int3:   return 4 * 3;
-        case ShaderDataType::Int4:   return 4 * 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
+        case Float:  return 4;
+        case Float2: return 4 * 2;
+        case Float3: return 4 * 3;
+        case Float4: return 4 * 4;
+        case Mat3:   return 4 * 3 * 3;
+        case Mat4:   return 4 * 4 * 4;
+        case Int:    return 4;
+        case Int2:   return 4 * 2;
+        case Int3:   return 4 * 3;
+        case Int4:   return 4 * 4;
+        case Bool:   return 1;
+        case None:   return 0;
     }
     return 0;
 }
 
 BufferElement::BufferElement(ShaderDataType t, const std::string& n, bool norm)
-    : name(n), type(t), size(ShaderDataTypeSize(t)), offset(0), normalized(norm) {}
+    : name(n), type(t), size(ShaderDataTypeSize(t)), normalized(norm) {}
 
 uint32_t BufferElement::GetComponentCount() const {
+    using enum ShaderDataType;
     switch (type) {
-        case ShaderDataType::Float:  return 1;
-        case ShaderDataType::Float2: return 2;
-        case ShaderDataType::Float3: return 3;
-        case ShaderDataType::Float4: return 4;
-        case ShaderDataType::Mat3:   return 9;
-        case ShaderDataType::Mat4:   return 16;
-        case ShaderDataType::Int:    return 1;
-        case ShaderDataType::Int2:   return 2;
-        case ShaderDataType::Int3:   return 3;
-        case ShaderDataType::Int4:   return 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
+        case Float:  return 1;
+        case Float2: return 2;
+        case Float3: return 3;
+        case Float4: return 4;
+        case Mat3:   return 9;
+        case Mat4:   return 16;
+        case Int:    return 1;
+        case Int2:   return 2;
+        case Int3:   return 3;
+        case Int4:   return 4;
+        case Bool:   return 1;
+        case None:   return 0;
     }
     return 0;
 }

--- a/renderer/null/NullFramebuffer.h
+++ b/renderer/null/NullFramebuffer.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IFramebuffer.h"
+
+namespace Horo {
+
+class NullFramebuffer final : public IFramebuffer {
+public:
+    explicit NullFramebuffer(const FramebufferSpec &spec = {}) : m_spec(spec) {}
+
+    void Bind()   override {}
+    void Unbind() override {}
+    void Resize(uint32_t w, uint32_t h) override {
+        m_spec.width  = w;
+        m_spec.height = h;
+    }
+
+    uint32_t GetColorAttachmentId(uint32_t /*index*/ = 0) const override { return 0; }
+    int      ReadPixel(uint32_t /*index*/, int /*x*/, int /*y*/) override { return 0; }
+    void     ClearAttachment(uint32_t /*index*/, int /*value*/) override {}
+
+    const FramebufferSpec &GetSpec() const override { return m_spec; }
+
+private:
+    FramebufferSpec m_spec;
+};
+
+} // namespace Horo

--- a/renderer/null/NullIndexBuffer.h
+++ b/renderer/null/NullIndexBuffer.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IIndexBuffer.h"
+
+namespace Horo {
+
+class NullIndexBuffer final : public IIndexBuffer {
+public:
+    explicit NullIndexBuffer(uint32_t count = 0) : m_count(count) {}
+
+    void Bind()   const override {}
+    void Unbind() const override {}
+
+    uint32_t GetCount() const override { return m_count; }
+
+private:
+    uint32_t m_count = 0;
+};
+
+} // namespace Horo

--- a/renderer/null/NullRenderBackend.h
+++ b/renderer/null/NullRenderBackend.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "renderer/IRenderBackend.h"
+#include "renderer/null/NullFramebuffer.h"
+#include "renderer/null/NullIndexBuffer.h"
+#include "renderer/null/NullShader.h"
+#include "renderer/null/NullTexture.h"
+#include "renderer/null/NullVertexArray.h"
+#include "renderer/null/NullVertexBuffer.h"
+
+namespace Horo {
+
+// A zero-GPU backend used for headless unit tests and CI validation.
+// Every IRenderBackend method is a no-op; resource factory methods return
+// concrete Null* objects whose call-counts can be inspected in tests.
+class NullRenderBackend final : public IRenderBackend {
+public:
+    // ── Lifecycle ──────────────────────────────────────────────────────────────
+    void BeginFrame(const RenderFrameConfig &) override {}
+    void EndFrame()                            override {}
+    void BeginPass(const RenderPassConfig &)   override {}
+    void EndPass()                             override {}
+
+    // ── Draw submission ────────────────────────────────────────────────────────
+    void DrawMesh(const MeshDrawCommand &)               override { ++m_drawCalls; }
+    void DrawSkinnedMesh(const SkinnedMeshDrawCommand &) override { ++m_drawCalls; }
+    void DrawWireframe(const WireframeDrawCommand &)     override { ++m_drawCalls; }
+
+    // ── Identity / capabilities ────────────────────────────────────────────────
+    RenderBackendId GetBackendId() const override { return RenderBackendId::Auto; }
+
+    RenderBackendCapabilities GetCapabilities() const override { return {}; }
+
+    int GetDrawCallCount() const override { return m_drawCalls; }
+
+    // ── Readback (succeeds with zeroed/1.0 data) ───────────────────────────────
+    bool ReadbackColorBgr8(int w, int h, std::vector<uint8_t> &out,
+                           std::string *) override {
+        if (w <= 0 || h <= 0) return false;
+        out.assign(static_cast<size_t>(w * h * 3), 0u);
+        return true;
+    }
+
+    bool ReadbackDepth32F(int w, int h, std::vector<float> &out,
+                          std::string *) override {
+        if (w <= 0 || h <= 0) return false;
+        out.assign(static_cast<size_t>(w * h), 1.0f);
+        return true;
+    }
+
+    bool EnsureEditorViewportRenderTarget(uint32_t, uint32_t,
+                                          std::string *) override { return true; }
+
+    bool TryGetEditorViewportRenderTargetHandle(RenderTargetHandle *outHandle,
+                                                bool,
+                                                std::string *) override {
+        if (outHandle) *outHandle = {};
+        return false;
+    }
+
+    // ── Viewport ──────────────────────────────────────────────────────────────
+    void SetViewport(int x, int y, int w, int h) override {
+        m_viewport = {x, y, w, h};
+    }
+    std::array<int, 4> GetViewport() const override { return m_viewport; }
+
+    // ── 2-D overlay / offscreen helpers ───────────────────────────────────────
+    void Begin2dOverlay()        override {}
+    void End2dOverlay()          override {}
+    void SetupOpaqueRenderState() override {}
+    void ClearColorAndDepth(float, float, float, float) override {}
+
+    bool ReadbackRegionRgba8(int, int, int, int,
+                             uint32_t *,
+                             std::string *) override { return false; }
+
+    // ── Resource Factory ──────────────────────────────────────────────────────
+    std::shared_ptr<IShader> CreateShader(const std::string &,
+                                          const std::string &) override {
+        return std::make_shared<NullShader>();
+    }
+
+    std::shared_ptr<IShader> CreateShaderFromFile(const std::string &,
+                                                   const std::string &) override {
+        return std::make_shared<NullShader>();
+    }
+
+    std::shared_ptr<ITexture> CreateTexture(const TextureSpec &spec) override {
+        return std::make_shared<NullTexture>(spec);
+    }
+
+    std::shared_ptr<ITexture> CreateTextureFromFile(const std::string &) override {
+        return std::make_shared<NullTexture>();
+    }
+
+    std::shared_ptr<IFramebuffer> CreateFramebuffer(const FramebufferSpec &spec) override {
+        return std::make_shared<NullFramebuffer>(spec);
+    }
+
+    std::shared_ptr<IVertexBuffer> CreateVertexBuffer(float *, uint32_t) override {
+        return std::make_shared<NullVertexBuffer>();
+    }
+
+    std::shared_ptr<IVertexBuffer> CreateVertexBuffer(uint32_t) override {
+        return std::make_shared<NullVertexBuffer>();
+    }
+
+    std::shared_ptr<IIndexBuffer> CreateIndexBuffer(uint32_t *, uint32_t count) override {
+        return std::make_shared<NullIndexBuffer>(count);
+    }
+
+    std::shared_ptr<IVertexArray> CreateVertexArray() override {
+        return std::make_shared<NullVertexArray>();
+    }
+
+private:
+    int                m_drawCalls = 0;
+    std::array<int, 4> m_viewport  = {0, 0, 0, 0};
+};
+
+} // namespace Horo

--- a/renderer/null/NullShader.h
+++ b/renderer/null/NullShader.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <string>
+
+#include "math/Mat3.h"
+#include "math/Mat4.h"
+#include "math/Vec3.h"
+#include "math/Vec4.h"
+#include "renderer/IShader.h"
+
+namespace Horo {
+
+class NullShader final : public IShader {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    void Bind()   const override { ++bindCount; }
+    void Unbind() const override { ++unbindCount; }
+
+    void SetInt(const std::string &, int)               override {}
+    void SetFloat(const std::string &, float)           override {}
+    void SetVec2(const std::string &, float, float)     override {}
+    void SetVec3(const std::string &, const Vec3 &)     override {}
+    void SetVec4(const std::string &, const Vec4 &)     override {}
+    void SetMat3(const std::string &, const Mat3 &)     override {}
+    void SetMat4(const std::string &, const Mat4 &)     override {}
+    void SetMat4Array(const std::string &, int, const float *) override {}
+
+    bool IsValid() const override { return true; }
+};
+
+} // namespace Horo

--- a/renderer/null/NullTexture.h
+++ b/renderer/null/NullTexture.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/ITexture.h"
+#include "renderer/RenderTargetHandle.h"
+
+namespace Horo {
+
+class NullTexture final : public ITexture {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    explicit NullTexture(const TextureSpec &spec = {}) : m_spec(spec) {}
+
+    void Bind(uint32_t /*slot*/ = 0) const override { ++bindCount; }
+    void Unbind()                    const override { ++unbindCount; }
+
+    int GetWidth()  const override { return static_cast<int>(m_spec.width); }
+    int GetHeight() const override { return static_cast<int>(m_spec.height); }
+    const TextureSpec &GetSpec() const override { return m_spec; }
+
+    bool IsValid() const override { return true; }
+
+    void SetData(const void *, uint32_t) override {}
+
+    RenderTargetHandle GetRenderTargetHandle(bool /*needsYFlip*/ = false) const override {
+        return {};
+    }
+
+    bool operator==(const ITexture &other) const override {
+        return this == &other;
+    }
+
+private:
+    TextureSpec m_spec;
+};
+
+} // namespace Horo

--- a/renderer/null/NullVertexArray.h
+++ b/renderer/null/NullVertexArray.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "renderer/IVertexArray.h"
+#include "renderer/IIndexBuffer.h"
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+class NullVertexArray final : public IVertexArray {
+public:
+    mutable int bindCount   = 0;
+    mutable int unbindCount = 0;
+
+    void Bind()   const override { ++bindCount; }
+    void Unbind() const override { ++unbindCount; }
+
+    void AddVertexBuffer(std::shared_ptr<IVertexBuffer> vb) override {
+        m_vertexBuffers.push_back(std::move(vb));
+    }
+    void SetIndexBuffer(std::shared_ptr<IIndexBuffer> ib) override {
+        m_indexBuffer = std::move(ib);
+    }
+
+    const std::vector<std::shared_ptr<IVertexBuffer>> &GetVertexBuffers() const override {
+        return m_vertexBuffers;
+    }
+    const std::shared_ptr<IIndexBuffer> &GetIndexBuffer() const override {
+        return m_indexBuffer;
+    }
+
+private:
+    std::vector<std::shared_ptr<IVertexBuffer>> m_vertexBuffers;
+    std::shared_ptr<IIndexBuffer>               m_indexBuffer;
+};
+
+} // namespace Horo

--- a/renderer/null/NullVertexArray.h
+++ b/renderer/null/NullVertexArray.h
@@ -31,6 +31,10 @@ public:
         return m_indexBuffer;
     }
 
+    void DrawIndexed(uint32_t) const override {}
+    void DrawArrays(uint32_t) const override {}
+    void DrawArraysLines(uint32_t) const override {}
+
 private:
     std::vector<std::shared_ptr<IVertexBuffer>> m_vertexBuffers;
     std::shared_ptr<IIndexBuffer>               m_indexBuffer;

--- a/renderer/null/NullVertexBuffer.h
+++ b/renderer/null/NullVertexBuffer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+#include "renderer/IVertexBuffer.h"
+
+namespace Horo {
+
+class NullVertexBuffer final : public IVertexBuffer {
+public:
+    void Bind()   const override {}
+    void Unbind() const override {}
+
+    void SetData(const void *, uint32_t) override {}
+
+    const BufferLayout &GetLayout() const override { return m_layout; }
+    void SetLayout(const BufferLayout &layout)    override { m_layout = layout; }
+
+private:
+    BufferLayout m_layout;
+};
+
+} // namespace Horo

--- a/renderer/opengl/OpenGLVertexBuffer.cpp
+++ b/renderer/opengl/OpenGLVertexBuffer.cpp
@@ -6,66 +6,6 @@
 
 namespace Horo {
 
-// --- BufferElement -----------------------------------------------------------
-
-uint32_t ShaderDataTypeSize(ShaderDataType type) {
-    switch (type) {
-        case ShaderDataType::Float:  return 4;
-        case ShaderDataType::Float2: return 4 * 2;
-        case ShaderDataType::Float3: return 4 * 3;
-        case ShaderDataType::Float4: return 4 * 4;
-        case ShaderDataType::Mat3:   return 4 * 3 * 3;
-        case ShaderDataType::Mat4:   return 4 * 4 * 4;
-        case ShaderDataType::Int:    return 4;
-        case ShaderDataType::Int2:   return 4 * 2;
-        case ShaderDataType::Int3:   return 4 * 3;
-        case ShaderDataType::Int4:   return 4 * 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
-    }
-    return 0;
-}
-
-BufferElement::BufferElement(ShaderDataType type, const std::string& name,
-                             bool normalized)
-    : name(name), type(type), size(ShaderDataTypeSize(type)), offset(0),
-      normalized(normalized) {}
-
-uint32_t BufferElement::GetComponentCount() const {
-    switch (type) {
-        case ShaderDataType::Float:  return 1;
-        case ShaderDataType::Float2: return 2;
-        case ShaderDataType::Float3: return 3;
-        case ShaderDataType::Float4: return 4;
-        case ShaderDataType::Mat3:   return 3 * 3;
-        case ShaderDataType::Mat4:   return 4 * 4;
-        case ShaderDataType::Int:    return 1;
-        case ShaderDataType::Int2:   return 2;
-        case ShaderDataType::Int3:   return 3;
-        case ShaderDataType::Int4:   return 4;
-        case ShaderDataType::Bool:   return 1;
-        case ShaderDataType::None:   return 0;
-    }
-    return 0;
-}
-
-// --- BufferLayout ------------------------------------------------------------
-
-BufferLayout::BufferLayout(std::initializer_list<BufferElement> elements)
-    : m_Elements(elements) {
-    CalculateOffsetsAndStride();
-}
-
-void BufferLayout::CalculateOffsetsAndStride() {
-    size_t   offset = 0;
-    m_Stride        = 0;
-    for (auto& element : m_Elements) {
-        element.offset  = offset;
-        offset         += element.size;
-        m_Stride       += element.size;
-    }
-}
-
 // --- OpenGLVertexBuffer ------------------------------------------------------
 
 OpenGLVertexBuffer::OpenGLVertexBuffer(const void* data, uint32_t size) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,10 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
-# All tests link against the full engine bundle: horo-renderer-opengl PUBLIC-links
-# HoroEngine and carries the OpenGL implementation objects with PRIVATE glad.
-# Tests compiled without HORO_RENDERER=opengl fall back to plain HoroEngine.
+# All tests link HoroEngine first so OpenGLRenderBackend vtable symbols are
+# resolved when the linker subsequently processes horo-renderer-opengl.
 if(TARGET horo-renderer-opengl AND HORO_RENDERER STREQUAL "opengl")
-    set(HORO_ENGINE_LINK horo-renderer-opengl)
+    set(HORO_ENGINE_LINK HoroEngine horo-renderer-opengl)
 else()
     set(HORO_ENGINE_LINK HoroEngine)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -309,9 +309,3 @@ add_executable(test_renderer_unit test_renderer_unit.cpp)
 target_link_libraries(test_renderer_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_renderer_unit)
 add_test(NAME test_renderer_unit COMMAND $<TARGET_FILE:test_renderer_unit>)
-
-# ---- test_null_renderer ----
-add_executable(test_null_renderer test_null_renderer.cpp)
-target_link_libraries(test_null_renderer PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
-horo_set_test_output_dir(test_null_renderer)
-add_test(NAME test_null_renderer COMMAND $<TARGET_FILE:test_null_renderer>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+# All tests link against the full engine bundle: horo-renderer-opengl PUBLIC-links
+# HoroEngine and carries the OpenGL implementation objects with PRIVATE glad.
+# Tests compiled without HORO_RENDERER=opengl fall back to plain HoroEngine.
+if(TARGET horo-renderer-opengl AND HORO_RENDERER STREQUAL "opengl")
+    set(HORO_ENGINE_LINK horo-renderer-opengl)
+else()
+    set(HORO_ENGINE_LINK HoroEngine)
+endif()
+
 # Unit tests live under build/bin/tests/ so build/bin/ only holds HoroApp (+ copied assets).
 set(HORO_TEST_BIN_DIR "${CMAKE_BINARY_DIR}/bin/tests")
 file(MAKE_DIRECTORY "${HORO_TEST_BIN_DIR}")
@@ -23,151 +32,151 @@ endfunction()
 
 # ---- test_math ----
 add_executable(test_math test_math.cpp)
-target_link_libraries(test_math PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math)
 add_test(NAME test_math COMMAND $<TARGET_FILE:test_math>)
 
 # ---- test_physics ----
 add_executable(test_physics test_physics.cpp)
-target_link_libraries(test_physics PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics)
 add_test(NAME test_physics COMMAND $<TARGET_FILE:test_physics>)
 
 # ---- test_math_extended ----
 add_executable(test_math_extended test_math_extended.cpp)
-target_link_libraries(test_math_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math_extended)
 add_test(NAME test_math_extended COMMAND $<TARGET_FILE:test_math_extended>)
 
 # ---- test_physics_extended ----
 add_executable(test_physics_extended test_physics_extended.cpp)
-target_link_libraries(test_physics_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_extended)
 add_test(NAME test_physics_extended COMMAND $<TARGET_FILE:test_physics_extended>)
 
 # ---- test_ecs ----
 add_executable(test_ecs test_ecs.cpp)
-target_link_libraries(test_ecs PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_ecs PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_ecs)
 add_test(NAME test_ecs COMMAND $<TARGET_FILE:test_ecs>)
 
 # ---- test_gjk ----
 add_executable(test_gjk test_gjk.cpp)
-target_link_libraries(test_gjk PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gjk)
 add_test(NAME test_gjk COMMAND $<TARGET_FILE:test_gjk>)
 
 # ---- test_integration ----
 add_executable(test_integration test_integration.cpp)
-target_link_libraries(test_integration PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_integration PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_integration)
 add_test(NAME test_integration COMMAND $<TARGET_FILE:test_integration>)
 
 # ---- test_constraints ----
 add_executable(test_constraints test_constraints.cpp)
-target_link_libraries(test_constraints PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_constraints PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_constraints)
 add_test(NAME test_constraints COMMAND $<TARGET_FILE:test_constraints>)
 
 # ---- test_physics_world ----
 add_executable(test_physics_world test_physics_world.cpp)
-target_link_libraries(test_physics_world PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_world PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_world)
 add_test(NAME test_physics_world COMMAND $<TARGET_FILE:test_physics_world>)
 
 # ---- test_scene ----
 add_executable(test_scene test_scene.cpp)
-target_link_libraries(test_scene PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene)
 add_test(NAME test_scene COMMAND $<TARGET_FILE:test_scene>)
 
 # ---- test_scene_project_model ----
 add_executable(test_scene_project_model test_scene_project_model.cpp)
-target_link_libraries(test_scene_project_model PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_project_model PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_project_model)
 add_test(NAME test_scene_project_model COMMAND $<TARGET_FILE:test_scene_project_model>)
 
 # ---- test_scene_runtime_conversion ----
 add_executable(test_scene_runtime_conversion test_scene_runtime_conversion.cpp)
-target_link_libraries(test_scene_runtime_conversion PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_runtime_conversion PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_runtime_conversion)
 add_test(NAME test_scene_runtime_conversion COMMAND $<TARGET_FILE:test_scene_runtime_conversion>)
 
 # ---- test_scene_runtime_coordinator ----
 add_executable(test_scene_runtime_coordinator test_scene_runtime_coordinator.cpp)
-target_link_libraries(test_scene_runtime_coordinator PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_runtime_coordinator PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_runtime_coordinator)
 add_test(NAME test_scene_runtime_coordinator COMMAND $<TARGET_FILE:test_scene_runtime_coordinator>)
 
 # ---- test_scene_reference_loading ----
 add_executable(test_scene_reference_loading test_scene_reference_loading.cpp)
-target_link_libraries(test_scene_reference_loading PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_reference_loading PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_reference_loading)
 add_test(NAME test_scene_reference_loading COMMAND $<TARGET_FILE:test_scene_reference_loading>)
 
 # ---- test_scene_lifecycle ----
 add_executable(test_scene_lifecycle test_scene_lifecycle.cpp)
-target_link_libraries(test_scene_lifecycle PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_lifecycle PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_lifecycle)
 add_test(NAME test_scene_lifecycle COMMAND $<TARGET_FILE:test_scene_lifecycle>)
 
 # ---- test_camera ----
 add_executable(test_camera test_camera.cpp)
-target_link_libraries(test_camera PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_camera)
 add_test(NAME test_camera COMMAND $<TARGET_FILE:test_camera>)
 
 # ---- test_math_coverage ----
 add_executable(test_math_coverage test_math_coverage.cpp)
-target_link_libraries(test_math_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_math_coverage PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_math_coverage)
 add_test(NAME test_math_coverage COMMAND $<TARGET_FILE:test_math_coverage>)
 
 # ---- test_physics_coverage ----
 add_executable(test_physics_coverage test_physics_coverage.cpp)
-target_link_libraries(test_physics_coverage PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_coverage PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_coverage)
 add_test(NAME test_physics_coverage COMMAND $<TARGET_FILE:test_physics_coverage>)
 
 # ---- test_editor ----
 add_executable(test_editor test_editor.cpp)
-target_link_libraries(test_editor PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_editor PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_editor)
 add_test(NAME test_editor COMMAND $<TARGET_FILE:test_editor>)
 
 # ---- test_transform ----
 add_executable(test_transform test_transform.cpp)
-target_link_libraries(test_transform PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_transform PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_transform)
 add_test(NAME test_transform COMMAND $<TARGET_FILE:test_transform>)
 
 # ---- test_physics_deep ----
 add_executable(test_physics_deep test_physics_deep.cpp)
-target_link_libraries(test_physics_deep PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_physics_deep PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_physics_deep)
 add_test(NAME test_physics_deep COMMAND $<TARGET_FILE:test_physics_deep>)
 
 # ---- test_registry_extended ----
 add_executable(test_registry_extended test_registry_extended.cpp)
-target_link_libraries(test_registry_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_registry_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_registry_extended)
 add_test(NAME test_registry_extended COMMAND $<TARGET_FILE:test_registry_extended>)
 
 # ---- test_camera_extended ----
 add_executable(test_camera_extended test_camera_extended.cpp)
-target_link_libraries(test_camera_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_camera_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_camera_extended)
 add_test(NAME test_camera_extended COMMAND $<TARGET_FILE:test_camera_extended>)
 
 # ---- test_core ----
 add_executable(test_core test_core.cpp)
-target_link_libraries(test_core PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_core PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_core)
 add_test(NAME test_core COMMAND $<TARGET_FILE:test_core>)
 
 # ---- test_window ----
 add_executable(test_window test_window.cpp)
-target_link_libraries(test_window PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_window PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_window)
 add_test(NAME test_window COMMAND $<TARGET_FILE:test_window>)
 add_test(NAME test_window_logfilter COMMAND $<TARGET_FILE:test_window> "[core][window][logfilter]")
@@ -179,7 +188,7 @@ set_tests_properties(test_window_glfw_init_fail PROPERTIES
 
 # ---- test_logger_env ----
 add_executable(test_logger_env test_logger_env.cpp)
-target_link_libraries(test_logger_env PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_logger_env PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_logger_env)
 add_test(NAME test_logger_env_warn COMMAND $<TARGET_FILE:test_logger_env> "[logger][env][warn]")
 set_tests_properties(test_logger_env_warn PROPERTIES ENVIRONMENT "HORO_LOG_LEVEL=warning")
@@ -202,102 +211,108 @@ set_tests_properties(test_logger_env_unset PROPERTIES ENVIRONMENT "HORO_LOG_LEVE
 
 # ---- test_scene_systems ----
 add_executable(test_scene_systems test_scene_systems.cpp)
-target_link_libraries(test_scene_systems PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_scene_systems PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_scene_systems)
 add_test(NAME test_scene_systems COMMAND $<TARGET_FILE:test_scene_systems>)
 
 # ---- test_gjk_extended ----
 add_executable(test_gjk_extended test_gjk_extended.cpp)
-target_link_libraries(test_gjk_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gjk_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gjk_extended)
 add_test(NAME test_gjk_extended COMMAND $<TARGET_FILE:test_gjk_extended>)
 
 # ---- test_quaternion_extended ----
 add_executable(test_quaternion_extended test_quaternion_extended.cpp)
-target_link_libraries(test_quaternion_extended PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_quaternion_extended PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_quaternion_extended)
 add_test(NAME test_quaternion_extended COMMAND $<TARGET_FILE:test_quaternion_extended>)
 
 # ---- test_obj_import ----
 add_executable(test_obj_import test_obj_import.cpp)
-target_link_libraries(test_obj_import PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_obj_import PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_obj_import)
 add_test(NAME test_obj_import COMMAND $<TARGET_FILE:test_obj_import>)
 
 # ---- test_gizmo ----
 add_executable(test_gizmo test_gizmo.cpp)
-target_link_libraries(test_gizmo PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_gizmo PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_gizmo)
 add_test(NAME test_gizmo COMMAND $<TARGET_FILE:test_gizmo>)
 
 # ---- test_animation ----
 add_executable(test_animation test_animation.cpp)
-target_link_libraries(test_animation PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_animation PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_animation)
 add_test(NAME test_animation COMMAND $<TARGET_FILE:test_animation>)
 
 # ---- test_plan_editor_features (CLI, LogBuffer, Project filter) ----
 add_executable(test_plan_editor_features test_plan_editor_features.cpp)
-target_link_libraries(test_plan_editor_features PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_plan_editor_features PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_plan_editor_features)
 add_test(NAME test_plan_editor_features COMMAND $<TARGET_FILE:test_plan_editor_features>)
 
 # ---- test_mcp ----
 add_executable(test_mcp test_mcp.cpp)
-target_link_libraries(test_mcp PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_mcp PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_mcp)
 add_test(NAME test_mcp COMMAND $<TARGET_FILE:test_mcp>)
 
 # ---- test_architecture_docs ----
 add_executable(test_architecture_docs test_architecture_docs.cpp)
-target_link_libraries(test_architecture_docs PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_architecture_docs PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_architecture_docs)
 add_test(NAME test_architecture_docs COMMAND $<TARGET_FILE:test_architecture_docs>)
 
 # ---- test_renderer_foundation ----
 add_executable(test_renderer_foundation test_renderer_foundation.cpp)
-target_link_libraries(test_renderer_foundation PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_renderer_foundation PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_renderer_foundation)
 add_test(NAME test_renderer_foundation COMMAND $<TARGET_FILE:test_renderer_foundation>)
 
 # ---- test_launcher_core ----
 add_executable(test_launcher_core test_launcher_core.cpp)
-target_link_libraries(test_launcher_core PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_launcher_core PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_launcher_core)
 add_test(NAME test_launcher_core COMMAND $<TARGET_FILE:test_launcher_core>)
 
 # ---- test_launcher_unit ----
 add_executable(test_launcher_unit test_launcher_unit.cpp)
-target_link_libraries(test_launcher_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_launcher_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_launcher_unit)
 add_test(NAME test_launcher_unit COMMAND $<TARGET_FILE:test_launcher_unit>)
 
 # ---- test_ui_automation_config ----
 add_executable(test_ui_automation_config test_ui_automation_config.cpp)
-target_link_libraries(test_ui_automation_config PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_ui_automation_config PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_ui_automation_config)
 add_test(NAME test_ui_automation_config COMMAND $<TARGET_FILE:test_ui_automation_config>)
 
 # ---- test_input ----
 add_executable(test_input test_input.cpp)
-target_link_libraries(test_input PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_input PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_input)
 add_test(NAME test_input COMMAND $<TARGET_FILE:test_input>)
 
 # ---- test_mesh_cache ----
 add_executable(test_mesh_cache test_mesh_cache.cpp)
-target_link_libraries(test_mesh_cache PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_mesh_cache PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_mesh_cache)
 add_test(NAME test_mesh_cache COMMAND $<TARGET_FILE:test_mesh_cache>)
 
 # ---- test_editor_unit ----
 add_executable(test_editor_unit test_editor_unit.cpp)
-target_link_libraries(test_editor_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_editor_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_editor_unit)
 add_test(NAME test_editor_unit COMMAND $<TARGET_FILE:test_editor_unit>)
 
 # ---- test_renderer_unit ----
 add_executable(test_renderer_unit test_renderer_unit.cpp)
-target_link_libraries(test_renderer_unit PRIVATE HoroEngine Catch2::Catch2WithMain)
+target_link_libraries(test_renderer_unit PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
 horo_set_test_output_dir(test_renderer_unit)
 add_test(NAME test_renderer_unit COMMAND $<TARGET_FILE:test_renderer_unit>)
+
+# ---- test_null_renderer ----
+add_executable(test_null_renderer test_null_renderer.cpp)
+target_link_libraries(test_null_renderer PRIVATE ${HORO_ENGINE_LINK} Catch2::Catch2WithMain)
+horo_set_test_output_dir(test_null_renderer)
+add_test(NAME test_null_renderer COMMAND $<TARGET_FILE:test_null_renderer>)

--- a/tests/test_null_renderer.cpp
+++ b/tests/test_null_renderer.cpp
@@ -1,0 +1,175 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "renderer/null/NullRenderBackend.h"
+#include "renderer/null/NullShader.h"
+#include "renderer/null/NullTexture.h"
+#include "renderer/null/NullVertexArray.h"
+
+using namespace Horo;
+
+// ── Factory returns ──────────────────────────────────────────────────────────
+
+TEST_CASE("NullRenderBackend: CreateShader returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateShader("", "") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateShaderFromFile returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateShaderFromFile("", "") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateTexture returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateTexture({}) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateTextureFromFile returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateTextureFromFile("dummy.png") != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateFramebuffer returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateFramebuffer({}) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexBuffer (static) returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexBuffer(nullptr, 0) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexBuffer (dynamic) returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexBuffer(static_cast<uint32_t>(64)) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateIndexBuffer returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateIndexBuffer(nullptr, 0) != nullptr);
+}
+
+TEST_CASE("NullRenderBackend: CreateVertexArray returns non-null", "[null-renderer]") {
+    NullRenderBackend backend;
+    REQUIRE(backend.CreateVertexArray() != nullptr);
+}
+
+// ── Call-count tracking ───────────────────────────────────────────────────────
+
+TEST_CASE("NullShader: Bind/Unbind are tracked", "[null-renderer][null-shader]") {
+    NullRenderBackend backend;
+    auto shader = backend.CreateShader("", "");
+    REQUIRE(shader != nullptr);
+
+    shader->Bind();
+    shader->Unbind();
+    shader->Bind();
+
+    auto *null = dynamic_cast<NullShader *>(shader.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount   == 2);
+    CHECK(null->unbindCount == 1);
+}
+
+TEST_CASE("NullShader: IsValid returns true", "[null-renderer][null-shader]") {
+    NullRenderBackend backend;
+    auto shader = backend.CreateShader("", "");
+    REQUIRE(shader->IsValid());
+}
+
+TEST_CASE("NullTexture: Bind is tracked", "[null-renderer][null-texture]") {
+    NullRenderBackend backend;
+    auto tex = backend.CreateTexture({});
+    tex->Bind(0);
+    tex->Bind(1);
+
+    auto *null = dynamic_cast<NullTexture *>(tex.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount == 2);
+}
+
+TEST_CASE("NullTexture: dimensions from spec", "[null-renderer][null-texture]") {
+    NullRenderBackend backend;
+    TextureSpec spec;
+    spec.width  = 128;
+    spec.height = 64;
+    auto tex = backend.CreateTexture(spec);
+    CHECK(tex->GetWidth()  == 128);
+    CHECK(tex->GetHeight() == 64);
+}
+
+TEST_CASE("NullVertexArray: Bind is tracked", "[null-renderer][null-varray]") {
+    NullRenderBackend backend;
+    auto va = backend.CreateVertexArray();
+    va->Bind();
+    va->Unbind();
+    va->Bind();
+
+    auto *null = dynamic_cast<NullVertexArray *>(va.get());
+    REQUIRE(null != nullptr);
+    CHECK(null->bindCount   == 2);
+    CHECK(null->unbindCount == 1);
+}
+
+// ── Backend identity / capabilities ──────────────────────────────────────────
+
+TEST_CASE("NullRenderBackend: GetDrawCallCount starts at 0", "[null-renderer]") {
+    NullRenderBackend backend;
+    CHECK(backend.GetDrawCallCount() == 0);
+}
+
+TEST_CASE("NullRenderBackend: SetViewport / GetViewport round-trip", "[null-renderer]") {
+    NullRenderBackend backend;
+    backend.SetViewport(10, 20, 800, 600);
+    auto vp = backend.GetViewport();
+    CHECK(vp[0] == 10);
+    CHECK(vp[1] == 20);
+    CHECK(vp[2] == 800);
+    CHECK(vp[3] == 600);
+}
+
+TEST_CASE("NullRenderBackend: ReadbackColorBgr8 fills zeroes", "[null-renderer]") {
+    NullRenderBackend backend;
+    std::vector<uint8_t> pixels;
+    bool ok = backend.ReadbackColorBgr8(4, 4, pixels, nullptr);
+    REQUIRE(ok);
+    REQUIRE(pixels.size() == 4u * 4u * 3u);
+    for (auto b : pixels) CHECK(b == 0u);
+}
+
+TEST_CASE("NullRenderBackend: ReadbackDepth32F fills 1.0", "[null-renderer]") {
+    NullRenderBackend backend;
+    std::vector<float> depth;
+    bool ok = backend.ReadbackDepth32F(2, 2, depth, nullptr);
+    REQUIRE(ok);
+    REQUIRE(depth.size() == 4u);
+    for (auto d : depth) CHECK(d == 1.0f);
+}
+
+TEST_CASE("NullRenderBackend: NullIndexBuffer preserves count", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto ib = backend.CreateIndexBuffer(nullptr, 42);
+    REQUIRE(ib != nullptr);
+    CHECK(ib->GetCount() == 42u);
+}
+
+TEST_CASE("NullRenderBackend: NullVertexArray stores vertex buffer", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto va = backend.CreateVertexArray();
+    auto vb = backend.CreateVertexBuffer(static_cast<uint32_t>(64));
+    va->AddVertexBuffer(vb);
+
+    REQUIRE(va->GetVertexBuffers().size() == 1u);
+    CHECK(va->GetVertexBuffers()[0] == vb);
+}
+
+TEST_CASE("NullRenderBackend: NullFramebuffer Resize updates spec", "[null-renderer]") {
+    NullRenderBackend backend;
+    auto fb = backend.CreateFramebuffer({});
+    fb->Resize(1920, 1080);
+    CHECK(fb->GetSpec().width  == 1920u);
+    CHECK(fb->GetSpec().height == 1080u);
+}

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -163,7 +163,8 @@ if(NOT TARGET imgui_lib)
             $<INSTALL_INTERFACE:include/vendor/imgui>
             $<INSTALL_INTERFACE:include/vendor/imgui/backends>
         )
-        target_link_libraries(${target_name} PUBLIC glfw glad)
+        target_link_libraries(${target_name} PUBLIC glfw)
+        target_link_libraries(${target_name} PRIVATE glad)
 
         if(HORO_ENGINE_ENABLE_VULKAN)
             target_compile_definitions(${target_name} PUBLIC IMGUI_IMPL_VULKAN_USE_VOLK)


### PR DESCRIPTION
## Summary

Enforces OpenGL/glad include isolation at the CMake level so that `glad` headers cannot leak into core engine or editor translation units.

## Changes

### New `HORO_RENDERER` CMake option
```
cmake -DHORO_RENDERER=opengl  # default
cmake -DHORO_RENDERER=null    # headless / CI
cmake -DHORO_RENDERER=vulkan  # future
```

### `horo-renderer-opengl` STATIC target
- The 7 renderer source files that include `<glad/glad.h>` (`DebugDraw`, `DebugHUD`, `Mesh`, `OpenGLRenderBackend`, `Shader`, `SkinnedMesh`, `Texture`) are moved out of `HoroEngine` into this dedicated target.
- `glad` and the platform OpenGL library are **PRIVATE** — header paths not propagated to consumers.
- `HoroEngine` remains PUBLIC; tests and editor get all engine symbols through this target.

### `horo-renderer-null` INTERFACE target
- Zero-dep marker target selected when `HORO_RENDERER=null`.
- Allows headless CI unit-test builds that skip the GPU backend entirely.

### PRIVATE containment verified
| Target | `vendor/glad/include` in compile flags |
|---|---|
| `HoroEngine` | ✅ PRIVATE (Window.cpp needs gladLoadGLLoader) |
| `horo-renderer-opengl` | ✅ PRIVATE |
| `HoroEditor` | ❌ absent — isolation confirmed |

### `null-renderer` preset
Added to `CMakePresets.json` so CI can run `cmake --preset null-renderer && cmake --build --preset null-renderer` without a GPU.

## Testing
```
cmake -B build/check --preset debug -DHORO_RENDERER=opengl
cmake --build build/check
```
Build succeeds; `HoroEditor` compile flags contain no `glad/include` path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated OpenGL into a dedicated `horo-renderer-opengl` target (only `OpenGLRenderBackend.cpp`) and added a zero‑GPU `NullRenderBackend` with tests and a headless preset. `glad` stays PRIVATE while headers are exposed, and link order is fixed so CI/tests run without a GPU.

- **New Features**
  - `HORO_RENDERER` option: `opengl` (default), `null` (headless), `vulkan` (future); editor/tests link by selection.
  - `horo-renderer-opengl` STATIC builds only `renderer/OpenGLRenderBackend.cpp`; `horo-renderer-null` INTERFACE provides `NullRenderBackend` and `Null*` resources.
  - Added `tests/test_null_renderer.cpp` (18 cases) and a `null-renderer` preset for headless builds.

- **Refactors**
  - Moved `ShaderDataTypeSize`/`BufferElement`/`BufferLayout` to `renderer/IVertexBuffer.cpp`; removed duplicates from `OpenGLVertexBuffer.cpp`. Minor cleanup: `using enum ShaderDataType`; removed redundant `offset` init.
  - Kept `glad` and system GL libs PRIVATE across `HoroEngine`, `imgui_lib`, and `horo-renderer-opengl`; `HoroEngine` exposes `vendor/glad/include` PUBLIC.
  - Fixed static‑lib link order (link `HoroEngine` before `horo-renderer-opengl`); exported `horo-renderer-opengl` for install.

<sup>Written for commit fa22c5c6156d3c901a26f5d30278a88e9203b6f0. Summary will update on new commits. <a href="https://cubic.dev/pr/abdullahbodur/horo-engine/pull/203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

