### PR TITLE
fix(editor): HiDPI gizmo and viewport picking HORO-58

### DIFF
--- a/ui/editor/EditorViewport.cpp
+++ b/ui/editor/EditorViewport.cpp
@@ -389,8 +389,12 @@ void EditorLayer::HandlePicking(const Camera &cam, int screenW, int screenH) {
                                    static_cast<float>(my), 2.0f))
     return;
 
-  Ray ray = ScreenToRay(static_cast<float>(mx), static_cast<float>(my), screenW,
-                        screenH, cam);
+  // Scale screen coordinates to framebuffer pixels for ray casting.
+  float xscale = 1.0f;
+  float yscale = 1.0f;
+  glfwGetWindowContentScale(m_window, &xscale, &yscale);
+  Ray ray = ScreenToRay(static_cast<float>(mx) * xscale,
+                        static_cast<float>(my) * yscale, screenW, screenH, cam);
 
   float bestT = std::numeric_limits<float>::max();
   int bestIdx = -1;

--- a/ui/editor/TransformGizmo.cpp
+++ b/ui/editor/TransformGizmo.cpp
@@ -336,8 +336,12 @@ GizmoAxis PickRotateRingAxis(float mx, float my, const Vec3& pos,
         double dmx;
         double dmy;
         glfwGetCursorPos(window, &dmx, &dmy);
-        auto mx = static_cast<float>(dmx);
-        auto my = static_cast<float>(dmy);
+        // Convert screen coordinates to framebuffer pixels (differs on HiDPI/Retina).
+        float xscale = 1.0f;
+        float yscale = 1.0f;
+        glfwGetWindowContentScale(window, &xscale, &yscale);
+        auto mx = static_cast<float>(dmx) * xscale;
+        auto my = static_cast<float>(dmy) * yscale;
 
         bool currMouseL =
                 glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS;


### PR DESCRIPTION
## Summary

Fixes transform gizmo hover/click and viewport object picking on macOS Retina (HiDPI) displays.

## Root Cause

`glfwGetCursorPos` returns screen coordinates (logical pixels), but `screenW`/`screenH` from `Window::GetWidth()/GetHeight()` are framebuffer pixels (2x on Retina). The gizmo's `WorldToScreen` projects to framebuffer pixel space, but `PickAxis` compared those against unscaled screen-coordinate cursor positions — a 2x mismatch making hit-testing impossible.

## Fix

Scale cursor position by `glfwGetWindowContentScale` in:
- `TransformGizmo::Update` — for gizmo axis picking and drag ray casting
- `EditorLayer::HandlePicking` — for viewport object ray picking

## Testing

- Build passes locally (macOS arm64)
- 55/55 unit tests pass
- Manual verification: gizmo arrows highlight on hover and respond to click/drag on Retina display

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HiDPI transform gizmo hover/click and viewport object picking on macOS by converting cursor screen coordinates to framebuffer pixels. Addresses HORO-58.

- **Bug Fixes**
  - Scale cursor position with `glfwGetWindowContentScale` so gizmo hit-tests and ray casting use the same pixel space.
  - Applied in TransformGizmo axis/ring picking and EditorLayer viewport picking.

<sup>Written for commit 96c40c9f9314d70dc280fda8e79ea341137c7bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

