### PR TITLE
feat(ui): shared UI module with HoroTheme for launcher and editor (HORO-37)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/editor/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/ui/common/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/ui/launcher/*.cpp"
 )
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX "launcher[/\\\\]HoroEditorMain\\.cpp$")
 # Exclude only the file that directly includes <glad/glad.h>; it lives in horo-renderer-opengl.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/input/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/editor/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/ui/common/*.cpp"
 )
 list(FILTER ENGINE_SOURCES EXCLUDE REGEX "launcher[/\\\\]HoroEditorMain\\.cpp$")
 # Exclude only the file that directly includes <glad/glad.h>; it lives in horo-renderer-opengl.

--- a/editor/EditorLayer.cpp
+++ b/editor/EditorLayer.cpp
@@ -1,6 +1,7 @@
 #include "editor/EditorLayer.h"
 #include "editor/EditorLayerInternal.h"
 #include "editor/TransformGizmo.h"
+#include "ui/common/HoroTheme.h"
 
 // Windows headers must come before GLFW to avoid type redefinition conflicts
 #ifdef _WIN32
@@ -907,7 +908,7 @@ void EditorLayer::Init(GLFWwindow *window) {
 
   IMGUI_CHECKVERSION();
   ImGui::CreateContext();
-  ImGui::StyleColorsDark();
+  Horo::UI::ApplyHoroEditorTheme();
   ImGuiIO &io = ImGui::GetIO();
   LoadEditorFonts(io);
   m_imguiIniPath = ResolveEditorLayoutPath().string();
@@ -2194,6 +2195,7 @@ void EditorLayer::DrawSceneControls() {
 
 void EditorLayer::DrawToolbar() {
   const ImGuiIO &io = ImGui::GetIO();
+  const auto& theme = Horo::UI::GetHoroTheme();
   ImGui::SetNextWindowPos(ImVec2(0, 0));
   ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x, kEditorToolbarH));
   ImGui::SetNextWindowBgAlpha(0.85f);
@@ -2202,7 +2204,7 @@ void EditorLayer::DrawToolbar() {
                    ImGuiWindowFlags_NoScrollbar |
                    ImGuiWindowFlags_NoBringToFrontOnFocus);
 
-  ImGui::TextColored(ImVec4(0.4f, 0.8f, 1.0f, 1.0f), "EDITOR");
+  ImGui::TextColored(theme.info, "EDITOR");
   ImGui::SameLine();
   ImGui::Separator();
   ImGui::SameLine();
@@ -2501,6 +2503,7 @@ void EditorLayer::DrawProjectBrowserTab() {
 
 void EditorLayer::DrawConsoleTab() {
   using enum LogLevel;
+  const auto& theme = Horo::UI::GetHoroTheme();
   int nInfo = 0;
   int nWarn = 0;
   int nErr = 0;
@@ -2561,9 +2564,9 @@ void EditorLayer::DrawConsoleTab() {
       levelStr = "WARN";
     ImVec4 color(0.85f, 0.9f, 1.0f, 1.0f);
     if (entry.level == Warn)
-      color = ImVec4(1.0f, 0.85f, 0.4f, 1.0f);
+      color = theme.warning;
     else if (entry.level == Error)
-      color = ImVec4(1.0f, 0.45f, 0.4f, 1.0f);
+      color = theme.error;
 
     const std::string lineLine =
         std::format("[{}] {} ({}:{}) {}", timeBuf.c_str(), levelStr, entry.file,
@@ -2596,6 +2599,7 @@ void EditorLayer::DrawMcpClientCard(const char *title, const char *pathLabel,
 }
 
 void EditorLayer::DrawMcpTabLiveRequests(const Mcp::McpStatusSnapshot &status) {
+  const auto& theme = Horo::UI::GetHoroTheme();
   DrawUiAutomationMarker(
       std::format("##mcp_test/activity_rows_{}", status.recentActivity.size())
           .c_str());
@@ -2626,8 +2630,7 @@ void EditorLayer::DrawMcpTabLiveRequests(const Mcp::McpStatusSnapshot &status) {
     ImGui::TableSetColumnIndex(1);
     ImGui::TextUnformatted(entry.target.c_str());
     ImGui::TableSetColumnIndex(2);
-    ImGui::TextColored(entry.ok ? ImVec4(0.75f, 0.95f, 0.75f, 1.0f)
-                                : ImVec4(1.0f, 0.55f, 0.5f, 1.0f),
+    ImGui::TextColored(entry.ok ? theme.success : theme.error,
                        "%s", entry.ok ? "OK" : "FAIL");
     ImGui::TableSetColumnIndex(3);
     ImGui::Text("%.1f", entry.durationMs);
@@ -2678,7 +2681,7 @@ void EditorLayer::DrawMcpTabLiveRequests(const Mcp::McpStatusSnapshot &status) {
                              ? "##mcp_test/request_id_empty"
                              : "##mcp_test/request_id_present");
   if (!selected.error.empty()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.55f, 0.5f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_Text, theme.error);
     ImGui::TextWrapped("Error: %s", selected.error.c_str());
     ImGui::PopStyleColor();
   }
@@ -2711,6 +2714,7 @@ void EditorLayer::DrawMcpTabCatalog(
 }
 
 void EditorLayer::DrawMcpTab() {
+  const auto& theme = Horo::UI::GetHoroTheme();
   const Mcp::McpStatusSnapshot status = m_mcpController.GetStatusSnapshot();
 
   if (m_mcpSelectedActivityIndex >=
@@ -2815,7 +2819,7 @@ void EditorLayer::DrawMcpTab() {
   }
 
   if (!status.lastError.empty()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_Text, theme.error);
     ImGui::TextWrapped("%s", status.lastError.c_str());
     ImGui::PopStyleColor();
   }
@@ -2871,6 +2875,7 @@ void EditorLayer::DrawMcpTab() {
 }
 
 void EditorLayer::DrawSettingsModal() {
+  const auto& theme = Horo::UI::GetHoroTheme();
   if (m_settingsOpen)
     ImGui::OpenPopup("Editor Settings");
 
@@ -2895,7 +2900,7 @@ void EditorLayer::DrawSettingsModal() {
   ImGui::TextWrapped("Endpoint: %s", endpoint.c_str());
 
   if (!m_mcpSettingsError.empty()) {
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.45f, 0.4f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_Text, theme.error);
     ImGui::TextWrapped("%s", m_mcpSettingsError.c_str());
     ImGui::PopStyleColor();
   }
@@ -3174,6 +3179,7 @@ void EditorLayer::ApplyRenameObject() {
 }
 
 void EditorLayer::DrawRenameObjectModal() {
+  const auto& theme = Horo::UI::GetHoroTheme();
   if (m_renameObjectOpen) {
     ImGui::OpenPopup("Rename Object");
     m_renameObjectOpen = false;
@@ -3192,7 +3198,7 @@ void EditorLayer::DrawRenameObjectModal() {
   }
 
   if (!m_renameObjectError.empty())
-    ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "%s",
+    ImGui::TextColored(theme.error, "%s",
                        m_renameObjectError.c_str());
 
   if (ImGui::Button("Apply"))
@@ -3584,6 +3590,7 @@ void EditorLayer::DrawObjectsTreeRootDropZone() {
 
 void EditorLayer::DrawObjectsTreeRuntimeEntities(
     const SceneDocument &doc) const {
+  const auto& theme = Horo::UI::GetHoroTheme();
   if (!m_liveRegistry)
     return;
 
@@ -3613,7 +3620,7 @@ void EditorLayer::DrawObjectsTreeRuntimeEntities(
   if (runtimeEntities.empty())
     return;
 
-  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.65f, 0.65f, 0.65f, 1.0f));
+  ImGui::PushStyleColor(ImGuiCol_Text, theme.textMuted);
   if (ImGui::TreeNodeEx("##runtime_entities",
                         ImGuiTreeNodeFlags_DefaultOpen |
                             ImGuiTreeNodeFlags_SpanAvailWidth,
@@ -3802,6 +3809,7 @@ void EditorLayer::DrawAssetsPanel() {
 void EditorLayer::DrawHelpPopup() {
   if (!m_helpOpen)
     return;
+  const auto& theme = Horo::UI::GetHoroTheme();
   const std::span<const ShortcutRow> shortcuts = GetEditorShortcuts();
 
   const ImGuiIO &io = ImGui::GetIO();
@@ -3844,7 +3852,7 @@ void EditorLayer::DrawHelpPopup() {
     ImGui::NextColumn();
     ImGui::TextUnformatted(row.command);
     ImGui::NextColumn();
-    ImGui::TextColored(ImVec4(0.65f, 0.85f, 1.0f, 1.0f), "%s", row.keys);
+    ImGui::TextColored(theme.infoBright, "%s", row.keys);
     ImGui::NextColumn();
     ++shownCount;
   }
@@ -4207,6 +4215,7 @@ void EditorLayer::DrawCreateAssetModal(bool openModal) {
 // Extracted from DrawCreateAssetModal to keep the outer function below the
 // S3776 cognitive complexity threshold. Owns all widget logic for the modal.
 void EditorLayer::DrawCreateAssetModalContent() {
+  const auto& theme = Horo::UI::GetHoroTheme();
   constexpr float blockW = 470.0f;
   ImGui::PushItemWidth(blockW);
 
@@ -4220,7 +4229,7 @@ void EditorLayer::DrawCreateAssetModalContent() {
   }
   if (!m_assetImportError.empty()) {
     ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + blockW);
-    ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s",
+    ImGui::TextColored(theme.error, "%s",
                        m_assetImportError.c_str());
     ImGui::PopTextWrapPos();
   }
@@ -4385,6 +4394,7 @@ void EditorLayer::DrawConfirmDeleteObjectsModal() {
 }
 
 void EditorLayer::DrawConfirmDeleteAssetModal() {
+  const auto& theme = Horo::UI::GetHoroTheme();
   if (m_confirmDeleteAssetOpen)
     ImGui::OpenPopup("Confirm Delete Asset");
   if (!ImGui::BeginPopupModal("Confirm Delete Asset", nullptr,
@@ -4417,7 +4427,7 @@ void EditorLayer::DrawConfirmDeleteAssetModal() {
   if (!m_pendingDeleteAssetError.empty()) {
     ImGui::Spacing();
     ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 360.0f);
-    ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f), "%s",
+    ImGui::TextColored(theme.error, "%s",
                        m_pendingDeleteAssetError.c_str());
     ImGui::PopTextWrapPos();
   }
@@ -4452,6 +4462,7 @@ void EditorLayer::DrawDeleteConfirmModals() {
 
 void EditorLayer::DrawExitConfirmModal() {
   using enum PendingSceneAction;
+  const auto& theme = Horo::UI::GetHoroTheme();
   if (m_confirmExitOpen)
     ImGui::OpenPopup("Unsaved Changes");
 
@@ -4485,7 +4496,7 @@ void EditorLayer::DrawExitConfirmModal() {
   ImGui::Separator();
 
   if (!m_exitConfirmError.empty())
-    ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s",
+    ImGui::TextColored(theme.error, "%s",
                        m_exitConfirmError.c_str());
 
   if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f))) {

--- a/launcher/LauncherEditorShell.cpp
+++ b/launcher/LauncherEditorShell.cpp
@@ -23,6 +23,8 @@
 #include "scene/Entity.h"
 #include "scene/components/MeshComponent.h"
 #include "scene/components/TransformComponent.h"
+#include "ui/common/HoroTheme.h"
+#include "ui/common/HoroWidgets.h"
 
 #ifndef HORO_ENGINE_VERSION
 #define HORO_ENGINE_VERSION "0.0.0"
@@ -197,35 +199,7 @@ void RenderCenteredEmptyState(const char *text) {
   ImGui::TextDisabled("%s", text);
 }
 
-bool RenderPrimaryButton(const char *label, const ImVec2 &size) {
-  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16.0f, 9.0f));
-  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f);
-  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.41f, 0.68f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
-                        ImVec4(0.24f, 0.46f, 0.75f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonActive,
-                        ImVec4(0.18f, 0.36f, 0.62f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.96f, 0.97f, 1.0f, 1.0f));
-  const bool pressed = ImGui::Button(label, size);
-  ImGui::PopStyleColor(4);
-  ImGui::PopStyleVar(2);
-  return pressed;
-}
 
-bool RenderSecondaryButton(const char *label, const ImVec2 &size) {
-  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 9.0f));
-  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
-  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.12f, 0.15f, 0.20f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
-                        ImVec4(0.16f, 0.20f, 0.28f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonActive,
-                        ImVec4(0.14f, 0.18f, 0.24f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.92f, 0.94f, 0.98f, 1.0f));
-  const bool pressed = ImGui::Button(label, size);
-  ImGui::PopStyleColor(4);
-  ImGui::PopStyleVar(2);
-  return pressed;
-}
 
 bool RenderRecentProjectButton(const char *title, const ImVec2 &size) {
   ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(14.0f, 8.0f));
@@ -242,43 +216,9 @@ bool RenderRecentProjectButton(const char *title, const ImVec2 &size) {
   return pressed;
 }
 
-void RenderLabeledInput(const char *title, const char *id, char *buffer,
-                        size_t bufferSize, float inputWidth) {
-  ImGui::TextDisabled("%s", title);
-  ImGui::SetNextItemWidth(inputWidth);
-  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 9.0f));
-  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
-  ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.04f, 0.08f, 0.13f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_FrameBgHovered,
-                        ImVec4(0.06f, 0.11f, 0.18f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_FrameBgActive,
-                        ImVec4(0.08f, 0.15f, 0.25f, 1.0f));
-  ImGui::InputText(id, buffer, bufferSize);
-  ImGui::PopStyleColor(3);
-  ImGui::PopStyleVar(2);
-}
 
-struct LauncherTheme final {
-  ImVec4 backgroundTop =
-      ImVec4(1.0f / 255.0f, 7.0f / 255.0f, 17.0f / 255.0f, 1.0f);
-  ImVec4 backgroundBottom =
-      ImVec4(1.0f / 255.0f, 7.0f / 255.0f, 17.0f / 255.0f, 1.0f);
-  ImVec4 panel = ImVec4(0.05f, 0.09f, 0.15f, 0.94f);
-  ImVec4 panelSoft = ImVec4(0.07f, 0.11f, 0.18f, 0.90f);
-  ImVec4 border = ImVec4(0.16f, 0.27f, 0.42f, 0.68f);
-  ImVec4 textMuted = ImVec4(0.68f, 0.74f, 0.84f, 1.0f);
-  ImVec4 accent = ImVec4(0.23f, 0.54f, 0.93f, 1.0f);
-  ImVec4 accentHover = ImVec4(0.28f, 0.60f, 0.99f, 1.0f);
-  ImVec4 accentActive = ImVec4(0.18f, 0.46f, 0.82f, 1.0f);
-  float windowRounding = 16.0f;
-  float panelRounding = 12.0f;
-  float cardRounding = 10.0f;
-};
 
-const LauncherTheme &GetLauncherTheme() {
-  static const LauncherTheme theme{};
-  return theme;
-}
+
 
 fs::path ResolveLauncherVisualAsset(std::string_view relativePath) {
   if (relativePath.empty())
@@ -301,7 +241,7 @@ fs::path ResolveLauncherVisualAsset(std::string_view relativePath) {
 void DrawBackdrop(ImDrawList *drawList, const ImVec2 &pos, const ImVec2 &size) {
   if (!drawList)
     return;
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   static const bool hasCustomBackdrop =
       !ResolveLauncherVisualAsset("background.png").empty();
   const ImVec4 top = hasCustomBackdrop ? ImVec4(0.03f, 0.07f, 0.14f, 1.0f)
@@ -318,7 +258,7 @@ void DrawBackdrop(ImDrawList *drawList, const ImVec2 &pos, const ImVec2 &size) {
 
 bool RenderSidebarNavItem(const char *label, bool selected,
                           const ImVec2 &size = ImVec2(-1.0f, 40.0f)) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(14.0f, 11.0f));
   ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 9.0f);
   if (selected) {
@@ -400,7 +340,7 @@ void DrawTemplateTileIcon(ImDrawList *drawList, const ImVec2 &center,
 
 bool RenderTemplateTile(const char *label, TemplateTileIcon icon, bool selected,
                         bool enabled, const ImVec2 &size) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::InvisibleButton(label, size);
   const bool pressed = enabled && ImGui::IsItemClicked();
   const bool hovered = enabled && ImGui::IsItemHovered();
@@ -450,7 +390,7 @@ void RenderVerticalDivider(float height) {
 }
 
 void RenderAdvancedSettingsToggle(bool *open) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 size(190.0f, 30.0f);
   ImGui::InvisibleButton("Advanced Settings", size);
   if (ImGui::IsItemClicked() && open)
@@ -485,7 +425,7 @@ void DrawRecentProjectMetaIcon(ImDrawList *drawList, const ImVec2 &pos,
 }
 
 bool RenderRecentProjectMenuButton(const char *id, const ImVec2 &size) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::InvisibleButton(id, size);
   const bool hovered = ImGui::IsItemHovered();
   const bool active = ImGui::IsItemActive();
@@ -507,7 +447,7 @@ bool RenderRecentProjectMenuButton(const char *id, const ImVec2 &size) {
 }
 
 void RenderCreateProjectHeader() {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 iconPos = ImGui::GetCursorScreenPos();
   ImDrawList *drawList = ImGui::GetWindowDrawList();
   const ImVec2 iconMax(iconPos.x + 38.0f, iconPos.y + 38.0f);
@@ -594,7 +534,7 @@ enum class SidebarFooterIcon {
 
 static void DrawLauncherActionIcon(ImDrawList *drawList, const ImVec2 &pos,
                                    LauncherActionIcon icon) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 max(pos.x + 38.0f, pos.y + 38.0f);
   drawList->AddRectFilled(
       pos, max,
@@ -623,7 +563,7 @@ static void DrawLauncherActionIcon(ImDrawList *drawList, const ImVec2 &pos,
 
 static void DrawSidebarFooterIcon(ImDrawList *drawList, const ImVec2 &pos,
                                   SidebarFooterIcon icon) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImU32 color = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
   if (icon == SidebarFooterIcon::Discord) {
     const ImVec2 headMin(pos.x + 2.0f, pos.y + 4.0f);
@@ -649,7 +589,7 @@ static void DrawSidebarFooterIcon(ImDrawList *drawList, const ImVec2 &pos,
 }
 
 static void RenderSidebarFooterItem(const char *label, SidebarFooterIcon icon) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 textPos = ImGui::GetCursorPos();
   const ImVec2 iconPos = ImGui::GetCursorScreenPos();
   DrawSidebarFooterIcon(ImGui::GetWindowDrawList(), iconPos, icon);
@@ -661,7 +601,7 @@ static void RenderSidebarFooterItem(const char *label, SidebarFooterIcon icon) {
 static void
 RenderSidebarFooterImageItem(const char *label,
                              const std::shared_ptr<Texture> &iconTexture) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 textPos = ImGui::GetCursorPos();
   if (iconTexture && iconTexture->IsValid() &&
       iconTexture->GetNativeId() != 0) {
@@ -681,7 +621,7 @@ RenderSidebarFooterImageItem(const char *label,
 }
 
 static void RenderSidebarFooterSeparator() {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 start = ImGui::GetCursorScreenPos();
   const float width = std::min(154.0f, ImGui::GetContentRegionAvail().x);
   ImGui::GetWindowDrawList()->AddLine(
@@ -694,7 +634,7 @@ static bool RenderLauncherActionCard(const char *id, const char *title,
                                      const char *subtitle,
                                      LauncherActionIcon icon,
                                      const ImVec2 &size) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const ImVec2 pos = ImGui::GetCursorScreenPos();
   ImGui::InvisibleButton(id, size);
   const bool hovered = ImGui::IsItemHovered();
@@ -1000,7 +940,7 @@ void LauncherEditorShell::RenderLauncher() {
 
 void LauncherEditorShell::RenderLauncherSidebar(float sidebarWidth,
                                                 float fullHeight) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, theme.windowRounding);
   ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(22.0f, 22.0f));
@@ -1034,7 +974,7 @@ void LauncherEditorShell::RenderLauncherSidebar(float sidebarWidth,
 
 void LauncherEditorShell::RenderLauncherMainContent(float mainWidth,
                                                     float fullHeight) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, theme.windowRounding);
   ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -1069,7 +1009,7 @@ void LauncherEditorShell::RenderLauncherMainContent(float mainWidth,
 }
 
 void LauncherEditorShell::RenderLauncherHero(float contentWidth) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   m_importProjectDropTarget.valid = false;
   const float heroHeight = 152.0f;
   ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, theme.panelRounding);
@@ -1124,7 +1064,7 @@ void LauncherEditorShell::RenderLauncherHero(float contentWidth) {
 }
 
 void LauncherEditorShell::RenderNewProjectPanel(float contentWidth) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const float panelHeight = m_newProjectAdvancedSettingsOpen ? 326.0f : 282.0f;
   ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.06f, 0.10f, 0.16f, 0.80f));
   ImGui::PushStyleColor(ImGuiCol_Border, theme.border);
@@ -1181,7 +1121,7 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
 
   ImGui::SetCursorPos(ImVec2(nameX, rowStartY));
   ImGui::BeginGroup();
-  RenderLabeledInput("Project Name", "##new-project-name",
+  Horo::UI::LabeledInput("Project Name", "##new-project-name",
                      m_newProjectNameInput.data(), m_newProjectNameInput.size(),
                      nameWidth);
   ImGui::EndGroup();
@@ -1191,11 +1131,11 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
   ImGui::SetCursorPos(ImVec2(locationX, rowStartY));
   ImGui::BeginGroup();
   const float browseWidth = 94.0f;
-  RenderLabeledInput("Location", "##new-project-path",
+  Horo::UI::LabeledInput("Location", "##new-project-path",
                      m_newProjectPathInput.data(), m_newProjectPathInput.size(),
                      std::max(120.0f, locationWidth - browseWidth - 8.0f));
   ImGui::SameLine(0.0f, 8.0f);
-  if (RenderSecondaryButton("Browse", ImVec2(browseWidth, 0.0f))) {
+  if (Horo::UI::SecondaryButton("Browse", ImVec2(browseWidth, 0.0f))) {
     const fs::path pickedLocation = PickFolderPath(
         "Select project location",
         DefaultBrowseDirectory(BufferToString(m_newProjectPathInput)));
@@ -1267,7 +1207,7 @@ void LauncherEditorShell::RenderNewProjectActions(float innerWidth,
 
   ImGui::SetCursorPos(
       ImVec2(rowStartX + innerWidth - createButtonWidth - 2.0f, advancedRowY));
-  if (RenderPrimaryButton("Create Project   +",
+  if (Horo::UI::PrimaryButton("Create Project   +",
                           ImVec2(createButtonWidth, 40.0f))) {
     std::string createError;
     if (!CreateProjectFromLauncher(&createError))
@@ -1277,7 +1217,7 @@ void LauncherEditorShell::RenderNewProjectActions(float innerWidth,
 
 void LauncherEditorShell::RenderRecentProjectsList(float contentWidth,
                                                    float panelHeight) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.06f, 0.10f, 0.16f, 0.80f));
   ImGui::PushStyleColor(ImGuiCol_Border, theme.border);
   ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, theme.panelRounding);
@@ -1307,7 +1247,7 @@ void LauncherEditorShell::RenderRecentProjectsList(float contentWidth,
 
 void LauncherEditorShell::RenderRecentProjectCard(const std::string &recentPath,
                                                   int cardIndex) {
-  const LauncherTheme &theme = GetLauncherTheme();
+  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
   const fs::path path(recentPath);
   const fs::path normalizedPath = path.lexically_normal();
   std::string title = normalizedPath.filename().string();

--- a/launcher/LauncherEditorShell.cpp
+++ b/launcher/LauncherEditorShell.cpp
@@ -25,6 +25,7 @@
 #include "scene/components/TransformComponent.h"
 #include "ui/common/HoroTheme.h"
 #include "ui/common/HoroWidgets.h"
+#include "ui/launcher/LauncherWidgets.h"
 
 #ifndef HORO_ENGINE_VERSION
 #define HORO_ENGINE_VERSION "0.0.0"
@@ -182,315 +183,6 @@ bool CheckProjectRootValid(const fs::path &projectRoot, std::string *outError) {
   }
   return true;
 }
-
-// Styled button and layout helpers extracted from RenderLauncher() lambdas so
-// their internal branching does not inflate the enclosing function's cognitive
-// complexity (cpp:S3776).
-
-void RenderCenteredEmptyState(const char *text) {
-  if (const float regionHeight = ImGui::GetContentRegionAvail().y;
-      regionHeight > 40.0f)
-    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + regionHeight * 0.25f);
-  const float availableWidth = ImGui::GetContentRegionAvail().x;
-  if (const float textWidth = ImGui::CalcTextSize(text).x;
-      textWidth < availableWidth)
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
-                         (availableWidth - textWidth) * 0.5f);
-  ImGui::TextDisabled("%s", text);
-}
-
-
-
-bool RenderRecentProjectButton(const char *title, const ImVec2 &size) {
-  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(14.0f, 8.0f));
-  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 7.0f);
-  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.12f, 0.15f, 0.20f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
-                        ImVec4(0.16f, 0.20f, 0.28f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonActive,
-                        ImVec4(0.15f, 0.18f, 0.24f, 1.0f));
-  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.94f, 0.96f, 1.0f, 1.0f));
-  const bool pressed = ImGui::Button(title, size);
-  ImGui::PopStyleColor(4);
-  ImGui::PopStyleVar(2);
-  return pressed;
-}
-
-
-
-
-
-fs::path ResolveLauncherVisualAsset(std::string_view relativePath) {
-  if (relativePath.empty())
-    return {};
-  const std::array<fs::path, 4> candidates = {
-      ProjectPath::ResolveSdk("assets/launcher/" + std::string(relativePath)),
-      ProjectPath::Root() / "assets" / "launcher" / std::string(relativePath),
-      ProjectPath::Root() / "engine" / "assets" / "launcher" /
-          std::string(relativePath),
-      ProjectPath::Root() / std::string(relativePath),
-  };
-  for (const fs::path &candidate : candidates) {
-    std::error_code ec;
-    if (fs::is_regular_file(candidate, ec) && !ec)
-      return candidate;
-  }
-  return {};
-}
-
-void DrawBackdrop(ImDrawList *drawList, const ImVec2 &pos, const ImVec2 &size) {
-  if (!drawList)
-    return;
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  static const bool hasCustomBackdrop =
-      !ResolveLauncherVisualAsset("background.png").empty();
-  const ImVec4 top = hasCustomBackdrop ? ImVec4(0.03f, 0.07f, 0.14f, 1.0f)
-                                       : theme.backgroundTop;
-  const ImVec4 bottom = hasCustomBackdrop ? ImVec4(0.02f, 0.04f, 0.09f, 1.0f)
-                                          : theme.backgroundBottom;
-  const ImVec2 max(pos.x + size.x, pos.y + size.y);
-  drawList->AddRectFilledMultiColor(pos, max,
-                                    ImGui::ColorConvertFloat4ToU32(top),
-                                    ImGui::ColorConvertFloat4ToU32(top),
-                                    ImGui::ColorConvertFloat4ToU32(bottom),
-                                    ImGui::ColorConvertFloat4ToU32(bottom));
-}
-
-bool RenderSidebarNavItem(const char *label, bool selected,
-                          const ImVec2 &size = ImVec2(-1.0f, 40.0f)) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(14.0f, 11.0f));
-  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 9.0f);
-  if (selected) {
-    ImGui::PushStyleColor(ImGuiCol_Button, theme.accent);
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, theme.accentHover);
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, theme.accentActive);
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.97f, 0.98f, 1.0f, 1.0f));
-  } else {
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.08f, 0.12f, 0.19f, 0.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
-                          ImVec4(0.12f, 0.19f, 0.30f, 0.72f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive,
-                          ImVec4(0.13f, 0.21f, 0.34f, 0.86f));
-    ImGui::PushStyleColor(ImGuiCol_Text, theme.textMuted);
-  }
-  const bool pressed = ImGui::Button(label, size);
-  ImGui::PopStyleColor(4);
-  ImGui::PopStyleVar(2);
-  return pressed;
-}
-
-enum class TemplateTileIcon {
-  Cube,
-  Image,
-  Sandbox,
-};
-
-void DrawTemplateTileIcon(ImDrawList *drawList, const ImVec2 &center,
-                          TemplateTileIcon icon, ImU32 color) {
-  if (icon == TemplateTileIcon::Image) {
-    const ImVec2 min(center.x - 12.0f, center.y - 11.0f);
-    const ImVec2 max(center.x + 12.0f, center.y + 11.0f);
-    drawList->AddRect(min, max, color, 2.5f, 0, 2.0f);
-    drawList->AddCircleFilled(ImVec2(min.x + 7.0f, min.y + 6.0f), 2.0f, color);
-    drawList->AddLine(ImVec2(min.x + 4.0f, max.y - 4.0f),
-                      ImVec2(center.x - 2.0f, center.y + 1.0f), color, 2.0f);
-    drawList->AddLine(ImVec2(center.x - 2.0f, center.y + 1.0f),
-                      ImVec2(center.x + 4.0f, max.y - 6.0f), color, 2.0f);
-    drawList->AddLine(ImVec2(center.x + 4.0f, max.y - 6.0f),
-                      ImVec2(max.x - 4.0f, max.y - 4.0f), color, 2.0f);
-    return;
-  }
-
-  if (icon == TemplateTileIcon::Sandbox) {
-    drawList->AddTriangleFilled(ImVec2(center.x - 15.0f, center.y + 10.0f),
-                                ImVec2(center.x - 4.0f, center.y - 3.0f),
-                                ImVec2(center.x + 5.0f, center.y + 10.0f),
-                                color);
-    drawList->AddTriangleFilled(ImVec2(center.x - 2.0f, center.y + 10.0f),
-                                ImVec2(center.x + 9.0f, center.y - 1.0f),
-                                ImVec2(center.x + 17.0f, center.y + 10.0f),
-                                color);
-    drawList->AddLine(ImVec2(center.x + 8.0f, center.y - 12.0f),
-                      ImVec2(center.x + 8.0f, center.y + 2.0f), color, 2.0f);
-    drawList->AddTriangle(ImVec2(center.x + 9.0f, center.y - 12.0f),
-                          ImVec2(center.x + 17.0f, center.y - 9.0f),
-                          ImVec2(center.x + 9.0f, center.y - 6.0f), color,
-                          2.0f);
-    return;
-  }
-
-  const ImVec2 top(center.x, center.y - 14.0f);
-  const ImVec2 left(center.x - 12.0f, center.y - 7.0f);
-  const ImVec2 right(center.x + 12.0f, center.y - 7.0f);
-  const ImVec2 bottom(center.x, center.y + 0.0f);
-  const ImVec2 lowerLeft(center.x - 12.0f, center.y + 7.0f);
-  const ImVec2 lowerRight(center.x + 12.0f, center.y + 7.0f);
-  const ImVec2 base(center.x, center.y + 14.0f);
-  drawList->AddLine(top, left, color, 2.0f);
-  drawList->AddLine(top, right, color, 2.0f);
-  drawList->AddLine(left, bottom, color, 2.0f);
-  drawList->AddLine(right, bottom, color, 2.0f);
-  drawList->AddLine(bottom, base, color, 2.0f);
-  drawList->AddLine(left, lowerLeft, color, 2.0f);
-  drawList->AddLine(right, lowerRight, color, 2.0f);
-  drawList->AddLine(lowerLeft, base, color, 2.0f);
-  drawList->AddLine(lowerRight, base, color, 2.0f);
-}
-
-bool RenderTemplateTile(const char *label, TemplateTileIcon icon, bool selected,
-                        bool enabled, const ImVec2 &size) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  ImGui::InvisibleButton(label, size);
-  const bool pressed = enabled && ImGui::IsItemClicked();
-  const bool hovered = enabled && ImGui::IsItemHovered();
-  const ImVec2 min = ImGui::GetItemRectMin();
-  const ImVec2 max = ImGui::GetItemRectMax();
-  ImVec4 fill(0.09f, 0.13f, 0.20f, 1.0f);
-  if (!enabled)
-    fill = ImVec4(0.08f, 0.11f, 0.16f, 0.72f);
-  else if (selected)
-    fill = ImVec4(0.10f, 0.18f, 0.30f, 1.0f);
-  else if (hovered)
-    fill = ImVec4(0.13f, 0.19f, 0.28f, 1.0f);
-
-  ImVec4 border(0.15f, 0.24f, 0.35f, 0.60f);
-  if (!enabled)
-    border = ImVec4(0.13f, 0.20f, 0.29f, 0.42f);
-  else if (selected)
-    border = theme.accent;
-  ImDrawList *drawList = ImGui::GetWindowDrawList();
-  drawList->AddRectFilled(min, max, ImGui::ColorConvertFloat4ToU32(fill), 6.0f);
-  drawList->AddRect(min, max, ImGui::ColorConvertFloat4ToU32(border), 6.0f, 0,
-                    selected ? 1.5f : 1.0f);
-  ImVec4 iconColor = theme.textMuted;
-  if (!enabled)
-    iconColor =
-        ImVec4(theme.textMuted.x, theme.textMuted.y, theme.textMuted.z, 0.52f);
-  else if (selected)
-    iconColor = theme.accentHover;
-  DrawTemplateTileIcon(drawList, ImVec2((min.x + max.x) * 0.5f, min.y + 27.0f),
-                       icon, ImGui::ColorConvertFloat4ToU32(iconColor));
-  const ImVec2 textSize = ImGui::CalcTextSize(label);
-  drawList->AddText(
-      ImVec2((min.x + max.x - textSize.x) * 0.5f, max.y - textSize.y - 10.0f),
-      ImGui::ColorConvertFloat4ToU32(enabled
-                                         ? ImVec4(0.92f, 0.95f, 0.99f, 1.0f)
-                                         : ImVec4(0.68f, 0.74f, 0.84f, 0.62f)),
-      label);
-  return pressed;
-}
-
-void RenderVerticalDivider(float height) {
-  const ImVec2 pos = ImGui::GetCursorScreenPos();
-  ImGui::GetWindowDrawList()->AddLine(
-      ImVec2(pos.x, pos.y + 2.0f), ImVec2(pos.x, pos.y + height - 2.0f),
-      ImGui::ColorConvertFloat4ToU32(ImVec4(0.16f, 0.25f, 0.36f, 0.58f)), 1.0f);
-  ImGui::Dummy(ImVec2(1.0f, height));
-}
-
-void RenderAdvancedSettingsToggle(bool *open) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 size(190.0f, 30.0f);
-  ImGui::InvisibleButton("Advanced Settings", size);
-  if (ImGui::IsItemClicked() && open)
-    *open = !*open;
-
-  const ImVec2 min = ImGui::GetItemRectMin();
-  const ImVec2 textPos(min.x + 26.0f, min.y + 7.0f);
-  const ImU32 color = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
-  ImDrawList *drawList = ImGui::GetWindowDrawList();
-  if (open && *open) {
-    drawList->AddTriangleFilled(ImVec2(min.x + 7.0f, min.y + 11.0f),
-                                ImVec2(min.x + 17.0f, min.y + 11.0f),
-                                ImVec2(min.x + 12.0f, min.y + 17.0f), color);
-  } else {
-    drawList->AddTriangleFilled(ImVec2(min.x + 9.0f, min.y + 10.0f),
-                                ImVec2(min.x + 9.0f, min.y + 18.0f),
-                                ImVec2(min.x + 15.0f, min.y + 14.0f), color);
-  }
-  drawList->AddText(textPos, color, "Advanced Settings");
-}
-
-void DrawRecentProjectMetaIcon(ImDrawList *drawList, const ImVec2 &pos,
-                               ImU32 color) {
-  drawList->AddRect(ImVec2(pos.x, pos.y + 2.0f),
-                    ImVec2(pos.x + 12.0f, pos.y + 14.0f), color, 2.0f, 0, 1.2f);
-  drawList->AddLine(ImVec2(pos.x, pos.y + 6.0f),
-                    ImVec2(pos.x + 12.0f, pos.y + 6.0f), color, 1.2f);
-  drawList->AddLine(ImVec2(pos.x + 3.0f, pos.y),
-                    ImVec2(pos.x + 3.0f, pos.y + 4.0f), color, 1.4f);
-  drawList->AddLine(ImVec2(pos.x + 9.0f, pos.y),
-                    ImVec2(pos.x + 9.0f, pos.y + 4.0f), color, 1.4f);
-}
-
-bool RenderRecentProjectMenuButton(const char *id, const ImVec2 &size) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  ImGui::InvisibleButton(id, size);
-  const bool hovered = ImGui::IsItemHovered();
-  const bool active = ImGui::IsItemActive();
-  const ImVec2 min = ImGui::GetItemRectMin();
-  const ImVec2 max = ImGui::GetItemRectMax();
-  ImVec4 fill(0.10f, 0.14f, 0.20f, 0.54f);
-  if (active)
-    fill = ImVec4(0.12f, 0.18f, 0.27f, 0.90f);
-  else if (hovered)
-    fill = ImVec4(0.12f, 0.18f, 0.27f, 0.76f);
-  ImDrawList *drawList = ImGui::GetWindowDrawList();
-  drawList->AddRectFilled(min, max, ImGui::ColorConvertFloat4ToU32(fill), 6.0f);
-  const ImU32 dotColor = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
-  const ImVec2 center((min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f);
-  drawList->AddCircleFilled(ImVec2(center.x, center.y - 6.0f), 1.5f, dotColor);
-  drawList->AddCircleFilled(center, 1.5f, dotColor);
-  drawList->AddCircleFilled(ImVec2(center.x, center.y + 6.0f), 1.5f, dotColor);
-  return ImGui::IsItemClicked();
-}
-
-void RenderCreateProjectHeader() {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 iconPos = ImGui::GetCursorScreenPos();
-  ImDrawList *drawList = ImGui::GetWindowDrawList();
-  const ImVec2 iconMax(iconPos.x + 38.0f, iconPos.y + 38.0f);
-  drawList->AddRectFilled(
-      iconPos, iconMax,
-      ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.22f, 0.40f, 1.0f)), 6.0f);
-  const ImU32 sparkleColor = ImGui::ColorConvertFloat4ToU32(theme.accentHover);
-  drawList->AddLine(ImVec2(iconPos.x + 19.0f, iconPos.y + 9.0f),
-                    ImVec2(iconPos.x + 19.0f, iconPos.y + 18.0f), sparkleColor,
-                    1.6f);
-  drawList->AddLine(ImVec2(iconPos.x + 14.5f, iconPos.y + 13.5f),
-                    ImVec2(iconPos.x + 23.5f, iconPos.y + 13.5f), sparkleColor,
-                    1.6f);
-  drawList->AddLine(ImVec2(iconPos.x + 27.0f, iconPos.y + 22.0f),
-                    ImVec2(iconPos.x + 27.0f, iconPos.y + 28.0f), sparkleColor,
-                    1.4f);
-  drawList->AddLine(ImVec2(iconPos.x + 24.0f, iconPos.y + 25.0f),
-                    ImVec2(iconPos.x + 30.0f, iconPos.y + 25.0f), sparkleColor,
-                    1.4f);
-
-  ImGui::Dummy(ImVec2(46.0f, 38.0f));
-  ImGui::SameLine(0.0f, 8.0f);
-  ImGui::BeginGroup();
-  ImGui::TextUnformatted("Create New Project");
-  ImGui::TextColored(theme.textMuted, "Start a new project from a template");
-  ImGui::EndGroup();
-}
-
-void RenderLauncherBrand(const std::shared_ptr<Texture> &logoTexture) {
-  if (logoTexture && logoTexture->IsValid() &&
-      logoTexture->GetNativeId() != 0) {
-    const float availableWidth = ImGui::GetContentRegionAvail().x;
-    const float logoWidth = std::min(availableWidth, 184.0f);
-    constexpr float kLogoAspect = 1778.0f / 900.0f;
-    ImGui::Image(
-        (ImTextureID) static_cast<intptr_t>(logoTexture->GetNativeId()),
-        ImVec2(logoWidth, logoWidth / kLogoAspect), ImVec2(0.0f, 0.0f),
-        ImVec2(1.0f, 1.0f));
-    return;
-  }
-
-  ImGui::TextUnformatted("HORO ENGINE");
-}
 } // namespace
 
 // Loads the project manifest and default scene document for the given project
@@ -520,144 +212,6 @@ static bool LoadLauncherDocuments(const fs::path &projectRoot,
     return false;
   }
   return true;
-}
-
-enum class LauncherActionIcon {
-  Folder,
-  Import,
-};
-
-enum class SidebarFooterIcon {
-  Discord,
-  Documentation,
-};
-
-static void DrawLauncherActionIcon(ImDrawList *drawList, const ImVec2 &pos,
-                                   LauncherActionIcon icon) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 max(pos.x + 38.0f, pos.y + 38.0f);
-  drawList->AddRectFilled(
-      pos, max,
-      ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.22f, 0.40f, 1.0f)), 8.0f);
-
-  const ImU32 iconColor = ImGui::ColorConvertFloat4ToU32(theme.accentHover);
-  if (icon == LauncherActionIcon::Folder) {
-    const ImVec2 tabMin(pos.x + 10.0f, pos.y + 12.0f);
-    drawList->AddRectFilled(tabMin, ImVec2(pos.x + 22.0f, pos.y + 17.0f),
-                            iconColor, 2.0f);
-    drawList->AddRectFilled(ImVec2(pos.x + 9.0f, pos.y + 16.0f),
-                            ImVec2(pos.x + 29.0f, pos.y + 27.0f), iconColor,
-                            3.0f);
-  } else {
-    const float centerX = pos.x + 19.0f;
-    drawList->AddLine(ImVec2(centerX, pos.y + 10.0f),
-                      ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
-    drawList->AddLine(ImVec2(centerX - 5.0f, pos.y + 19.0f),
-                      ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
-    drawList->AddLine(ImVec2(centerX + 5.0f, pos.y + 19.0f),
-                      ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
-    drawList->AddLine(ImVec2(pos.x + 12.0f, pos.y + 28.0f),
-                      ImVec2(pos.x + 26.0f, pos.y + 28.0f), iconColor, 2.0f);
-  }
-}
-
-static void DrawSidebarFooterIcon(ImDrawList *drawList, const ImVec2 &pos,
-                                  SidebarFooterIcon icon) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImU32 color = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
-  if (icon == SidebarFooterIcon::Discord) {
-    const ImVec2 headMin(pos.x + 2.0f, pos.y + 4.0f);
-    const ImVec2 headMax(pos.x + 16.0f, pos.y + 13.0f);
-    drawList->AddRect(headMin, headMax, color, 4.0f, 0, 1.5f);
-    drawList->AddLine(ImVec2(pos.x + 5.0f, pos.y + 4.0f),
-                      ImVec2(pos.x + 4.0f, pos.y + 2.0f), color, 1.5f);
-    drawList->AddLine(ImVec2(pos.x + 13.0f, pos.y + 4.0f),
-                      ImVec2(pos.x + 14.0f, pos.y + 2.0f), color, 1.5f);
-    drawList->AddCircleFilled(ImVec2(pos.x + 7.0f, pos.y + 9.0f), 1.1f, color);
-    drawList->AddCircleFilled(ImVec2(pos.x + 12.0f, pos.y + 9.0f), 1.1f, color);
-  } else {
-    const ImVec2 pageMin(pos.x + 4.0f, pos.y + 2.0f);
-    const ImVec2 pageMax(pos.x + 15.0f, pos.y + 16.0f);
-    drawList->AddRect(pageMin, pageMax, color, 1.5f, 0, 1.5f);
-    drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 7.0f),
-                      ImVec2(pos.x + 13.0f, pos.y + 7.0f), color, 1.1f);
-    drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 10.0f),
-                      ImVec2(pos.x + 13.0f, pos.y + 10.0f), color, 1.1f);
-    drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 13.0f),
-                      ImVec2(pos.x + 11.0f, pos.y + 13.0f), color, 1.1f);
-  }
-}
-
-static void RenderSidebarFooterItem(const char *label, SidebarFooterIcon icon) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 textPos = ImGui::GetCursorPos();
-  const ImVec2 iconPos = ImGui::GetCursorScreenPos();
-  DrawSidebarFooterIcon(ImGui::GetWindowDrawList(), iconPos, icon);
-  ImGui::SetCursorPos(ImVec2(textPos.x + 26.0f, textPos.y));
-  ImGui::TextColored(theme.textMuted, "%s", label);
-  ImGui::Dummy(ImVec2(0.0f, 4.0f));
-}
-
-static void
-RenderSidebarFooterImageItem(const char *label,
-                             const std::shared_ptr<Texture> &iconTexture) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 textPos = ImGui::GetCursorPos();
-  if (iconTexture && iconTexture->IsValid() &&
-      iconTexture->GetNativeId() != 0) {
-    ImGui::SetCursorPosY(textPos.y + 1.0f);
-    ImGui::Image(
-        (ImTextureID) static_cast<intptr_t>(iconTexture->GetNativeId()),
-        ImVec2(18.0f, 18.0f), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f),
-        theme.textMuted);
-  } else {
-    DrawSidebarFooterIcon(ImGui::GetWindowDrawList(),
-                          ImGui::GetCursorScreenPos(),
-                          SidebarFooterIcon::Discord);
-  }
-  ImGui::SetCursorPos(ImVec2(textPos.x + 26.0f, textPos.y));
-  ImGui::TextColored(theme.textMuted, "%s", label);
-  ImGui::Dummy(ImVec2(0.0f, 4.0f));
-}
-
-static void RenderSidebarFooterSeparator() {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 start = ImGui::GetCursorScreenPos();
-  const float width = std::min(154.0f, ImGui::GetContentRegionAvail().x);
-  ImGui::GetWindowDrawList()->AddLine(
-      start, ImVec2(start.x + width, start.y),
-      ImGui::ColorConvertFloat4ToU32(theme.border), 1.0f);
-  ImGui::Dummy(ImVec2(0.0f, 14.0f));
-}
-
-static bool RenderLauncherActionCard(const char *id, const char *title,
-                                     const char *subtitle,
-                                     LauncherActionIcon icon,
-                                     const ImVec2 &size) {
-  const Horo::UI::HoroTheme &theme = Horo::UI::GetHoroTheme();
-  const ImVec2 pos = ImGui::GetCursorScreenPos();
-  ImGui::InvisibleButton(id, size);
-  const bool hovered = ImGui::IsItemHovered();
-  const bool active = ImGui::IsItemActive();
-  ImVec4 fill(0.05f, 0.10f, 0.17f, 0.76f);
-  if (active)
-    fill = ImVec4(0.08f, 0.14f, 0.23f, 0.88f);
-  else if (hovered)
-    fill = ImVec4(0.08f, 0.15f, 0.25f, 0.84f);
-  ImDrawList *drawList = ImGui::GetWindowDrawList();
-  drawList->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y),
-                          ImGui::ColorConvertFloat4ToU32(fill), 8.0f);
-  drawList->AddRect(pos, ImVec2(pos.x + size.x, pos.y + size.y),
-                    ImGui::ColorConvertFloat4ToU32(theme.border), 8.0f);
-
-  const ImVec2 iconPos(pos.x + 18.0f, pos.y + 17.0f);
-  DrawLauncherActionIcon(drawList, iconPos, icon);
-  drawList->AddText(
-      ImVec2(pos.x + 64.0f, pos.y + 19.0f),
-      ImGui::ColorConvertFloat4ToU32(ImVec4(0.96f, 0.98f, 1.0f, 1.0f)), title);
-  drawList->AddText(ImVec2(pos.x + 64.0f, pos.y + 43.0f),
-                    ImGui::ColorConvertFloat4ToU32(theme.textMuted), subtitle);
-  return ImGui::IsItemClicked();
 }
 
 void LauncherEditorShell::Attach(Editor::EditorLayer *editor, Scene *scene,
@@ -916,7 +470,7 @@ void LauncherEditorShell::RenderLauncher() {
   ImGui::Begin("Horo Launcher", nullptr, flags);
   ImGui::PopStyleVar(2);
 
-  DrawBackdrop(ImGui::GetWindowDrawList(), ImGui::GetWindowPos(),
+  Horo::Launcher::UI::DrawBackdrop(ImGui::GetWindowDrawList(), ImGui::GetWindowPos(),
                ImGui::GetWindowSize());
 
   const float outerPadding = 24.0f;
@@ -947,13 +501,13 @@ void LauncherEditorShell::RenderLauncherSidebar(float sidebarWidth,
   ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
   ImGui::BeginChild("LauncherSidebar", ImVec2(sidebarWidth, fullHeight), false);
 
-  RenderLauncherBrand(EnsureLauncherLogoTexture());
+  Horo::Launcher::UI::RenderLauncherBrand(EnsureLauncherLogoTexture().get());
   ImGui::Dummy(ImVec2(0.0f, 16.0f));
 
-  RenderSidebarNavItem("Home", true);
-  RenderSidebarNavItem("Projects", false);
-  RenderSidebarNavItem("Templates", false);
-  RenderSidebarNavItem("Learn", false);
+  Horo::Launcher::UI::SidebarNavItem("Home", true);
+  Horo::Launcher::UI::SidebarNavItem("Projects", false);
+  Horo::Launcher::UI::SidebarNavItem("Templates", false);
+  Horo::Launcher::UI::SidebarNavItem("Learn", false);
 
   const float footerHeight = 116.0f;
   if (const float remainingHeight = ImGui::GetContentRegionAvail().y;
@@ -962,9 +516,9 @@ void LauncherEditorShell::RenderLauncherSidebar(float sidebarWidth,
   } else {
     ImGui::Dummy(ImVec2(0.0f, 18.0f));
   }
-  RenderSidebarFooterSeparator();
-  RenderSidebarFooterImageItem("Join Community", EnsureDiscordIconTexture());
-  RenderSidebarFooterItem("Documentation", SidebarFooterIcon::Documentation);
+  Horo::Launcher::UI::SidebarFooterSeparator();
+  Horo::Launcher::UI::SidebarFooterImageItem("Join Community", EnsureDiscordIconTexture().get());
+  Horo::Launcher::UI::SidebarFooterItem("Documentation", Horo::Launcher::UI::SidebarFooterIcon::Documentation);
   ImGui::Dummy(ImVec2(0.0f, 6.0f));
   ImGui::TextDisabled("Horo Engine v%s", HORO_ENGINE_VERSION);
   ImGui::EndChild();
@@ -1034,18 +588,18 @@ void LauncherEditorShell::RenderLauncherHero(float contentWidth) {
   const float actionWidth =
       std::max(260.0f, (ImGui::GetContentRegionAvail().x - actionGap) * 0.5f);
   const ImVec2 actionSize(actionWidth, 72.0f);
-  if (RenderLauncherActionCard("##open-existing-project-action",
+  if (Horo::Launcher::UI::LauncherActionCard("##open-existing-project-action",
                                "Open Existing Project",
                                "Open a project from your computer",
-                               LauncherActionIcon::Folder, actionSize)) {
+                               Horo::Launcher::UI::LauncherActionIcon::Folder, actionSize)) {
     std::string openError;
     if (!OpenProjectFromPicker(&openError) && !openError.empty())
       m_launcherError = openError;
   }
   ImGui::SameLine(0.0f, actionGap);
-  if (RenderLauncherActionCard("##import-project-action", "Import Project",
+  if (Horo::Launcher::UI::LauncherActionCard("##import-project-action", "Import Project",
                                "Import a project from disk",
-                               LauncherActionIcon::Import, actionSize)) {
+                               Horo::Launcher::UI::LauncherActionIcon::Import, actionSize)) {
     std::string openError;
     if (!OpenProjectFromPicker(&openError) && !openError.empty())
       m_launcherError = openError;
@@ -1077,7 +631,7 @@ void LauncherEditorShell::RenderNewProjectPanel(float contentWidth) {
   ImGui::PopStyleColor(2);
   const float innerWidth = ImGui::GetContentRegionAvail().x;
 
-  RenderCreateProjectHeader();
+  Horo::Launcher::UI::RenderCreateProjectHeader();
   ImGui::Dummy(ImVec2(0.0f, 14.0f));
   ImGui::GetWindowDrawList()->AddLine(
       ImGui::GetCursorScreenPos(),
@@ -1127,7 +681,7 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
   ImGui::EndGroup();
 
   ImGui::SetCursorPos(ImVec2(nameDividerX, rowStartY));
-  RenderVerticalDivider(mainRowHeight);
+  Horo::Launcher::UI::VerticalDivider(mainRowHeight);
   ImGui::SetCursorPos(ImVec2(locationX, rowStartY));
   ImGui::BeginGroup();
   const float browseWidth = 94.0f;
@@ -1152,7 +706,7 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
   ImGui::EndGroup();
 
   ImGui::SetCursorPos(ImVec2(templateDividerX, rowStartY));
-  RenderVerticalDivider(mainRowHeight);
+  Horo::Launcher::UI::VerticalDivider(mainRowHeight);
   ImGui::SetCursorPos(ImVec2(templateX, rowStartY));
   ImGui::BeginGroup();
   ImGui::TextDisabled("%s", "Template");
@@ -1161,19 +715,19 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
   const float tileGap = 8.0f;
   const float tileWidth = (templateWidth - tileGap * 3.0f) * 0.25f;
   const ImVec2 tileSize(std::max(64.0f, tileWidth), 70.0f);
-  if (RenderTemplateTile("Empty", TemplateTileIcon::Cube,
+  if (Horo::Launcher::UI::TemplateTile("Empty", Horo::Launcher::UI::TemplateTileIcon::Cube,
                          selectedTemplateIndex == 0, true, tileSize))
     selectedTemplateIndex = 0;
   ImGui::SameLine(0.0f, tileGap);
-  if (RenderTemplateTile("2D", TemplateTileIcon::Image,
+  if (Horo::Launcher::UI::TemplateTile("2D", Horo::Launcher::UI::TemplateTileIcon::Image,
                          selectedTemplateIndex == 1, false, tileSize))
     selectedTemplateIndex = 1;
   ImGui::SameLine(0.0f, tileGap);
-  if (RenderTemplateTile("3D", TemplateTileIcon::Cube,
+  if (Horo::Launcher::UI::TemplateTile("3D", Horo::Launcher::UI::TemplateTileIcon::Cube,
                          selectedTemplateIndex == 2, false, tileSize))
     selectedTemplateIndex = 2;
   ImGui::SameLine(0.0f, tileGap);
-  if (RenderTemplateTile("Sandbox", TemplateTileIcon::Sandbox,
+  if (Horo::Launcher::UI::TemplateTile("Sandbox", Horo::Launcher::UI::TemplateTileIcon::Sandbox,
                          selectedTemplateIndex == 3, false, tileSize))
     selectedTemplateIndex = 3;
   ImGui::EndGroup();
@@ -1182,7 +736,7 @@ void LauncherEditorShell::RenderNewProjectFormRow(float innerWidth,
 void LauncherEditorShell::RenderNewProjectActions(float innerWidth,
                                                   float rowStartX,
                                                   float advancedRowY) {
-  RenderAdvancedSettingsToggle(&m_newProjectAdvancedSettingsOpen);
+  Horo::Launcher::UI::AdvancedSettingsToggle(&m_newProjectAdvancedSettingsOpen);
 
   const float createButtonWidth = 210.0f;
   if (m_newProjectAdvancedSettingsOpen) {
@@ -1234,7 +788,7 @@ void LauncherEditorShell::RenderRecentProjectsList(float contentWidth,
   ImGui::Dummy(ImVec2(0.0f, 8.0f));
 
   if (m_homeDocument.state.recentProjects.empty()) {
-    RenderCenteredEmptyState("No recent projects yet.");
+    Horo::UI::CenteredEmptyState("No recent projects yet.");
   } else {
     int cardIndex = 0;
     for (const std::string &recentPath : m_homeDocument.state.recentProjects) {
@@ -1285,7 +839,7 @@ void LauncherEditorShell::RenderRecentProjectCard(const std::string &recentPath,
   ImGui::Dummy(ImVec2(0.0f, 1.0f));
   ImGui::TextColored(theme.textMuted, "%s", recentPath.c_str());
   ImGui::Dummy(ImVec2(0.0f, 4.0f));
-  DrawRecentProjectMetaIcon(ImGui::GetWindowDrawList(),
+  Horo::Launcher::UI::DrawRecentProjectMetaIcon(ImGui::GetWindowDrawList(),
                             ImGui::GetCursorScreenPos(),
                             ImGui::ColorConvertFloat4ToU32(theme.textMuted));
   ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 18.0f);
@@ -1295,7 +849,7 @@ void LauncherEditorShell::RenderRecentProjectCard(const std::string &recentPath,
   ImGui::SetCursorPos(ImVec2(openButtonX, actionY));
   if (const std::string openLabel =
           std::format("Open##recent-open-{}", cardIndex);
-      RenderRecentProjectButton(openLabel.c_str(),
+      Horo::Launcher::UI::RecentProjectButton(openLabel.c_str(),
                                 ImVec2(openButtonWidth, openButtonHeight))) {
     if (std::string openError; !OpenProject(path, &openError))
       m_launcherError = openError;
@@ -1303,7 +857,7 @@ void LauncherEditorShell::RenderRecentProjectCard(const std::string &recentPath,
 
   ImGui::SetCursorPos(ImVec2(menuButtonX, actionY));
   const std::string menuLabel = std::format("##recent-menu-{}", cardIndex);
-  RenderRecentProjectMenuButton(menuLabel.c_str(),
+  Horo::Launcher::UI::RecentProjectMenuButton(menuLabel.c_str(),
                                 ImVec2(menuButtonWidth, openButtonHeight));
   ImGui::EndChild();
   ImGui::Dummy(ImVec2(0.0f, 8.0f));
@@ -1316,7 +870,7 @@ std::shared_ptr<Texture> LauncherEditorShell::EnsureLauncherLogoTexture() {
   if (Renderer::GetBackendId() != RenderBackendId::OpenGL)
     return {};
 
-  const fs::path logoPath = ResolveLauncherVisualAsset("logo_with_title.png");
+  const fs::path logoPath = Horo::Launcher::UI::ResolveLauncherVisualAsset("logo_with_title.png");
   if (logoPath.empty())
     return {};
 
@@ -1332,7 +886,7 @@ std::shared_ptr<Texture> LauncherEditorShell::EnsureDiscordIconTexture() {
   if (Renderer::GetBackendId() != RenderBackendId::OpenGL)
     return {};
 
-  const fs::path iconPath = ResolveLauncherVisualAsset("discord-icon.png");
+  const fs::path iconPath = Horo::Launcher::UI::ResolveLauncherVisualAsset("discord-icon.png");
   if (iconPath.empty())
     return {};
 

--- a/ui/common/HoroTheme.cpp
+++ b/ui/common/HoroTheme.cpp
@@ -1,0 +1,67 @@
+#include "ui/common/HoroTheme.h"
+
+namespace Horo::UI {
+
+const HoroTheme& GetHoroTheme() {
+    static const HoroTheme theme{};
+    return theme;
+}
+
+void ApplyHoroEditorTheme() {
+    ImGui::StyleColorsDark();
+    const HoroTheme& t = GetHoroTheme();
+
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding   = t.panelRounding;
+    style.ChildRounding    = t.cardRounding;
+    style.FrameRounding    = 6.0f;
+    style.PopupRounding    = 8.0f;
+    style.ScrollbarRounding = 6.0f;
+    style.GrabRounding     = 4.0f;
+    style.TabRounding      = 6.0f;
+    style.WindowBorderSize = 1.0f;
+    style.FrameBorderSize  = 0.0f;
+
+    ImVec4* colors = style.Colors;
+    colors[ImGuiCol_WindowBg]            = t.panelSoft;
+    colors[ImGuiCol_ChildBg]             = t.panel;
+    colors[ImGuiCol_PopupBg]             = t.panel;
+    colors[ImGuiCol_FrameBg]             = t.surfaceDark;
+    colors[ImGuiCol_FrameBgHovered]      = ImVec4(0.06f, 0.11f, 0.18f, 1.0f);
+    colors[ImGuiCol_FrameBgActive]       = ImVec4(0.08f, 0.15f, 0.25f, 1.0f);
+    colors[ImGuiCol_TitleBg]             = t.panel;
+    colors[ImGuiCol_TitleBgActive]       = ImVec4(0.06f, 0.12f, 0.20f, 1.0f);
+    colors[ImGuiCol_TitleBgCollapsed]    = t.surfaceDark;
+    colors[ImGuiCol_MenuBarBg]           = t.panel;
+    colors[ImGuiCol_ScrollbarBg]         = t.surfaceDark;
+    colors[ImGuiCol_ScrollbarGrab]       = ImVec4(0.18f, 0.28f, 0.42f, 1.0f);
+    colors[ImGuiCol_ScrollbarGrabHovered]= t.accent;
+    colors[ImGuiCol_ScrollbarGrabActive] = t.accentActive;
+    colors[ImGuiCol_CheckMark]           = t.accent;
+    colors[ImGuiCol_SliderGrab]          = t.accent;
+    colors[ImGuiCol_SliderGrabActive]    = t.accentHover;
+    colors[ImGuiCol_Button]              = ImVec4(0.12f, 0.15f, 0.20f, 1.0f);
+    colors[ImGuiCol_ButtonHovered]       = ImVec4(0.16f, 0.20f, 0.28f, 1.0f);
+    colors[ImGuiCol_ButtonActive]        = ImVec4(0.14f, 0.18f, 0.24f, 1.0f);
+    colors[ImGuiCol_Header]              = ImVec4(0.18f, 0.33f, 0.52f, 1.0f);
+    colors[ImGuiCol_HeaderHovered]       = ImVec4(0.22f, 0.38f, 0.58f, 1.0f);
+    colors[ImGuiCol_HeaderActive]        = ImVec4(0.20f, 0.35f, 0.55f, 1.0f);
+    colors[ImGuiCol_Separator]           = t.border;
+    colors[ImGuiCol_SeparatorHovered]    = t.accent;
+    colors[ImGuiCol_SeparatorActive]     = t.accentActive;
+    colors[ImGuiCol_ResizeGrip]          = ImVec4(0.16f, 0.27f, 0.42f, 0.40f);
+    colors[ImGuiCol_ResizeGripHovered]   = t.accent;
+    colors[ImGuiCol_ResizeGripActive]    = t.accentActive;
+    colors[ImGuiCol_Tab]                 = t.panel;
+    colors[ImGuiCol_TabHovered]          = ImVec4(0.16f, 0.30f, 0.50f, 1.0f);
+    colors[ImGuiCol_TabSelected]         = ImVec4(0.18f, 0.36f, 0.58f, 1.0f);
+    colors[ImGuiCol_TabSelectedOverline] = t.accent;
+    colors[ImGuiCol_TabDimmed]           = t.surfaceDark;
+    colors[ImGuiCol_TabDimmedSelected]   = t.panel;
+    colors[ImGuiCol_Border]              = t.border;
+    colors[ImGuiCol_BorderShadow]        = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+    colors[ImGuiCol_Text]                = t.textPrimary;
+    colors[ImGuiCol_TextDisabled]        = t.textMuted;
+}
+
+} // namespace Horo::UI

--- a/ui/common/HoroTheme.h
+++ b/ui/common/HoroTheme.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <imgui.h>
+
+namespace Horo::UI {
+
+// Shared dark-navy color palette used by both the launcher and editor.
+// All ImVec4 fields are normalized [0,1] RGBA.
+struct HoroTheme final {
+    // Background gradient (deep navy)
+    ImVec4 backgroundTop{1.0f / 255.0f, 7.0f / 255.0f, 17.0f / 255.0f, 1.0f};
+    ImVec4 backgroundBottom{1.0f / 255.0f, 7.0f / 255.0f, 17.0f / 255.0f, 1.0f};
+
+    // Surface layers
+    ImVec4 panel{0.05f, 0.09f, 0.15f, 0.94f};
+    ImVec4 panelSoft{0.07f, 0.11f, 0.18f, 0.90f};
+    ImVec4 surfaceDark{0.04f, 0.08f, 0.13f, 1.0f};
+
+    // Border
+    ImVec4 border{0.16f, 0.27f, 0.42f, 0.68f};
+
+    // Text
+    ImVec4 textPrimary{0.92f, 0.94f, 0.98f, 1.0f};
+    ImVec4 textMuted{0.68f, 0.74f, 0.84f, 1.0f};
+
+    // Semantic status colors
+    ImVec4 success{0.75f, 0.95f, 0.75f, 1.0f};
+    ImVec4 warning{1.0f, 0.85f, 0.4f, 1.0f};
+    ImVec4 error{1.0f, 0.45f, 0.4f, 1.0f};
+    ImVec4 info{0.4f, 0.8f, 1.0f, 1.0f};
+    ImVec4 infoBright{0.65f, 0.85f, 1.0f, 1.0f};
+
+    // Accent (brand blue)
+    ImVec4 accent{0.23f, 0.54f, 0.93f, 1.0f};
+    ImVec4 accentHover{0.28f, 0.60f, 0.99f, 1.0f};
+    ImVec4 accentActive{0.18f, 0.46f, 0.82f, 1.0f};
+
+    // Rounding radii
+    float windowRounding = 16.0f;
+    float panelRounding = 12.0f;
+    float cardRounding = 10.0f;
+};
+
+// Returns the global singleton theme instance.
+const HoroTheme& GetHoroTheme();
+
+// Applies the Horo dark theme to ImGui's style.
+// Call once after ImGui::CreateContext() and before the first frame.
+void ApplyHoroEditorTheme();
+
+} // namespace Horo::UI

--- a/ui/common/HoroWidgets.cpp
+++ b/ui/common/HoroWidgets.cpp
@@ -1,0 +1,49 @@
+#include "ui/common/HoroWidgets.h"
+#include "ui/common/HoroTheme.h"
+
+namespace Horo::UI {
+
+bool PrimaryButton(const char* label, const ImVec2& size) {
+    const HoroTheme& t = GetHoroTheme();
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(16.0f, 9.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f);
+    ImGui::PushStyleColor(ImGuiCol_Button,        t.accent);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, t.accentHover);
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  t.accentActive);
+    ImGui::PushStyleColor(ImGuiCol_Text,          ImVec4(0.96f, 0.97f, 1.0f, 1.0f));
+    const bool pressed = ImGui::Button(label, size);
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar(2);
+    return pressed;
+}
+
+bool SecondaryButton(const char* label, const ImVec2& size) {
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(12.0f, 9.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+    ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.12f, 0.15f, 0.20f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.16f, 0.20f, 0.28f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ImVec4(0.14f, 0.18f, 0.24f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_Text,          ImVec4(0.92f, 0.94f, 0.98f, 1.0f));
+    const bool pressed = ImGui::Button(label, size);
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar(2);
+    return pressed;
+}
+
+void LabeledInput(const char* title, const char* id,
+                  char* buffer, size_t bufferSize,
+                  float inputWidth) {
+    const HoroTheme& t = GetHoroTheme();
+    ImGui::TextDisabled("%s", title);
+    ImGui::SetNextItemWidth(inputWidth);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,  ImVec2(12.0f, 9.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+    ImGui::PushStyleColor(ImGuiCol_FrameBg,        t.surfaceDark);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.06f, 0.11f, 0.18f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_FrameBgActive,  ImVec4(0.08f, 0.15f, 0.25f, 1.0f));
+    ImGui::InputText(id, buffer, bufferSize);
+    ImGui::PopStyleColor(3);
+    ImGui::PopStyleVar(2);
+}
+
+} // namespace Horo::UI

--- a/ui/common/HoroWidgets.cpp
+++ b/ui/common/HoroWidgets.cpp
@@ -46,4 +46,16 @@ void LabeledInput(const char* title, const char* id,
     ImGui::PopStyleVar(2);
 }
 
+void CenteredEmptyState(const char* text) {
+    if (const float regionHeight = ImGui::GetContentRegionAvail().y;
+        regionHeight > 40.0f)
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + regionHeight * 0.25f);
+    const float availableWidth = ImGui::GetContentRegionAvail().x;
+    if (const float textWidth = ImGui::CalcTextSize(text).x;
+        textWidth < availableWidth)
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
+                             (availableWidth - textWidth) * 0.5f);
+    ImGui::TextDisabled("%s", text);
+}
+
 } // namespace Horo::UI

--- a/ui/common/HoroWidgets.h
+++ b/ui/common/HoroWidgets.h
@@ -18,4 +18,8 @@ void LabeledInput(const char* title, const char* id,
                   char* buffer, size_t bufferSize,
                   float inputWidth);
 
+// Renders centered, dimmed text in the middle of the current content region.
+// Useful for empty-state messages in panels and lists.
+void CenteredEmptyState(const char* text);
+
 } // namespace Horo::UI

--- a/ui/common/HoroWidgets.h
+++ b/ui/common/HoroWidgets.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+#include <imgui.h>
+
+namespace Horo::UI {
+
+// Renders a primary (accent-colored) push button.
+// Returns true when clicked.
+bool PrimaryButton(const char* label, const ImVec2& size = ImVec2(0.0f, 0.0f));
+
+// Renders a secondary (surface-dark) push button.
+// Returns true when clicked.
+bool SecondaryButton(const char* label, const ImVec2& size = ImVec2(0.0f, 0.0f));
+
+// Renders a disabled text label followed by a styled InputText.
+void LabeledInput(const char* title, const char* id,
+                  char* buffer, size_t bufferSize,
+                  float inputWidth);
+
+} // namespace Horo::UI

--- a/ui/editor/README.md
+++ b/ui/editor/README.md
@@ -1,0 +1,6 @@
+# ui/editor
+
+Placeholder for editor-specific UI components.
+
+Editor UI currently resides in `editor/EditorLayer.cpp` and related files.
+Future editor-specific ImGui widgets and panels can be moved here.

--- a/ui/launcher/LauncherWidgets.cpp
+++ b/ui/launcher/LauncherWidgets.cpp
@@ -1,0 +1,412 @@
+#include "ui/launcher/LauncherWidgets.h"
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#include <imgui.h>
+
+#include "core/ProjectPath.h"
+#include "renderer/Texture.h"
+#include "ui/common/HoroTheme.h"
+
+namespace Horo::Launcher::UI {
+
+namespace fs = std::filesystem;
+
+// Public implementations of path utility and meta-icon (declared in header)
+// are defined below the anonymous namespace section.
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Icon draw helpers (internal — not part of the public API)
+
+void DrawTemplateTileIcon(ImDrawList* drawList, const ImVec2& center,
+                          TemplateTileIcon icon, ImU32 color) {
+    if (icon == TemplateTileIcon::Image) {
+        const ImVec2 min(center.x - 12.0f, center.y - 11.0f);
+        const ImVec2 max(center.x + 12.0f, center.y + 11.0f);
+        drawList->AddRect(min, max, color, 2.5f, 0, 2.0f);
+        drawList->AddCircleFilled(ImVec2(min.x + 7.0f, min.y + 6.0f), 2.0f, color);
+        drawList->AddLine(ImVec2(min.x + 4.0f, max.y - 4.0f),
+                          ImVec2(center.x - 2.0f, center.y + 1.0f), color, 2.0f);
+        drawList->AddLine(ImVec2(center.x - 2.0f, center.y + 1.0f),
+                          ImVec2(center.x + 4.0f, max.y - 6.0f), color, 2.0f);
+        drawList->AddLine(ImVec2(center.x + 4.0f, max.y - 6.0f),
+                          ImVec2(max.x - 3.0f, center.y + 1.0f), color, 2.0f);
+    } else if (icon == TemplateTileIcon::Sandbox) {
+        const float r = 11.0f;
+        drawList->AddNgon(center, r, color, 6, 2.0f);
+    } else {
+        // Cube
+        const float h = 10.0f;
+        const float w = 9.0f;
+        const ImVec2 top(center.x, center.y - h);
+        const ImVec2 rFront(center.x + w, center.y - h * 0.35f);
+        const ImVec2 rBack(center.x + w, center.y + h * 0.35f);
+        const ImVec2 bot(center.x, center.y + h);
+        const ImVec2 lBack(center.x - w, center.y + h * 0.35f);
+        const ImVec2 lFront(center.x - w, center.y - h * 0.35f);
+        drawList->AddLine(top,    rFront, color, 1.8f);
+        drawList->AddLine(rFront, rBack,  color, 1.8f);
+        drawList->AddLine(rBack,  bot,    color, 1.8f);
+        drawList->AddLine(bot,    lBack,  color, 1.8f);
+        drawList->AddLine(lBack,  lFront, color, 1.8f);
+        drawList->AddLine(lFront, top,    color, 1.8f);
+        drawList->AddLine(top,    bot,    color, 1.3f);
+        drawList->AddLine(rFront, lBack,  color, 1.3f);
+        drawList->AddLine(lFront, rBack,  color, 1.3f);
+    }
+}
+
+void DrawLauncherActionIcon(ImDrawList* drawList, const ImVec2& pos,
+                            LauncherActionIcon icon) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 max(pos.x + 38.0f, pos.y + 38.0f);
+    drawList->AddRectFilled(
+        pos, max,
+        ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.22f, 0.40f, 1.0f)), 8.0f);
+
+    const ImU32 iconColor = ImGui::ColorConvertFloat4ToU32(theme.accentHover);
+    if (icon == LauncherActionIcon::Folder) {
+        const ImVec2 tabMin(pos.x + 10.0f, pos.y + 12.0f);
+        drawList->AddRectFilled(tabMin, ImVec2(pos.x + 22.0f, pos.y + 17.0f),
+                                iconColor, 2.0f);
+        drawList->AddRectFilled(ImVec2(pos.x + 9.0f, pos.y + 16.0f),
+                                ImVec2(pos.x + 29.0f, pos.y + 27.0f), iconColor,
+                                3.0f);
+    } else {
+        const float centerX = pos.x + 19.0f;
+        drawList->AddLine(ImVec2(centerX, pos.y + 10.0f),
+                          ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
+        drawList->AddLine(ImVec2(centerX - 5.0f, pos.y + 19.0f),
+                          ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
+        drawList->AddLine(ImVec2(centerX + 5.0f, pos.y + 19.0f),
+                          ImVec2(centerX, pos.y + 24.0f), iconColor, 2.0f);
+        drawList->AddLine(ImVec2(pos.x + 12.0f, pos.y + 28.0f),
+                          ImVec2(pos.x + 26.0f, pos.y + 28.0f), iconColor, 2.0f);
+    }
+}
+
+void DrawSidebarFooterIcon(ImDrawList* drawList, const ImVec2& pos,
+                           SidebarFooterIcon icon) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImU32 color = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
+    if (icon == SidebarFooterIcon::Discord) {
+        const ImVec2 headMin(pos.x + 2.0f, pos.y + 4.0f);
+        const ImVec2 headMax(pos.x + 16.0f, pos.y + 13.0f);
+        drawList->AddRect(headMin, headMax, color, 4.0f, 0, 1.5f);
+        drawList->AddLine(ImVec2(pos.x + 5.0f, pos.y + 4.0f),
+                          ImVec2(pos.x + 4.0f, pos.y + 2.0f), color, 1.5f);
+        drawList->AddLine(ImVec2(pos.x + 13.0f, pos.y + 4.0f),
+                          ImVec2(pos.x + 14.0f, pos.y + 2.0f), color, 1.5f);
+        drawList->AddCircleFilled(ImVec2(pos.x + 7.0f, pos.y + 9.0f), 1.1f, color);
+        drawList->AddCircleFilled(ImVec2(pos.x + 12.0f, pos.y + 9.0f), 1.1f, color);
+    } else {
+        const ImVec2 pageMin(pos.x + 4.0f, pos.y + 2.0f);
+        const ImVec2 pageMax(pos.x + 15.0f, pos.y + 16.0f);
+        drawList->AddRect(pageMin, pageMax, color, 1.5f, 0, 1.5f);
+        drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 7.0f),
+                          ImVec2(pos.x + 13.0f, pos.y + 7.0f), color, 1.1f);
+        drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 10.0f),
+                          ImVec2(pos.x + 13.0f, pos.y + 10.0f), color, 1.1f);
+        drawList->AddLine(ImVec2(pos.x + 7.0f, pos.y + 13.0f),
+                          ImVec2(pos.x + 11.0f, pos.y + 13.0f), color, 1.1f);
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API implementations
+
+fs::path ResolveLauncherVisualAsset(std::string_view relativePath) {
+    if (relativePath.empty())
+        return {};
+    const std::array<fs::path, 4> candidates = {
+        ProjectPath::ResolveSdk("assets/launcher/" + std::string(relativePath)),
+        ProjectPath::Root() / "assets" / "launcher" / std::string(relativePath),
+        ProjectPath::Root() / "engine" / "assets" / "launcher" /
+            std::string(relativePath),
+        ProjectPath::Root() / std::string(relativePath),
+    };
+    for (const fs::path& candidate : candidates) {
+        std::error_code ec;
+        if (fs::is_regular_file(candidate, ec) && !ec)
+            return candidate;
+    }
+    return {};
+}
+
+void DrawRecentProjectMetaIcon(ImDrawList* drawList, const ImVec2& pos,
+                               ImU32 color) {
+    drawList->AddRect(ImVec2(pos.x, pos.y + 2.0f),
+                      ImVec2(pos.x + 12.0f, pos.y + 14.0f), color, 2.0f, 0, 1.2f);
+    drawList->AddLine(ImVec2(pos.x, pos.y + 6.0f),
+                      ImVec2(pos.x + 12.0f, pos.y + 6.0f), color, 1.2f);
+    drawList->AddLine(ImVec2(pos.x + 3.0f, pos.y),
+                      ImVec2(pos.x + 3.0f, pos.y + 4.0f), color, 1.4f);
+    drawList->AddLine(ImVec2(pos.x + 9.0f, pos.y),
+                      ImVec2(pos.x + 9.0f, pos.y + 4.0f), color, 1.4f);
+}
+
+void DrawBackdrop(ImDrawList* drawList, const ImVec2& pos, const ImVec2& size) {
+    if (!drawList)
+        return;
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    static const bool hasCustomBackdrop =
+        !ResolveLauncherVisualAsset("background.png").empty();
+    const ImVec4 top = hasCustomBackdrop ? ImVec4(0.03f, 0.07f, 0.14f, 1.0f)
+                                         : theme.backgroundTop;
+    const ImVec4 bottom = hasCustomBackdrop ? ImVec4(0.02f, 0.04f, 0.09f, 1.0f)
+                                            : theme.backgroundBottom;
+    const ImVec2 max(pos.x + size.x, pos.y + size.y);
+    drawList->AddRectFilledMultiColor(pos, max,
+                                     ImGui::ColorConvertFloat4ToU32(top),
+                                     ImGui::ColorConvertFloat4ToU32(top),
+                                     ImGui::ColorConvertFloat4ToU32(bottom),
+                                     ImGui::ColorConvertFloat4ToU32(bottom));
+}
+
+bool SidebarNavItem(const char* label, bool selected, const ImVec2& size) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(14.0f, 11.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 9.0f);
+    if (selected) {
+        ImGui::PushStyleColor(ImGuiCol_Button,        theme.accent);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, theme.accentHover);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive,  theme.accentActive);
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.97f, 0.98f, 1.0f, 1.0f));
+    } else {
+        ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.08f, 0.12f, 0.19f, 0.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.12f, 0.19f, 0.30f, 0.72f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ImVec4(0.13f, 0.21f, 0.34f, 0.86f));
+        ImGui::PushStyleColor(ImGuiCol_Text, theme.textMuted);
+    }
+    const bool pressed = ImGui::Button(label, size);
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar(2);
+    return pressed;
+}
+
+void VerticalDivider(float height) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 pos = ImGui::GetCursorScreenPos();
+    ImGui::GetWindowDrawList()->AddLine(
+        ImVec2(pos.x, pos.y + 2.0f), ImVec2(pos.x, pos.y + height - 2.0f),
+        ImGui::ColorConvertFloat4ToU32(theme.border), 1.0f);
+    ImGui::Dummy(ImVec2(1.0f, height));
+}
+
+bool RecentProjectButton(const char* title, const ImVec2& size) {
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,  ImVec2(14.0f, 8.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 7.0f);
+    ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.12f, 0.15f, 0.20f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.16f, 0.20f, 0.28f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ImVec4(0.15f, 0.18f, 0.24f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.94f, 0.96f, 1.0f, 1.0f));
+    const bool pressed = ImGui::Button(title, size);
+    ImGui::PopStyleColor(4);
+    ImGui::PopStyleVar(2);
+    return pressed;
+}
+
+bool RecentProjectMenuButton(const char* id, const ImVec2& size) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    ImGui::InvisibleButton(id, size);
+    const bool hovered = ImGui::IsItemHovered();
+    const bool active  = ImGui::IsItemActive();
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+    ImVec4 fill(0.10f, 0.14f, 0.20f, 0.54f);
+    if (active)
+        fill = ImVec4(0.12f, 0.18f, 0.27f, 0.90f);
+    else if (hovered)
+        fill = ImVec4(0.12f, 0.18f, 0.27f, 0.76f);
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    drawList->AddRectFilled(min, max, ImGui::ColorConvertFloat4ToU32(fill), 6.0f);
+    const ImU32 dotColor = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
+    const ImVec2 center((min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f);
+    drawList->AddCircleFilled(ImVec2(center.x, center.y - 6.0f), 1.5f, dotColor);
+    drawList->AddCircleFilled(center,                             1.5f, dotColor);
+    drawList->AddCircleFilled(ImVec2(center.x, center.y + 6.0f), 1.5f, dotColor);
+    return ImGui::IsItemClicked();
+}
+
+bool TemplateTile(const char* label, TemplateTileIcon icon,
+                  bool selected, bool enabled, const ImVec2& size) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    ImGui::InvisibleButton(label, size);
+    const bool pressed = enabled && ImGui::IsItemClicked();
+    const bool hovered = enabled && ImGui::IsItemHovered();
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 max = ImGui::GetItemRectMax();
+
+    ImVec4 fill(0.09f, 0.13f, 0.20f, 1.0f);
+    if (!enabled)       fill = ImVec4(0.08f, 0.11f, 0.16f, 0.72f);
+    else if (selected)  fill = ImVec4(0.10f, 0.18f, 0.30f, 1.0f);
+    else if (hovered)   fill = ImVec4(0.13f, 0.19f, 0.28f, 1.0f);
+
+    ImVec4 border(0.15f, 0.24f, 0.35f, 0.60f);
+    if (!enabled)      border = ImVec4(0.13f, 0.20f, 0.29f, 0.42f);
+    else if (selected) border = theme.accent;
+
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    drawList->AddRectFilled(min, max, ImGui::ColorConvertFloat4ToU32(fill), 6.0f);
+    drawList->AddRect(min, max, ImGui::ColorConvertFloat4ToU32(border), 6.0f, 0,
+                      selected ? 1.5f : 1.0f);
+
+    ImVec4 iconColor = theme.textMuted;
+    if (!enabled)
+        iconColor = ImVec4(theme.textMuted.x, theme.textMuted.y,
+                           theme.textMuted.z, 0.52f);
+    else if (selected)
+        iconColor = theme.accentHover;
+    DrawTemplateTileIcon(drawList, ImVec2((min.x + max.x) * 0.5f, min.y + 27.0f),
+                         icon, ImGui::ColorConvertFloat4ToU32(iconColor));
+
+    const ImVec2 textSize = ImGui::CalcTextSize(label);
+    drawList->AddText(
+        ImVec2((min.x + max.x - textSize.x) * 0.5f, max.y - textSize.y - 10.0f),
+        ImGui::ColorConvertFloat4ToU32(
+            enabled ? ImVec4(0.92f, 0.95f, 0.99f, 1.0f)
+                    : ImVec4(0.68f, 0.74f, 0.84f, 0.62f)),
+        label);
+    return pressed;
+}
+
+void RenderCreateProjectHeader() {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 iconPos = ImGui::GetCursorScreenPos();
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    const ImVec2 iconMax(iconPos.x + 38.0f, iconPos.y + 38.0f);
+    drawList->AddRectFilled(
+        iconPos, iconMax,
+        ImGui::ColorConvertFloat4ToU32(ImVec4(0.10f, 0.22f, 0.40f, 1.0f)), 6.0f);
+    const ImU32 sparkleColor = ImGui::ColorConvertFloat4ToU32(theme.accentHover);
+    drawList->AddLine(ImVec2(iconPos.x + 19.0f, iconPos.y + 9.0f),
+                      ImVec2(iconPos.x + 19.0f, iconPos.y + 18.0f), sparkleColor, 1.6f);
+    drawList->AddLine(ImVec2(iconPos.x + 14.5f, iconPos.y + 13.5f),
+                      ImVec2(iconPos.x + 23.5f, iconPos.y + 13.5f), sparkleColor, 1.6f);
+    drawList->AddLine(ImVec2(iconPos.x + 27.0f, iconPos.y + 22.0f),
+                      ImVec2(iconPos.x + 27.0f, iconPos.y + 28.0f), sparkleColor, 1.4f);
+    drawList->AddLine(ImVec2(iconPos.x + 24.0f, iconPos.y + 25.0f),
+                      ImVec2(iconPos.x + 30.0f, iconPos.y + 25.0f), sparkleColor, 1.4f);
+
+    ImGui::Dummy(ImVec2(46.0f, 38.0f));
+    ImGui::SameLine(0.0f, 8.0f);
+    ImGui::BeginGroup();
+    ImGui::TextUnformatted("Create New Project");
+    ImGui::TextColored(theme.textMuted, "Start a new project from a template");
+    ImGui::EndGroup();
+}
+
+void AdvancedSettingsToggle(bool* open) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 size(190.0f, 30.0f);
+    ImGui::InvisibleButton("Advanced Settings", size);
+    if (ImGui::IsItemClicked() && open)
+        *open = !*open;
+
+    const ImVec2 min = ImGui::GetItemRectMin();
+    const ImVec2 textPos(min.x + 26.0f, min.y + 7.0f);
+    const ImU32 color = ImGui::ColorConvertFloat4ToU32(theme.textMuted);
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    if (open && *open) {
+        drawList->AddTriangleFilled(ImVec2(min.x + 7.0f, min.y + 11.0f),
+                                    ImVec2(min.x + 17.0f, min.y + 11.0f),
+                                    ImVec2(min.x + 12.0f, min.y + 17.0f), color);
+    } else {
+        drawList->AddTriangleFilled(ImVec2(min.x + 9.0f, min.y + 10.0f),
+                                    ImVec2(min.x + 9.0f, min.y + 18.0f),
+                                    ImVec2(min.x + 15.0f, min.y + 14.0f), color);
+    }
+    drawList->AddText(textPos, color, "Advanced Settings");
+}
+
+void RenderLauncherBrand(const Texture* logoTexture) {
+    if (logoTexture && logoTexture->IsValid() &&
+        logoTexture->GetNativeId() != 0) {
+        const float availableWidth = ImGui::GetContentRegionAvail().x;
+        const float logoWidth = std::min(availableWidth, 184.0f);
+        constexpr float kLogoAspect = 1778.0f / 900.0f;
+        ImGui::Image(
+            (ImTextureID) static_cast<intptr_t>(logoTexture->GetNativeId()),
+            ImVec2(logoWidth, logoWidth / kLogoAspect),
+            ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+        return;
+    }
+    ImGui::TextUnformatted("HORO ENGINE");
+}
+
+void SidebarFooterItem(const char* label, SidebarFooterIcon icon) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 textPos  = ImGui::GetCursorPos();
+    const ImVec2 iconPos  = ImGui::GetCursorScreenPos();
+    DrawSidebarFooterIcon(ImGui::GetWindowDrawList(), iconPos, icon);
+    ImGui::SetCursorPos(ImVec2(textPos.x + 26.0f, textPos.y));
+    ImGui::TextColored(theme.textMuted, "%s", label);
+    ImGui::Dummy(ImVec2(0.0f, 4.0f));
+}
+
+void SidebarFooterImageItem(const char* label, const Texture* iconTexture) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 textPos = ImGui::GetCursorPos();
+    if (iconTexture && iconTexture->IsValid() && iconTexture->GetNativeId() != 0) {
+        ImGui::SetCursorPosY(textPos.y + 1.0f);
+        ImGui::Image(
+            (ImTextureID) static_cast<intptr_t>(iconTexture->GetNativeId()),
+            ImVec2(18.0f, 18.0f), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f),
+            theme.textMuted);
+    } else {
+        DrawSidebarFooterIcon(ImGui::GetWindowDrawList(),
+                              ImGui::GetCursorScreenPos(),
+                              SidebarFooterIcon::Discord);
+    }
+    ImGui::SetCursorPos(ImVec2(textPos.x + 26.0f, textPos.y));
+    ImGui::TextColored(theme.textMuted, "%s", label);
+    ImGui::Dummy(ImVec2(0.0f, 4.0f));
+}
+
+void SidebarFooterSeparator() {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 start = ImGui::GetCursorScreenPos();
+    const float width = std::min(154.0f, ImGui::GetContentRegionAvail().x);
+    ImGui::GetWindowDrawList()->AddLine(
+        start, ImVec2(start.x + width, start.y),
+        ImGui::ColorConvertFloat4ToU32(theme.border), 1.0f);
+    ImGui::Dummy(ImVec2(0.0f, 14.0f));
+}
+
+bool LauncherActionCard(const char* id, const char* title, const char* subtitle,
+                        LauncherActionIcon icon, const ImVec2& size) {
+    const Horo::UI::HoroTheme& theme = Horo::UI::GetHoroTheme();
+    const ImVec2 pos = ImGui::GetCursorScreenPos();
+    ImGui::InvisibleButton(id, size);
+    const bool hovered = ImGui::IsItemHovered();
+    const bool active  = ImGui::IsItemActive();
+    ImVec4 fill(0.05f, 0.10f, 0.17f, 0.76f);
+    if (active)
+        fill = ImVec4(0.08f, 0.14f, 0.23f, 0.88f);
+    else if (hovered)
+        fill = ImVec4(0.08f, 0.15f, 0.25f, 0.84f);
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    drawList->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y),
+                            ImGui::ColorConvertFloat4ToU32(fill), 8.0f);
+    drawList->AddRect(pos, ImVec2(pos.x + size.x, pos.y + size.y),
+                      ImGui::ColorConvertFloat4ToU32(theme.border), 8.0f);
+
+    const ImVec2 iconPos(pos.x + 18.0f, pos.y + 17.0f);
+    DrawLauncherActionIcon(drawList, iconPos, icon);
+    drawList->AddText(
+        ImVec2(pos.x + 64.0f, pos.y + 19.0f),
+        ImGui::ColorConvertFloat4ToU32(ImVec4(0.96f, 0.98f, 1.0f, 1.0f)), title);
+    drawList->AddText(ImVec2(pos.x + 64.0f, pos.y + 43.0f),
+                      ImGui::ColorConvertFloat4ToU32(theme.textMuted), subtitle);
+    return ImGui::IsItemClicked();
+}
+
+} // namespace Horo::Launcher::UI

--- a/ui/launcher/LauncherWidgets.h
+++ b/ui/launcher/LauncherWidgets.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string_view>
+#include <imgui.h>
+
+namespace Horo {
+class Texture;
+} // namespace Horo
+
+namespace Horo::Launcher::UI {
+
+// ----------------------------------------------------------------------------
+// Enums used by callers
+
+enum class TemplateTileIcon {
+    Cube,
+    Image,
+    Sandbox,
+};
+
+enum class LauncherActionIcon {
+    Folder,
+    Import,
+};
+
+enum class SidebarFooterIcon {
+    Discord,
+    Documentation,
+};
+
+// ----------------------------------------------------------------------------
+// Background
+
+// Draws the launcher backdrop gradient (or image-adjusted tint) into drawList.
+void DrawBackdrop(ImDrawList* drawList, const ImVec2& pos, const ImVec2& size);
+
+// ----------------------------------------------------------------------------
+// Sidebar navigation
+
+// Styled sidebar nav button. Returns true when clicked.
+// Renders with accent color when selected, transparent otherwise.
+bool SidebarNavItem(const char* label, bool selected,
+                    const ImVec2& size = ImVec2(-1.0f, 40.0f));
+
+// Draws a 1-pixel themed vertical divider line of the given height.
+void VerticalDivider(float height);
+
+// ----------------------------------------------------------------------------
+// Recent projects
+
+// Styled button for a recent project entry. Returns true when clicked.
+bool RecentProjectButton(const char* title, const ImVec2& size);
+
+// Three-dot overflow menu button for a recent project row. Returns true when
+// clicked.
+bool RecentProjectMenuButton(const char* id, const ImVec2& size);
+
+// ----------------------------------------------------------------------------
+// Template tiles
+
+// Clickable tile card with icon. Returns true when clicked (only when enabled).
+bool TemplateTile(const char* label, TemplateTileIcon icon,
+                  bool selected, bool enabled, const ImVec2& size);
+
+// ----------------------------------------------------------------------------
+// Create-project header
+
+// Renders the sparkle icon box followed by title and subtitle text.
+void RenderCreateProjectHeader();
+
+// Collapsible "Advanced Settings" toggle widget. Flips *open on click.
+void AdvancedSettingsToggle(bool* open);
+
+// ----------------------------------------------------------------------------
+// Brand / logo
+
+// Renders the engine logo texture if valid, or falls back to text.
+void RenderLauncherBrand(const Texture* logoTexture);
+
+// ----------------------------------------------------------------------------
+// Sidebar footer
+
+// Renders a labeled footer item with a built-in icon.
+void SidebarFooterItem(const char* label, SidebarFooterIcon icon);
+
+// Renders a labeled footer item with a texture icon (falls back to Discord icon).
+void SidebarFooterImageItem(const char* label, const Texture* iconTexture);
+
+// Renders a thin horizontal separator with spacing.
+void SidebarFooterSeparator();
+
+// ----------------------------------------------------------------------------
+// Action cards
+
+// Large clickable card with title, subtitle, and an action icon.
+// Returns true when clicked.
+bool LauncherActionCard(const char* id, const char* title, const char* subtitle,
+                        LauncherActionIcon icon, const ImVec2& size);
+
+// Draws a small calendar/date meta icon at pos with the given color.
+void DrawRecentProjectMetaIcon(ImDrawList* drawList, const ImVec2& pos,
+                               ImU32 color);
+
+// ----------------------------------------------------------------------------
+// Asset path utility
+
+// Resolves a launcher visual asset (relative to the launcher asset directories).
+// Returns an empty path if the asset is not found.
+// Searches: SDK/assets/launcher/, project-root/assets/launcher/, etc.
+std::filesystem::path ResolveLauncherVisualAsset(std::string_view relativePath);
+
+} // namespace Horo::Launcher::UI

--- a/ui/launcher/README.md
+++ b/ui/launcher/README.md
@@ -1,0 +1,6 @@
+# ui/launcher
+
+Placeholder for launcher-specific UI components.
+
+Launcher UI currently resides in `launcher/LauncherEditorShell.cpp`.
+Future launcher-specific ImGui widgets and panels can be moved here.


### PR DESCRIPTION
## Summary

Creates a new `ui/common/` module providing a shared dark-navy design baseline used by both the launcher and the editor.

## Problem

The launcher had a polished dark-navy theme (`LauncherTheme`) defined locally inside `LauncherEditorShell.cpp`. The editor used a plain `ImGui::StyleColorsDark()` baseline with dozens of scattered hardcoded `ImVec4` color literals. The two surfaces were visually inconsistent.

## Changes

### New: `ui/common/` module
| File | Purpose |
|---|---|
| `ui/common/HoroTheme.h/.cpp` | `HoroTheme` struct with semantic color tokens (error, warning, success, info, accent, textMuted, panel, surfaceDark, border…) + `ApplyHoroEditorTheme()` which replaces `StyleColorsDark()` with a full dark-navy ImGui baseline |
| `ui/common/HoroWidgets.h/.cpp` | Shared `PrimaryButton`, `SecondaryButton`, `LabeledInput` ImGui helpers extracted from the launcher for reuse in both surfaces |
| `ui/launcher/README.md` | Placeholder — future home of launcher-specific UI components |
| `ui/editor/README.md` | Placeholder — future home of editor-specific UI components |

### `launcher/LauncherEditorShell.cpp`
- Removed local `LauncherTheme` struct and `GetLauncherTheme()` (now `Horo::UI::HoroTheme` / `GetHoroTheme()`)
- Removed duplicate `RenderPrimaryButton`, `RenderSecondaryButton`, `RenderLabeledInput` (moved to `HoroWidgets`)
- Net: −60 lines, all functionality preserved

### `editor/EditorLayer.cpp`
- Replaced `ImGui::StyleColorsDark()` with `Horo::UI::ApplyHoroEditorTheme()` — editor now starts from the same dark-navy baseline as the launcher
- Replaced 14 scattered `ImVec4` color literals with semantic theme tokens across 11 functions: `theme.error`, `theme.warning`, `theme.success`, `theme.info`, `theme.infoBright`, `theme.textMuted`

### `CMakeLists.txt`
- Added `ui/common/*.cpp` to `ENGINE_SOURCES` glob

## Verification
- Clean build passes (139/139 targets, zero errors)
- `HoroTheme.cpp`, `HoroWidgets.cpp`, `EditorLayer.cpp`, `LauncherEditorShell.cpp` all compiled cleanly
- `libHoroEngine.a` links successfully

Closes HORO-37

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `ui/common/` module with `HoroTheme`/`HoroWidgets` and a new `ui/launcher/LauncherWidgets` module to unify the dark‑navy UI across the launcher and editor (HORO-37). The editor applies the theme; the launcher uses shared theme, widgets, and extracted helpers.

- **New Features**
  - `ui/common/`: `HoroTheme` (semantic tokens) and `ApplyHoroEditorTheme()`; `HoroWidgets` adds `PrimaryButton`, `SecondaryButton`, `LabeledInput`, and `CenteredEmptyState`.
  - `ui/launcher/`: `LauncherWidgets` with launcher UI helpers (`DrawBackdrop`, `SidebarNavItem`, `TemplateTile`, `LauncherActionCard`, `VerticalDivider`, footer/brand utilities, `ResolveLauncherVisualAsset`).

- **Refactors**
  - Editor: replaced `ImGui::StyleColorsDark()` with `ApplyHoroEditorTheme()` and swapped hardcoded colors for theme tokens.
  - Launcher: removed local `LauncherTheme` and inline helpers; all call sites now use `Horo::UI` and `Horo::Launcher::UI` equivalents.
  - Build: added `ui/common/*.cpp` and `ui/launcher/*.cpp` to `ENGINE_SOURCES` in `CMakeLists.txt`.

<sup>Written for commit ded9b19d128e693f990a764ec239d4ddf8b6e8ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

