### PR TITLE
docs: remove features table HORO-59

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,6 @@ Horo may not be the best choice if you need:
 - A source-available engine intended for direct integration, not opaque SDK consumption
 - A practical platform for gameplay, editor workflows, and automation tests
 
-## Features
-
-| Module | Status | Notes |
-|---|---|---|
-| Core (ECS, scene, serialization) | ✅ Production | |
-| OpenGL renderer | ✅ Production | |
-| Asset import pipeline | ✅ Production | |
-| Unit test suite (Catch2) | ✅ Production | |
-| UI automation tests | ✅ Production | Launcher + editor flows |
-| MCP server (editor AI tooling) | ✅ Production | HTTP endpoint, opt-in |
-| Vulkan renderer | 🔧 In progress | Not parity-complete yet |
-| Backend resource factory API | 🔧 In progress | Active PRs |
-| Physics | 🔧 In progress | Module scaffolded |
-| GI / reflections | 📋 Planned | Architecture defined |
-
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the outdated Features table from README to avoid confusion and reduce maintenance. Aligns with HORO-59 by removing static feature status from the docs.

<sup>Written for commit 1c3984fddb9f813e054e4d3f4c1a5d72fd2f8521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

