### PR TITLE
feat(renderer): FBX animation clip import to engine-native .anim.bin (HORO-108)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,7 @@ This directory documents the current engine architecture, calls out temporary ex
 - [ownership-lifecycle.md](./ownership-lifecycle.md)
 - [error-result-model.md](./error-result-model.md)
 - [threading-and-mutation.md](./threading-and-mutation.md)
+- [fbx-import-support-matrix.md](./fbx-import-support-matrix.md)
 
 ## Reviewer Rules
 

--- a/docs/architecture/fbx-import-support-matrix.md
+++ b/docs/architecture/fbx-import-support-matrix.md
@@ -1,0 +1,141 @@
+# FBX import — support matrix and limitations
+
+This document describes the FBX import pipeline shipped under the HORO-89 epic.
+It captures what is currently supported, what is intentionally out of scope,
+and how to read the diagnostics emitted by the importer.
+
+> **Status:** import-side complete. Runtime-side consumption of the
+> `.skinned.bin` and `.anim.bin` artefacts (ECS animation system reading
+> animations, full skinned render path through the new manifest) is a separate
+> follow-up tracked under the cook/package work.
+
+## Pipeline at a glance
+
+```
+.fbx source file
+       │
+       ▼
+   FbxAssetImporter           (ui/editor/AssetImporterRegistry.cpp)
+       │
+       ├── FbxLoader (renderer/FbxLoader.h)
+       │       └── ufbx (vendor/ufbx, MIT, v0.21.3)
+       │
+       ▼
+managed assets/<guid>/
+       ├── <stem>.mesh.bin       (static path, HoroMeshBin v1)
+       ├── <stem>.skinned.bin    (skinned path, HoroSkinnedBin v1)
+       ├── <stem>.anim.bin       (skeletal + animation only)
+       ├── <copied textures>     (external + embedded)
+       └── asset.meta.json       (metadata sidecar)
+```
+
+The importer auto-detects whether the FBX has a skin deformer and dispatches
+to the correct path. Static and skinned imports never produce both
+`.mesh.bin` and `.skinned.bin` for the same asset.
+
+## Vendored library
+
+| Library | Version | License | Purpose                                              |
+|---------|---------|---------|------------------------------------------------------|
+| ufbx    | v0.21.3 | MIT     | Single-source FBX parser; no external dependencies. |
+
+Library lives under `vendor/ufbx/` and is private-linked into `HoroEngine`.
+ufbx symbols are intentionally invisible on the public engine surface.
+
+## What is supported
+
+| Capability                       | Supported | Notes                                                                                         |
+|----------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| Static-mesh extraction           | ✅        | Concatenates all renderable meshes; missing normals are auto-generated; UV defaults to (0, 0).|
+| Multi-mesh files                 | ✅        | Combined into a single output mesh.                                                          |
+| Right-handed Y-up axes           | ✅        | ufbx target axes set to RHS Y-up; one-time conversion at load.                               |
+| Diffuse / albedo channel         | ✅        | First diffuse-flagged texture drives `AssetDef::albedoMap`.                                  |
+| Embedded textures                | ✅        | Bytes from `scene->videos[].content` written into managed storage; magic-byte sniff for missing extensions. |
+| External texture resolution      | ✅        | Searches absolute / sibling / `textures/` / sourceDir candidates.                            |
+| Skeletal mesh (skin deformer)    | ✅        | Top-4 bone influences per vertex, weights renormalised to 1.0; bones topologically sorted.   |
+| Bind-pose skeleton               | ✅        | `inverseBindMatrix` taken from each cluster's `geometry_to_bone`.                            |
+| Animation clips                  | ✅        | One `AnimationClip` per ufbx anim_stack; uniform 30 fps sampling via `ufbx_evaluate_transform`.|
+| Per-bone TRS tracks              | ✅        | Position / rotation / scale stored as separate time arrays; rotations as quaternions.        |
+| Diagnostics taxonomy             | ✅        | Typed `DiagnosticCodes::Fbx*` constants, persisted in metadata.                              |
+| Source dependency tracking       | ✅        | FBX file + every resolved external texture path recorded as `Source`.                        |
+| Reimport propagation             | ✅        | Driven by `AssetImportService::ReimportAssetWithDependents`.                                 |
+| Editor file-drop                 | ✅        | OS file-drop dispatcher accepts both `.obj` and `.fbx`.                                      |
+| Editor "Import Asset" modal      | ✅        | `EditorImportAssetModal`; multi-format chooser via `AssetImporterRegistry`.                  |
+| Thumbnail preview (static)       | ✅        | `EditorAssetThumbnailPreview` reads `.mesh.bin` via `MeshBin::ReadStaticMesh`.               |
+
+## Known limitations / out of scope
+
+| Limitation                                  | Workaround / follow-up                                                                                                            |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| Up to 4 bone influences per vertex           | Standard four-bone skinning; smallest weights are dropped, surviving weights renormalised. Lift in a future revision when needed. |
+| Animation tangent / curve shapes             | Uniform 30 fps sampling is the deliberate trade-off (smaller runtime + simpler engine sampler). Bump `kAnimBinVersion` if a tangent variant becomes necessary. |
+| PBR base / normal / metallic split           | Importer captures all `scene->textures` but currently only the first diffuse drives `AssetDef`. Add additional texture slots when the asset model grows. |
+| Thumbnail preview for skinned meshes         | `.mesh.bin` thumbnail support is in; `.skinned.bin` thumbnail rendering follows the runtime work.                                |
+| Runtime-side `.skinned.bin` / `.anim.bin`    | `MeshCache` loads `.mesh.bin`. A `SkinnedMeshCache` and ECS-driven animation playback are planned alongside the cook/package work.|
+| Cook / package integration                  | Out of HORO-89 scope; tracked under HORO-24 (Cooked asset cache generation and release artifact packaging).                       |
+
+## On-disk artefact formats
+
+All formats are little-endian and have versioned headers; readers reject
+mismatched magic / version cleanly.
+
+### `<stem>.mesh.bin` — HoroMeshBin v1 (static mesh)
+
+48-byte header followed by `Vertex` records and `uint32_t` indices.
+See `renderer/MeshBin.h` for the full layout.
+
+### `<stem>.skinned.bin` — HoroSkinnedBin v1 (skinned mesh + skeleton)
+
+64-byte header followed by `SkinnedVertex` records, `uint32_t` indices, and
+per-bone records (parent index + 16-float column-major inverse-bind matrix +
+length-prefixed name).
+See `renderer/SkinnedMeshBin.h` for the full layout.
+
+### `<stem>.anim.bin` — HoroAnimBin v1 (animation clips)
+
+32-byte header followed by per-clip records (name, duration, track count) and
+per-track records (`boneIndex` + position / rotation / scale time arrays with
+their value arrays).
+See `renderer/AnimBin.h` for the full layout.
+
+## Diagnostic codes
+
+The importer emits typed diagnostic codes from
+`Horo::Editor::DiagnosticCodes` (header: `ui/editor/AssetImportDiagnosticCodes.h`).
+Codes are part of the public diagnostic contract — never rename or repurpose
+an existing constant.
+
+| Code                                      | Severity | Meaning                                                                  |
+|-------------------------------------------|----------|--------------------------------------------------------------------------|
+| `asset.fbx.unsupported_type`              | Error    | Source file is not `.fbx`.                                                |
+| `asset.fbx.source_missing`                | Error    | Source path does not resolve to a regular file.                          |
+| `asset.fbx.create_directory_failed`       | Error    | Managed asset directory could not be created.                            |
+| `asset.fbx.parse_failed`                  | Error    | ufbx rejected the file (corrupt or unsupported variant).                 |
+| `asset.fbx.no_geometry`                   | Error    | File parsed but contains no triangulable mesh data.                      |
+| `asset.fbx.mesh_write_failed`             | Error    | `.mesh.bin` could not be written to managed storage.                     |
+| `asset.fbx.skeleton_missing`              | Warning/Error | Skin clusters reference bones that could not be linked.             |
+| `asset.fbx.skeleton_write_failed`         | Error    | `.skinned.bin` could not be written.                                     |
+| `asset.fbx.animation_write_failed`        | Warning  | `.anim.bin` could not be written; mesh import still succeeds.            |
+| `asset.fbx.external_texture_missing`      | Warning  | External texture referenced by the FBX could not be resolved on disk.    |
+| `asset.fbx.external_texture_copy_failed`  | Warning  | External texture was located but could not be copied into managed storage. |
+| `asset.fbx.embedded_texture_extract_failed` | Warning | Embedded texture blob could not be written.                              |
+| `asset.fbx.unit_scale_warning`            | Warning  | Reserved for future unit-scale auditing.                                 |
+| `asset.fbx.unsupported_feature_warning`   | Warning  | Reserved for future per-feature gating.                                  |
+
+## Test fixtures
+
+The repository ships small permissive FBX fixtures vendored from the upstream
+ufbx test suite (same MIT license):
+
+| Fixture                                       | Coverage                                       |
+|-----------------------------------------------|------------------------------------------------|
+| `cube_5800_binary.fbx`                        | HORO-94 static mesh, HORO-108 animation extraction (`Take 001`). |
+| `cube_texture_5800_binary.fbx`                | HORO-95/96 — embedded video texture.           |
+| `embedded_textures_7400_binary.fbx`           | HORO-95/96 — multi-channel embedded textures.  |
+| `external_texture_6100_binary.fbx`            | HORO-95 — external reference, no embedded.     |
+| `skinned_7400_binary.fbx`                     | HORO-107 — skinned mesh + skeleton.            |
+
+## Related documents
+
+- [module-boundaries.md](./module-boundaries.md)
+- [ownership-lifecycle.md](./ownership-lifecycle.md)

--- a/renderer/AnimBin.cpp
+++ b/renderer/AnimBin.cpp
@@ -7,8 +7,10 @@
  */
 #include "renderer/AnimBin.h"
 
+#include <array>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <fstream>
 
 namespace Horo::AnimBin {
@@ -28,19 +30,21 @@ namespace Horo::AnimBin {
         static_assert(sizeof(Header) == 32,
                       "AnimBin header layout must remain 32 bytes; bump kAnimBinVersion before changing it.");
 
-        bool WriteBytes(std::ofstream &stream, const void *data, std::size_t size) {
-            stream.write(static_cast<const char *>(data), static_cast<std::streamsize>(size));
+        template <typename T>
+        bool WriteBytes(std::ofstream &stream, const T *data, std::size_t size) {
+            stream.write(reinterpret_cast<const char *>(data), static_cast<std::streamsize>(size));
             return stream.good();
         }
 
-        bool ReadBytes(std::ifstream &stream, void *data, std::size_t size) {
-            stream.read(static_cast<char *>(data), static_cast<std::streamsize>(size));
+        template <typename T>
+        bool ReadBytes(std::ifstream &stream, T *data, std::size_t size) {
+            stream.read(reinterpret_cast<char *>(data), static_cast<std::streamsize>(size));
             return stream.good();
         }
 
         bool WriteFloatArray(std::ofstream &stream, const std::vector<float> &v) {
-            const uint32_t count = static_cast<uint32_t>(v.size());
-            if (!WriteBytes(stream, &count, sizeof(count)))
+            if (const auto count = static_cast<uint32_t>(v.size());
+                !WriteBytes(stream, &count, sizeof(count)))
                 return false;
             return v.empty() || WriteBytes(stream, v.data(), v.size() * sizeof(float));
         }
@@ -54,12 +58,12 @@ namespace Horo::AnimBin {
         }
 
         bool WriteVec3Array(std::ofstream &stream, const std::vector<Vec3> &v) {
-            const uint32_t count = static_cast<uint32_t>(v.size());
-            if (!WriteBytes(stream, &count, sizeof(count)))
+            if (const auto count = static_cast<uint32_t>(v.size());
+                !WriteBytes(stream, &count, sizeof(count)))
                 return false;
             for (const Vec3 &p: v) {
-                const float buf[3] = {p.x, p.y, p.z};
-                if (!WriteBytes(stream, buf, sizeof(buf)))
+                const std::array<float, 3> buf = {p.x, p.y, p.z};
+                if (!WriteBytes(stream, buf.data(), sizeof(buf)))
                     return false;
             }
             return true;
@@ -71,8 +75,8 @@ namespace Horo::AnimBin {
                 return false;
             v.resize(count);
             for (uint32_t i = 0; i < count; ++i) {
-                float buf[3];
-                if (!ReadBytes(stream, buf, sizeof(buf)))
+                std::array<float, 3> buf{};
+                if (!ReadBytes(stream, buf.data(), sizeof(buf)))
                     return false;
                 v[i] = {buf[0], buf[1], buf[2]};
             }
@@ -80,12 +84,12 @@ namespace Horo::AnimBin {
         }
 
         bool WriteQuatArray(std::ofstream &stream, const std::vector<Quaternion> &v) {
-            const uint32_t count = static_cast<uint32_t>(v.size());
-            if (!WriteBytes(stream, &count, sizeof(count)))
+            if (const auto count = static_cast<uint32_t>(v.size());
+                !WriteBytes(stream, &count, sizeof(count)))
                 return false;
             for (const Quaternion &q: v) {
-                const float buf[4] = {q.x, q.y, q.z, q.w};
-                if (!WriteBytes(stream, buf, sizeof(buf)))
+                const std::array<float, 4> buf = {q.x, q.y, q.z, q.w};
+                if (!WriteBytes(stream, buf.data(), sizeof(buf)))
                     return false;
             }
             return true;
@@ -97,8 +101,8 @@ namespace Horo::AnimBin {
                 return false;
             v.resize(count);
             for (uint32_t i = 0; i < count; ++i) {
-                float buf[4];
-                if (!ReadBytes(stream, buf, sizeof(buf)))
+                std::array<float, 4> buf{};
+                if (!ReadBytes(stream, buf.data(), sizeof(buf)))
                     return false;
                 v[i] = Quaternion{buf[0], buf[1], buf[2], buf[3]};
             }
@@ -143,27 +147,27 @@ namespace Horo::AnimBin {
         }
 
         for (const AnimationClip &clip: clips) {
-            const uint32_t nameLength = static_cast<uint32_t>(clip.name.size());
-            if (!WriteBytes(stream, &nameLength, sizeof(nameLength)) ||
+            if (const auto nameLength = static_cast<uint32_t>(clip.name.size());
+                !WriteBytes(stream, &nameLength, sizeof(nameLength)) ||
                 (nameLength > 0 &&
                  !WriteBytes(stream, clip.name.data(), nameLength))) {
                 result.error = "AnimBin write: failed writing clip name.";
                 return result;
             }
-            const float duration = clip.duration;
-            if (!WriteBytes(stream, &duration, sizeof(duration))) {
+            if (const float duration = clip.duration;
+                !WriteBytes(stream, &duration, sizeof(duration))) {
                 result.error = "AnimBin write: failed writing clip duration.";
                 return result;
             }
             const std::vector<BoneTrack> &tracks = clip.GetTracks();
-            const uint32_t trackCount = static_cast<uint32_t>(tracks.size());
-            if (!WriteBytes(stream, &trackCount, sizeof(trackCount))) {
+            if (const auto trackCount = static_cast<uint32_t>(tracks.size());
+                !WriteBytes(stream, &trackCount, sizeof(trackCount))) {
                 result.error = "AnimBin write: failed writing track count.";
                 return result;
             }
             for (const BoneTrack &track: tracks) {
-                const int32_t boneIndex = static_cast<int32_t>(track.boneIndex);
-                if (!WriteBytes(stream, &boneIndex, sizeof(boneIndex))) {
+                if (const auto boneIndex = static_cast<int32_t>(track.boneIndex);
+                    !WriteBytes(stream, &boneIndex, sizeof(boneIndex))) {
                     result.error = "AnimBin write: failed writing track bone index.";
                     return result;
                 }
@@ -191,8 +195,7 @@ namespace Horo::AnimBin {
     /** @copydoc Horo::AnimBin::ReadClips */
     ReadResult ReadClips(const std::string &sourcePath) {
         ReadResult result;
-        std::error_code ec;
-        if (!std::filesystem::is_regular_file(sourcePath, ec) || ec) {
+        if (std::error_code ec; !std::filesystem::is_regular_file(sourcePath, ec) || ec) {
             result.error = "AnimBin read: source path is not a regular file.";
             return result;
         }
@@ -211,9 +214,8 @@ namespace Horo::AnimBin {
             return result;
         }
         if (header.version != kAnimBinVersion) {
-            result.error = "AnimBin read: unsupported version " +
-                           std::to_string(header.version) +
-                           " (expected " + std::to_string(kAnimBinVersion) + ").";
+            result.error = std::format("AnimBin read: unsupported version {} (expected {}).",
+                                       header.version, kAnimBinVersion);
             return result;
         }
 

--- a/renderer/AnimBin.cpp
+++ b/renderer/AnimBin.cpp
@@ -1,0 +1,271 @@
+/** @file AnimBin.cpp
+ *  @brief Animation clip binary writer / reader. See AnimBin.h.
+ *
+ *  AnimationClip exposes its tracks via @c AddTrack / @c GetTracks. We expand the
+ *  read path through @c AddTrack so the deserialized clips behave identically to
+ *  freshly-built ones.
+ */
+#include "renderer/AnimBin.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+namespace Horo::AnimBin {
+    namespace {
+        /** @brief 32-byte header. */
+        struct Header {
+            uint32_t magic;
+            uint32_t version;
+            uint32_t clipCount;
+            uint32_t reserved0;
+            uint32_t reserved1;
+            uint32_t reserved2;
+            uint32_t reserved3;
+            uint32_t reserved4;
+        };
+
+        static_assert(sizeof(Header) == 32,
+                      "AnimBin header layout must remain 32 bytes; bump kAnimBinVersion before changing it.");
+
+        bool WriteBytes(std::ofstream &stream, const void *data, std::size_t size) {
+            stream.write(static_cast<const char *>(data), static_cast<std::streamsize>(size));
+            return stream.good();
+        }
+
+        bool ReadBytes(std::ifstream &stream, void *data, std::size_t size) {
+            stream.read(static_cast<char *>(data), static_cast<std::streamsize>(size));
+            return stream.good();
+        }
+
+        bool WriteFloatArray(std::ofstream &stream, const std::vector<float> &v) {
+            const uint32_t count = static_cast<uint32_t>(v.size());
+            if (!WriteBytes(stream, &count, sizeof(count)))
+                return false;
+            return v.empty() || WriteBytes(stream, v.data(), v.size() * sizeof(float));
+        }
+
+        bool ReadFloatArray(std::ifstream &stream, std::vector<float> &v) {
+            uint32_t count = 0;
+            if (!ReadBytes(stream, &count, sizeof(count)))
+                return false;
+            v.resize(count);
+            return count == 0 || ReadBytes(stream, v.data(), count * sizeof(float));
+        }
+
+        bool WriteVec3Array(std::ofstream &stream, const std::vector<Vec3> &v) {
+            const uint32_t count = static_cast<uint32_t>(v.size());
+            if (!WriteBytes(stream, &count, sizeof(count)))
+                return false;
+            for (const Vec3 &p: v) {
+                const float buf[3] = {p.x, p.y, p.z};
+                if (!WriteBytes(stream, buf, sizeof(buf)))
+                    return false;
+            }
+            return true;
+        }
+
+        bool ReadVec3Array(std::ifstream &stream, std::vector<Vec3> &v) {
+            uint32_t count = 0;
+            if (!ReadBytes(stream, &count, sizeof(count)))
+                return false;
+            v.resize(count);
+            for (uint32_t i = 0; i < count; ++i) {
+                float buf[3];
+                if (!ReadBytes(stream, buf, sizeof(buf)))
+                    return false;
+                v[i] = {buf[0], buf[1], buf[2]};
+            }
+            return true;
+        }
+
+        bool WriteQuatArray(std::ofstream &stream, const std::vector<Quaternion> &v) {
+            const uint32_t count = static_cast<uint32_t>(v.size());
+            if (!WriteBytes(stream, &count, sizeof(count)))
+                return false;
+            for (const Quaternion &q: v) {
+                const float buf[4] = {q.x, q.y, q.z, q.w};
+                if (!WriteBytes(stream, buf, sizeof(buf)))
+                    return false;
+            }
+            return true;
+        }
+
+        bool ReadQuatArray(std::ifstream &stream, std::vector<Quaternion> &v) {
+            uint32_t count = 0;
+            if (!ReadBytes(stream, &count, sizeof(count)))
+                return false;
+            v.resize(count);
+            for (uint32_t i = 0; i < count; ++i) {
+                float buf[4];
+                if (!ReadBytes(stream, buf, sizeof(buf)))
+                    return false;
+                v[i] = Quaternion{buf[0], buf[1], buf[2], buf[3]};
+            }
+            return true;
+        }
+    } // namespace
+
+    /** @copydoc Horo::AnimBin::WriteClips */
+    WriteResult WriteClips(const std::string &destPath,
+                            const std::vector<AnimationClip> &clips) {
+        WriteResult result;
+        if (clips.empty()) {
+            result.error = "AnimBin write: empty clip list.";
+            return result;
+        }
+
+        std::error_code ec;
+        const std::filesystem::path path(destPath);
+        if (path.has_parent_path()) {
+            std::filesystem::create_directories(path.parent_path(), ec);
+            if (ec) {
+                result.error =
+                        "AnimBin write: cannot create destination directory: " +
+                        ec.message();
+                return result;
+            }
+        }
+
+        std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+        if (!stream.is_open()) {
+            result.error = "AnimBin write: cannot open destination file.";
+            return result;
+        }
+
+        Header header{};
+        header.magic = kAnimBinMagic;
+        header.version = kAnimBinVersion;
+        header.clipCount = static_cast<uint32_t>(clips.size());
+        if (!WriteBytes(stream, &header, sizeof(header))) {
+            result.error = "AnimBin write: failed writing header.";
+            return result;
+        }
+
+        for (const AnimationClip &clip: clips) {
+            const uint32_t nameLength = static_cast<uint32_t>(clip.name.size());
+            if (!WriteBytes(stream, &nameLength, sizeof(nameLength)) ||
+                (nameLength > 0 &&
+                 !WriteBytes(stream, clip.name.data(), nameLength))) {
+                result.error = "AnimBin write: failed writing clip name.";
+                return result;
+            }
+            const float duration = clip.duration;
+            if (!WriteBytes(stream, &duration, sizeof(duration))) {
+                result.error = "AnimBin write: failed writing clip duration.";
+                return result;
+            }
+            const std::vector<BoneTrack> &tracks = clip.GetTracks();
+            const uint32_t trackCount = static_cast<uint32_t>(tracks.size());
+            if (!WriteBytes(stream, &trackCount, sizeof(trackCount))) {
+                result.error = "AnimBin write: failed writing track count.";
+                return result;
+            }
+            for (const BoneTrack &track: tracks) {
+                const int32_t boneIndex = static_cast<int32_t>(track.boneIndex);
+                if (!WriteBytes(stream, &boneIndex, sizeof(boneIndex))) {
+                    result.error = "AnimBin write: failed writing track bone index.";
+                    return result;
+                }
+                if (!WriteFloatArray(stream, track.positionTimes) ||
+                    !WriteVec3Array(stream, track.positions) ||
+                    !WriteFloatArray(stream, track.rotationTimes) ||
+                    !WriteQuatArray(stream, track.rotations) ||
+                    !WriteFloatArray(stream, track.scaleTimes) ||
+                    !WriteVec3Array(stream, track.scales)) {
+                    result.error = "AnimBin write: failed writing track keys.";
+                    return result;
+                }
+            }
+        }
+
+        stream.flush();
+        if (!stream.good()) {
+            result.error = "AnimBin write: stream entered fail state during flush.";
+            return result;
+        }
+        result.ok = true;
+        return result;
+    }
+
+    /** @copydoc Horo::AnimBin::ReadClips */
+    ReadResult ReadClips(const std::string &sourcePath) {
+        ReadResult result;
+        std::error_code ec;
+        if (!std::filesystem::is_regular_file(sourcePath, ec) || ec) {
+            result.error = "AnimBin read: source path is not a regular file.";
+            return result;
+        }
+        std::ifstream stream(sourcePath, std::ios::binary);
+        if (!stream.is_open()) {
+            result.error = "AnimBin read: cannot open source file.";
+            return result;
+        }
+        Header header{};
+        if (!ReadBytes(stream, &header, sizeof(header))) {
+            result.error = "AnimBin read: file too short for header.";
+            return result;
+        }
+        if (header.magic != kAnimBinMagic) {
+            result.error = "AnimBin read: bad magic bytes; not a HoroAnimBin file.";
+            return result;
+        }
+        if (header.version != kAnimBinVersion) {
+            result.error = "AnimBin read: unsupported version " +
+                           std::to_string(header.version) +
+                           " (expected " + std::to_string(kAnimBinVersion) + ").";
+            return result;
+        }
+
+        result.clips.reserve(header.clipCount);
+        for (uint32_t c = 0; c < header.clipCount; ++c) {
+            AnimationClip clip;
+            uint32_t nameLength = 0;
+            if (!ReadBytes(stream, &nameLength, sizeof(nameLength))) {
+                result.error = "AnimBin read: failed reading clip name length.";
+                return result;
+            }
+            if (nameLength > 0) {
+                clip.name.resize(nameLength);
+                if (!ReadBytes(stream, clip.name.data(), nameLength)) {
+                    result.error = "AnimBin read: failed reading clip name.";
+                    return result;
+                }
+            }
+            float duration = 0.0f;
+            if (!ReadBytes(stream, &duration, sizeof(duration))) {
+                result.error = "AnimBin read: failed reading clip duration.";
+                return result;
+            }
+            clip.duration = duration;
+            uint32_t trackCount = 0;
+            if (!ReadBytes(stream, &trackCount, sizeof(trackCount))) {
+                result.error = "AnimBin read: failed reading track count.";
+                return result;
+            }
+            for (uint32_t t = 0; t < trackCount; ++t) {
+                BoneTrack track;
+                int32_t boneIndex = 0;
+                if (!ReadBytes(stream, &boneIndex, sizeof(boneIndex))) {
+                    result.error = "AnimBin read: failed reading track bone index.";
+                    return result;
+                }
+                track.boneIndex = static_cast<int>(boneIndex);
+                if (!ReadFloatArray(stream, track.positionTimes) ||
+                    !ReadVec3Array(stream, track.positions) ||
+                    !ReadFloatArray(stream, track.rotationTimes) ||
+                    !ReadQuatArray(stream, track.rotations) ||
+                    !ReadFloatArray(stream, track.scaleTimes) ||
+                    !ReadVec3Array(stream, track.scales)) {
+                    result.error = "AnimBin read: failed reading track keys.";
+                    return result;
+                }
+                clip.AddTrack(std::move(track));
+            }
+            result.clips.push_back(std::move(clip));
+        }
+
+        result.ok = true;
+        return result;
+    }
+} // namespace Horo::AnimBin

--- a/renderer/AnimBin.h
+++ b/renderer/AnimBin.h
@@ -1,0 +1,89 @@
+/** @file AnimBin.h
+ *  @brief Engine-native binary serialization for animation clips.
+ *
+ *  AnimBin is the runtime artifact produced by FBX animation import (HORO-108).
+ *  It stores one or more @ref AnimationClip records, each holding per-bone
+ *  position / rotation / scale tracks with their own time arrays. Tracks use
+ *  uniform sampling (typically 30 fps) so the runtime sampler does not have
+ *  to interpolate FBX's tangent / curve shapes.
+ *
+ *  Layout (all multi-byte integers are little-endian):
+ *  @code
+ *  offset  size  field
+ *  0       4     magic       'H','R','A','N' (HoroAnimBin)
+ *  4       4     version     uint32_t, currently @ref kAnimBinVersion
+ *  8       4     clipCount   uint32_t
+ *  12      4     reserved0   uint32_t, write 0
+ *  16      4     reserved1   uint32_t, write 0
+ *  20      4     reserved2   uint32_t, write 0
+ *  24      4     reserved3   uint32_t, write 0
+ *  28      4     reserved4   uint32_t, write 0
+ *  32      ...   clips       repeated for clipCount
+ *  @endcode
+ *
+ *  Per clip:
+ *  @code
+ *  4         nameLength   uint32_t
+ *  N         name         ASCII bytes (no terminator)
+ *  4         duration     float32 (seconds)
+ *  4         trackCount   uint32_t
+ *  ...       tracks       repeated for trackCount
+ *  @endcode
+ *
+ *  Per track:
+ *  @code
+ *  4         boneIndex             int32_t (index into the matching skeleton)
+ *  4         positionKeyCount      uint32_t
+ *  K * 4     positionTimes         K float32
+ *  K * 12    positions             K Vec3 (x, y, z)
+ *  4         rotationKeyCount      uint32_t
+ *  R * 4     rotationTimes         R float32
+ *  R * 16    rotations             R Quaternion (x, y, z, w)
+ *  4         scaleKeyCount         uint32_t
+ *  S * 4     scaleTimes            S float32
+ *  S * 12    scales                S Vec3 (x, y, z)
+ *  @endcode
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "renderer/AnimationClip.h"
+
+namespace Horo::AnimBin {
+    /** @brief Format magic bytes ('H','R','A','N'). */
+    inline constexpr uint32_t kAnimBinMagic =
+        (static_cast<uint32_t>('H')) |
+        (static_cast<uint32_t>('R') << 8) |
+        (static_cast<uint32_t>('A') << 16) |
+        (static_cast<uint32_t>('N') << 24);
+
+    /** @brief Current on-disk schema version. */
+    inline constexpr uint32_t kAnimBinVersion = 1;
+
+    /** @brief Outcome of a read operation. */
+    struct ReadResult {
+        bool ok = false;                       /**< True on success. */
+        std::vector<AnimationClip> clips;      /**< Decoded animation clips. */
+        std::string error;                     /**< Human-readable diagnostic on failure; empty on success. */
+    };
+
+    /** @brief Outcome of a write operation. */
+    struct WriteResult {
+        bool ok = false;       /**< True on success. */
+        std::string error;     /**< Human-readable diagnostic on failure; empty on success. */
+    };
+
+    /** @brief Writes a list of animation clips to disk in the engine-native format.
+     *  @param destPath Absolute or project-relative destination file path.
+     *  @param clips    Clips to serialize; must not be empty.
+     *  @return WriteResult with @c ok = true on success or a populated @c error.
+     */
+    WriteResult WriteClips(const std::string &destPath,
+                            const std::vector<AnimationClip> &clips);
+
+    /** @brief Reads animation clips previously produced by @ref WriteClips. */
+    ReadResult ReadClips(const std::string &sourcePath);
+} // namespace Horo::AnimBin

--- a/renderer/FbxLoader.cpp
+++ b/renderer/FbxLoader.cpp
@@ -607,12 +607,18 @@ namespace Horo::FbxLoader {
         }
 
         // Resolve bone-name -> ufbx_node*.
-        std::unordered_map<std::string, const ufbx_node *> nodeByName;
+        struct StringHash {
+            using is_transparent = void;
+            std::size_t operator()(std::string_view sv) const noexcept {
+                return std::hash<std::string_view>{}(sv);
+            }
+        };
+        std::unordered_map<std::string, const ufbx_node *, StringHash, std::equal_to<>> nodeByName;
         for (std::size_t i = 0; i < scene->nodes.count; ++i) {
             const ufbx_node *node = scene->nodes.data[i];
             if (node == nullptr || node->name.length == 0)
                 continue;
-            nodeByName.emplace(std::string(node->name.data, node->name.length), node);
+            nodeByName.try_emplace(std::string(node->name.data, node->name.length), node);
         }
 
         constexpr float kSampleRateHz = 30.0f;
@@ -622,8 +628,8 @@ namespace Horo::FbxLoader {
             const ufbx_anim_stack *stack = scene->anim_stacks.data[si];
             if (stack == nullptr || stack->anim == nullptr)
                 continue;
-            const float t0 = static_cast<float>(stack->time_begin);
-            const float t1 = static_cast<float>(stack->time_end);
+            const auto t0 = static_cast<float>(stack->time_begin);
+            const auto t1 = static_cast<float>(stack->time_end);
             if (t1 <= t0)
                 continue;
 

--- a/renderer/FbxLoader.cpp
+++ b/renderer/FbxLoader.cpp
@@ -582,3 +582,104 @@ namespace Horo::FbxLoader {
         return result;
     }
 } // namespace Horo::FbxLoader
+
+namespace Horo::FbxLoader {
+    /** @copydoc Horo::FbxLoader::LoadAnimations */
+    FbxAnimLoadResult LoadAnimations(const std::string &sourcePath,
+                                      const std::vector<std::string> &boneNames) {
+        FbxAnimLoadResult result;
+
+        ufbx_load_opts opts{};
+        opts.target_axes = ufbx_axes_right_handed_y_up;
+        opts.target_unit_meters = 1.0f;
+        opts.evaluate_skinning = false;
+        opts.load_external_files = false;
+
+        ufbx_error error{};
+        ufbx_scene *scene = ufbx_load_file(sourcePath.c_str(), &opts, &error);
+        if (scene == nullptr) {
+            result.errorCode = "fbx.parse_failed";
+            result.error = std::string("ufbx parse failed: ") +
+                           (error.description.length > 0
+                                ? std::string(error.description.data, error.description.length)
+                                : std::string("unknown error"));
+            return result;
+        }
+
+        // Resolve bone-name -> ufbx_node*.
+        std::unordered_map<std::string, const ufbx_node *> nodeByName;
+        for (std::size_t i = 0; i < scene->nodes.count; ++i) {
+            const ufbx_node *node = scene->nodes.data[i];
+            if (node == nullptr || node->name.length == 0)
+                continue;
+            nodeByName.emplace(std::string(node->name.data, node->name.length), node);
+        }
+
+        constexpr float kSampleRateHz = 30.0f;
+        constexpr float kFrameDt = 1.0f / kSampleRateHz;
+
+        for (std::size_t si = 0; si < scene->anim_stacks.count; ++si) {
+            const ufbx_anim_stack *stack = scene->anim_stacks.data[si];
+            if (stack == nullptr || stack->anim == nullptr)
+                continue;
+            const float t0 = static_cast<float>(stack->time_begin);
+            const float t1 = static_cast<float>(stack->time_end);
+            if (t1 <= t0)
+                continue;
+
+            AnimationClip clip;
+            clip.name =
+                std::string(stack->name.data, static_cast<std::size_t>(stack->name.length));
+            clip.duration = t1 - t0;
+
+            // Determine number of samples (inclusive of both endpoints).
+            const float duration = t1 - t0;
+            const std::size_t sampleCount =
+                std::max<std::size_t>(2, static_cast<std::size_t>(
+                                              std::ceil(duration * kSampleRateHz)) + 1);
+
+            for (std::size_t bi = 0; bi < boneNames.size(); ++bi) {
+                const auto it = nodeByName.find(boneNames[bi]);
+                if (it == nodeByName.end())
+                    continue;
+                const ufbx_node *node = it->second;
+
+                BoneTrack track;
+                track.boneIndex = static_cast<int>(bi);
+                track.positionTimes.reserve(sampleCount);
+                track.positions.reserve(sampleCount);
+                track.rotationTimes.reserve(sampleCount);
+                track.rotations.reserve(sampleCount);
+                track.scaleTimes.reserve(sampleCount);
+                track.scales.reserve(sampleCount);
+
+                for (std::size_t s = 0; s < sampleCount; ++s) {
+                    const float t = std::min(duration, static_cast<float>(s) * kFrameDt);
+                    const ufbx_transform xform =
+                        ufbx_evaluate_transform(stack->anim, node,
+                                                static_cast<double>(t0 + t));
+                    track.positionTimes.push_back(t);
+                    track.positions.push_back({static_cast<float>(xform.translation.x),
+                                                static_cast<float>(xform.translation.y),
+                                                static_cast<float>(xform.translation.z)});
+                    track.rotationTimes.push_back(t);
+                    track.rotations.push_back(
+                        Quaternion{static_cast<float>(xform.rotation.x),
+                                    static_cast<float>(xform.rotation.y),
+                                    static_cast<float>(xform.rotation.z),
+                                    static_cast<float>(xform.rotation.w)});
+                    track.scaleTimes.push_back(t);
+                    track.scales.push_back({static_cast<float>(xform.scale.x),
+                                              static_cast<float>(xform.scale.y),
+                                              static_cast<float>(xform.scale.z)});
+                }
+                clip.AddTrack(std::move(track));
+            }
+            result.clips.push_back(std::move(clip));
+        }
+
+        ufbx_free_scene(scene);
+        result.ok = true;
+        return result;
+    }
+} // namespace Horo::FbxLoader

--- a/renderer/FbxLoader.h
+++ b/renderer/FbxLoader.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "renderer/AnimationClip.h"
 #include "renderer/Mesh.h"
 #include "renderer/Skeleton.h"
 #include "renderer/SkinnedVertex.h"
@@ -103,4 +104,27 @@ namespace Horo::FbxLoader {
      *  - @c errorCode == "fbx.skeleton_missing" — file has skin clusters but no bone nodes.
      */
     FbxSkeletalLoadResult LoadSkeletalMesh(const std::string &sourcePath);
+
+    /** @brief Result of an animation extraction operation. */
+    struct FbxAnimLoadResult {
+        bool ok = false;                  /**< True on success (a successful parse with zero clips is still ok). */
+        std::vector<AnimationClip> clips; /**< Decoded animation clips, one per FBX anim_stack. */
+        std::string error;                /**< Diagnostic on parse failure. */
+        std::string errorCode;            /**< Short tag e.g. @c "fbx.parse_failed". */
+    };
+
+    /** @brief Loads animation clips from an FBX file using uniform 30 fps sampling.
+     *  @param sourcePath Absolute path to the FBX source file.
+     *  @param boneNames  Bone names that match the engine-side skeleton order;
+     *                    each track's @c boneIndex matches the index of the bone
+     *                    name in this vector.
+     *
+     *  Tracks are produced only for bones whose names match an FBX node. Each
+     *  track is uniformly sampled at 30 fps via @c ufbx_evaluate_transform over
+     *  the stack's @c [time_begin, time_end] range and split into separate
+     *  position / rotation / scale arrays so the engine sampler can SLERP
+     *  rotations and LERP positions / scales without re-deriving them.
+     */
+    FbxAnimLoadResult LoadAnimations(const std::string &sourcePath,
+                                      const std::vector<std::string> &boneNames);
 } // namespace Horo::FbxLoader

--- a/tests/test_fbx_import.cpp
+++ b/tests/test_fbx_import.cpp
@@ -1067,3 +1067,134 @@ TEST_CASE("FbxAssetImporter: skinned FBX without animation does NOT produce .ani
                                      return p.ends_with(".anim.bin");
                                    }));
 }
+
+// ===========================================================================
+// HORO-104 + HORO-105 + HORO-110 — bundled FBX import test sweep
+// ===========================================================================
+// HORO-104 (importer fixtures), HORO-105 (editor integration), and HORO-110
+// (skinned + animation regression) were planned as a final bundled test pass.
+// The per-feature PRs in this stack already shipped most of the coverage; this
+// section adds the end-to-end consolidations that tie everything together
+// across the public surface.
+
+#include "ui/editor/components/EditorImportAssetModal.h"
+
+TEST_CASE("E2E: Import Asset modal drives FBX import all the way to producedFiles",
+          "[editor][asset-import][fbx][e2e]") {
+  const std::filesystem::path root =
+      Horo::Tests::SecureTempBase() / "horo_e2e_modal_fbx";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  std::filesystem::create_directories(root / "assets" / "models", ec);
+  WriteFile(root / "CMakePresets.json", "{}");
+  ProjectPathGuard guard(root);
+
+  AssetImporterRegistry registry;
+  EditorImportAssetModal modal;
+
+  // 1. User opens the modal seeded with an FBX path; importer is auto-selected.
+  modal.Open(FixturePath("cube_5800_binary.fbx"), &registry);
+  REQUIRE(modal.IsOpen());
+  REQUIRE(modal.DraftForTest().importerId == "builtin.fbx_static_mesh");
+  REQUIRE(modal.DraftForTest().assetId == "cube_5800_binary");
+
+  // 2. User clicks Import → caller drives the actual import via AssetImportService.
+  modal.RequestImportForTest();
+  REQUIRE(modal.HasPendingRequest());
+  const ImportAssetRequest req = modal.ConsumePendingRequest();
+
+  AssetImportService service;
+  const AssetImportResult result = service.ImportAssetFromSource(
+      req.sourcePath, req.assetId, "guid_e2e_cube",
+      req.displayName.empty() ? req.assetId : req.displayName);
+  REQUIRE(result.ok);
+
+  // 3. Caller pushes the outcome back into the modal; clean import auto-closes it.
+  ImportAssetOutcome outcome;
+  outcome.ok = result.ok;
+  outcome.error = result.error;
+  outcome.assetMesh = result.asset.mesh;
+  outcome.assetAlbedoMap = result.asset.albedoMap;
+  outcome.diagnostics = result.diagnostics;
+  modal.SetLastResult(outcome);
+  CHECK_FALSE(modal.IsOpen());
+
+  // 4. The produced .mesh.bin is on disk and loadable via MeshCache.
+  const std::filesystem::path meshAbs = root / result.asset.mesh;
+  REQUIRE(std::filesystem::is_regular_file(meshAbs));
+  MeshCache cache;
+  const std::shared_ptr<Mesh> mesh = cache.Get(meshAbs.string());
+  REQUIRE(mesh != nullptr);
+  REQUIRE(mesh->GetIndexCount() > 0);
+  REQUIRE_FALSE(mesh->GetVertices().empty());
+}
+
+TEST_CASE("E2E: skinned + animated FBX yields .skinned.bin and (when present) .anim.bin",
+          "[editor][asset-import][fbx][skeletal][animation][e2e]") {
+  // Pin the regression: the skinned fixture has no anim_stacks, so the import
+  // must produce .skinned.bin but not a .anim.bin. This confirms HORO-107 +
+  // HORO-108 cooperate without false positives.
+  const std::filesystem::path root =
+      Horo::Tests::SecureTempBase() / "horo_e2e_skinned_no_anim";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  std::filesystem::create_directories(root / "assets" / "models", ec);
+  WriteFile(root / "CMakePresets.json", "{}");
+  ProjectPathGuard guard(root);
+
+  AssetImportService service;
+  const std::string source = FixturePath("skinned_7400_binary.fbx");
+  const AssetImportResult result = service.ImportAssetFromSource(
+      source, "skinned_e2e", "guid_skinned_e2e", "Skinned E2E", {});
+  REQUIRE(result.ok);
+  CHECK(result.asset.mesh.ends_with(".skinned.bin"));
+
+  AssetMetadata metadata;
+  std::string metaError;
+  REQUIRE(LoadAssetMetadata("guid_skinned_e2e", &metadata, &metaError));
+
+  bool sawSkinnedBin = false;
+  bool sawAnimBin = false;
+  for (const std::string &p: metadata.producedFiles) {
+    if (p.ends_with(".skinned.bin")) sawSkinnedBin = true;
+    if (p.ends_with(".anim.bin")) sawAnimBin = true;
+  }
+  CHECK(sawSkinnedBin);
+  CHECK_FALSE(sawAnimBin); // fixture has no anim_stacks
+}
+
+TEST_CASE("E2E: drag-drop predicate accepts both .obj and .fbx",
+          "[editor][asset-import][fbx][drag-drop][e2e]") {
+  // ProcessPendingMeshDrops dispatches by IsObjFilePath || IsFbxFilePath.
+  // Pin both predicates here so a future widening that re-introduces an
+  // .fbx-only or .obj-only path breaks this test loudly.
+  REQUIRE(IsObjFilePath("/x/y/cube.obj"));
+  REQUIRE(IsFbxFilePath("/x/y/cube.fbx"));
+  REQUIRE_FALSE(IsObjFilePath("/x/y/cube.fbx"));
+  REQUIRE_FALSE(IsFbxFilePath("/x/y/cube.obj"));
+}
+
+TEST_CASE("E2E: every vendored FBX fixture loads without parse error",
+          "[fbx][loader][e2e]") {
+  // Coverage map for the fixtures vendored across this stack:
+  // - cube_5800_binary           HORO-94 + HORO-108 (animation extraction).
+  // - cube_texture_5800_binary   HORO-95/96 (embedded video texture).
+  // - embedded_textures_7400     HORO-95/96 (multi-channel embedded textures).
+  // - external_texture_6100      HORO-95   (external reference, no embedded).
+  // - skinned_7400_binary        HORO-107  (skinned mesh + skeleton).
+  const std::vector<std::string> fixtures = {
+      "cube_5800_binary.fbx",
+      "cube_texture_5800_binary.fbx",
+      "embedded_textures_7400_binary.fbx",
+      "external_texture_6100_binary.fbx",
+      "skinned_7400_binary.fbx",
+  };
+  for (const std::string &f: fixtures) {
+    INFO("fixture: " << f);
+    const std::string path = FixturePath(f);
+    REQUIRE(std::filesystem::exists(path));
+    const FbxLoader::FbxLoadResult result = FbxLoader::LoadStaticMesh(path);
+    REQUIRE(result.ok);
+    CHECK(result.error.empty());
+  }
+}

--- a/tests/test_fbx_import.cpp
+++ b/tests/test_fbx_import.cpp
@@ -958,3 +958,112 @@ TEST_CASE("FbxAssetImporter: skinned FBX produces a managed .skinned.bin",
     return p == result.asset.mesh;
   }));
 }
+
+// ===========================================================================
+// HORO-108 — animation clip extraction + AnimBin round-trip
+// ===========================================================================
+
+#include "renderer/AnimBin.h"
+
+TEST_CASE("FbxLoader::LoadAnimations: animated cube fixture exposes a non-empty clip",
+          "[fbx][loader][animation]") {
+  // The static-cube fixture happens to ship with a 'Take 001' animation stack
+  // covering 0..2s; sampling the cube node by name produces tracks with
+  // multiple keyframes per channel.
+  const std::string path = FixturePath("cube_5800_binary.fbx");
+  REQUIRE(std::filesystem::exists(path));
+  const std::vector<std::string> boneNames = {"Box01"};
+  const FbxLoader::FbxAnimLoadResult result =
+      FbxLoader::LoadAnimations(path, boneNames);
+  REQUIRE(result.ok);
+  REQUIRE_FALSE(result.clips.empty());
+  const AnimationClip &clip = result.clips.front();
+  CHECK(clip.duration > 0.0f);
+  REQUIRE_FALSE(clip.GetTracks().empty());
+  const BoneTrack &track = clip.GetTracks().front();
+  CHECK(track.boneIndex == 0);
+  CHECK(track.positionTimes.size() >= 2);
+  CHECK(track.rotationTimes.size() == track.positionTimes.size());
+  CHECK(track.scaleTimes.size() == track.positionTimes.size());
+}
+
+TEST_CASE("FbxLoader::LoadAnimations: file with no anim_stacks returns ok with empty clips",
+          "[fbx][loader][animation]") {
+  const std::string path = FixturePath("skinned_7400_binary.fbx");
+  const std::vector<std::string> boneNames = {"Bone"};
+  const FbxLoader::FbxAnimLoadResult result =
+      FbxLoader::LoadAnimations(path, boneNames);
+  REQUIRE(result.ok);
+  CHECK(result.clips.empty());
+}
+
+TEST_CASE("AnimBin: round-trip preserves clip name, duration, and track keys",
+          "[anim-bin]") {
+  const std::filesystem::path path =
+      Horo::Tests::SecureTempBase() / "horo_animbin_roundtrip.anim.bin";
+
+  AnimationClip clip;
+  clip.name = "Walk";
+  clip.duration = 1.5f;
+  BoneTrack track;
+  track.boneIndex = 2;
+  track.positionTimes = {0.0f, 0.5f, 1.0f};
+  track.positions = {{0, 0, 0}, {1, 0, 0}, {2, 0, 0}};
+  track.rotationTimes = {0.0f, 0.5f, 1.0f};
+  track.rotations = {Quaternion{0, 0, 0, 1}, Quaternion{0, 0, 0, 1},
+                      Quaternion{0, 0, 0, 1}};
+  track.scaleTimes = {0.0f, 1.0f};
+  track.scales = {{1, 1, 1}, {1, 1, 1}};
+  clip.AddTrack(std::move(track));
+
+  REQUIRE(AnimBin::WriteClips(path.string(), {clip}).ok);
+  const AnimBin::ReadResult rr = AnimBin::ReadClips(path.string());
+  REQUIRE(rr.ok);
+  REQUIRE(rr.clips.size() == 1);
+  CHECK(rr.clips[0].name == "Walk");
+  CHECK(rr.clips[0].duration == 1.5f);
+  REQUIRE(rr.clips[0].GetTracks().size() == 1);
+  const BoneTrack &back = rr.clips[0].GetTracks().front();
+  CHECK(back.boneIndex == 2);
+  REQUIRE(back.positions.size() == 3);
+  CHECK(back.positions[2].x == 2.0f);
+  CHECK(back.rotations.size() == 3);
+  CHECK(back.scales.size() == 2);
+}
+
+TEST_CASE("AnimBin: ReadClips rejects bad magic", "[anim-bin]") {
+  const std::filesystem::path path =
+      Horo::Tests::SecureTempBase() / "horo_animbin_badmagic.anim.bin";
+  std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+  const std::array<char, 64> zeros{};
+  stream.write(zeros.data(), zeros.size());
+  stream.close();
+  const AnimBin::ReadResult rr = AnimBin::ReadClips(path.string());
+  REQUIRE_FALSE(rr.ok);
+}
+
+TEST_CASE("FbxAssetImporter: skinned FBX without animation does NOT produce .anim.bin",
+          "[editor][asset-import][fbx][animation]") {
+  const std::filesystem::path root =
+      Horo::Tests::SecureTempBase() / "horo_fbx_skinned_no_anim";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  std::filesystem::create_directories(root / "assets" / "models", ec);
+  WriteFile(root / "CMakePresets.json", "{}");
+  ProjectPathGuard guard(root);
+
+  const AssetImportService service;
+  const std::string source = FixturePath("skinned_7400_binary.fbx");
+  const AssetImportResult result = service.ImportAssetFromSource(
+      source, "skinned_b", "guid_skinned_b", "Skinned B", {});
+  REQUIRE(result.ok);
+
+  AssetMetadata metadata;
+  std::string metaError;
+  REQUIRE(LoadAssetMetadata("guid_skinned_b", &metadata, &metaError));
+  // No anim.bin should appear in producedFiles when the FBX has zero anim_stacks.
+  CHECK_FALSE(std::ranges::any_of(metadata.producedFiles,
+                                   [](const std::string &p) {
+                                     return p.ends_with(".anim.bin");
+                                   }));
+}

--- a/ui/editor/AssetImporterRegistry.cpp
+++ b/ui/editor/AssetImporterRegistry.cpp
@@ -769,9 +769,9 @@ namespace Horo::Editor {
                     boneNames.reserve(skeletal.bones.size());
                     for (const Bone &bone: skeletal.bones)
                         boneNames.push_back(bone.name);
-                    FbxLoader::FbxAnimLoadResult animResult =
-                        FbxLoader::LoadAnimations(sourcePath.string(), boneNames);
-                    if (animResult.ok && !animResult.clips.empty()) {
+                    if (auto animResult =
+                            FbxLoader::LoadAnimations(sourcePath.string(), boneNames);
+                        animResult.ok && !animResult.clips.empty()) {
                         const fs::path destAnimBin =
                             destDir / (sourcePath.stem().string() + ".anim.bin");
                         const AnimBin::WriteResult animWrite =

--- a/ui/editor/AssetImporterRegistry.cpp
+++ b/ui/editor/AssetImporterRegistry.cpp
@@ -20,6 +20,7 @@
 #include "ui/editor/AssetIdentity.h"
 #include "ui/editor/AssetImportDiagnosticCodes.h"
 #include "ui/editor/EditorAssetImport.h"
+#include "renderer/AnimBin.h"
 #include "renderer/FbxLoader.h"
 #include "renderer/MeshBin.h"
 #include "renderer/ObjLoader.h"
@@ -762,6 +763,33 @@ namespace Horo::Editor {
                     std::vector<std::string> producedFiles;
                     producedFiles.push_back(
                         fs::relative(destSkinnedBin, ProjectPath::Root()).generic_string());
+
+                    // HORO-108: extract animation clips for the skeleton's bones.
+                    std::vector<std::string> boneNames;
+                    boneNames.reserve(skeletal.bones.size());
+                    for (const Bone &bone: skeletal.bones)
+                        boneNames.push_back(bone.name);
+                    FbxLoader::FbxAnimLoadResult animResult =
+                        FbxLoader::LoadAnimations(sourcePath.string(), boneNames);
+                    if (animResult.ok && !animResult.clips.empty()) {
+                        const fs::path destAnimBin =
+                            destDir / (sourcePath.stem().string() + ".anim.bin");
+                        const AnimBin::WriteResult animWrite =
+                            AnimBin::WriteClips(destAnimBin.string(), animResult.clips);
+                        if (animWrite.ok) {
+                            producedFiles.push_back(
+                                fs::relative(destAnimBin, ProjectPath::Root())
+                                    .generic_string());
+                        } else {
+                            result.diagnostics.push_back(MakeDiagnostic(
+                                AssetDiagnosticSeverity::Warning,
+                                DiagnosticCodes::FbxAnimationWriteFailed,
+                                animWrite.error.empty()
+                                    ? "Failed writing animation binary."
+                                    : animWrite.error,
+                                request, ImporterId()));
+                        }
+                    }
 
                     std::string albedoMapPath;
                     std::vector<std::string> externalSourcePaths;


### PR DESCRIPTION
## Summary
- Skeletal FBX imports now also produce a managed `<stem>.anim.bin` whenever the source contains animation stacks.
- New `renderer/AnimBin` versioned format that round-trips `AnimationClip` records with per-bone tracks split into position / rotation / scale arrays.
- New `FbxLoader::LoadAnimations` that uniformly samples each bone via `ufbx_evaluate_transform` at 30 fps over the stack's `[time_begin, time_end]` range.
- 5 new tests / 26 new assertions covering loader, container, and importer behaviours.

## Motivation
HORO-107 delivered the skeletal half (skinned mesh + bind-pose skeleton). HORO-108 closes the loop: animation clips bound to that skeleton now persist as engine-native artifacts ready for runtime consumption. Uniform 30 fps sampling avoids reasoning about FBX's tangent / curve shapes and maps directly onto the engine's `AnimationClip::Sample` LERP/SLERP paths.

## Implementation Notes

**`renderer/AnimBin.{h,cpp}`**
- 32-byte fixed header (`HRAN`) with version + clip count + reserved padding. Per-clip records carry name, duration, track count; per-track records hold a `boneIndex` and three time/value arrays (positions Vec3, rotations Quaternion, scales Vec3).
- `WriteClips` rejects empty clip lists; `ReadClips` uses `AnimationClip::AddTrack` so deserialized clips behave identically to freshly-built ones.

**`renderer/FbxLoader::LoadAnimations`**
- Builds a `std::unordered_map<string, ufbx_node*>` from `scene->nodes` so each bone name from HORO-107's skeleton can be resolved without re-parsing.
- For each `ufbx_anim_stack` and each known bone, samples uniformly at 30 fps. Sample count = `ceil(duration * 30) + 1` so both endpoints are present.
- Bones with no matching node are silently skipped; tracks for bones that have no animation data still carry the bone's rest pose because `ufbx_evaluate_transform` returns it.

**Importer wiring (`AssetImporterRegistry`)**
- The skeletal branch now extracts `boneNames` from `skeletal.bones`, calls `LoadAnimations`, and writes `<stem>.anim.bin` only when `clips` is non-empty.
- `producedFiles` and `Source` dependency tracking pick up the `.anim.bin` automatically through `BuildImportedMetadata`.
- Write failures surface as `FbxAnimationWriteFailed` warnings; the mesh import is never failed by an animation-side error.

## Validation
- [x] `cmake --build --preset debug` clean.
- [x] Pre-commit gate green.
- [x] `test_fbx_import` — 36 cases / 235 assertions (was 31 / 209 in PR 11).
- [x] `test_editor` — 1677 / 492.
- [x] `test_editor_unit` — 1718 / 155.
- [x] `test_animation` — 125 / 30.

New tests:
- `LoadAnimations` against `cube_5800_binary.fbx` (bundled `Take 001` 0–2 s) produces a non-empty clip whose first track has multiple position/rotation/scale keys.
- `LoadAnimations` against the skinned fixture (no anim_stacks) returns `ok = true` with an empty clip list.
- AnimBin round-trip preserves clip name, duration, and per-track keys.
- AnimBin rejects bad magic on read.
- Importing the skinned fixture does NOT add a `.anim.bin` to `producedFiles` (no anim_stacks ⇒ no file).

## Risks
- **Uniform 30 fps sampling** is the deliberate trade-off: simpler runtime, larger on-disk files than tangent-preserving curves. When higher fidelity is needed, the version field on the AnimBin header lets us add a curve-encoded variant without breaking v1 readers.
- **Bone resolution is by name.** When HORO-107's bone naming matches the FBX, every bone gets a track; mismatches manifest as silently-skipped tracks. This is the same convention every game engine uses for skeleton retargeting and matches the skeleton names HORO-107 already exports.
- **Runtime-side AnimBin consumption** (ECS animation system reading `.anim.bin` and feeding `AnimationClip::Sample`) is intentionally out of scope; pairs with future skinned-mesh runtime work.

## Issue Links
- HORO-108 — FBX: animation clip import and runtime playback.
- Builds on HORO-107 (skeletal extraction).

## Reviewer Notes
- Review order:
  1. `renderer/AnimBin.{h,cpp}` — format spec + round-trip.
  2. `renderer/FbxLoader.h` — new `FbxAnimLoadResult` + declaration.
  3. `renderer/FbxLoader.cpp` — `LoadAnimations` body with the uniform-sampling loop.
  4. `ui/editor/AssetImporterRegistry.cpp` — animation block in the skeletal branch.
  5. `tests/test_fbx_import.cpp` — five new cases under `[animation]` and `[anim-bin]`.
- The `cube_5800_binary.fbx` fixture pulls double duty (HORO-94 static mesh + HORO-108 animation extraction) because it ships with a `Take 001` stack. The skinned fixture has no animation, which makes it the right negative test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FBX animation import that writes an engine-native `.anim.bin` alongside `.skinned.bin` when the FBX has animation stacks. Completes HORO-108; also adds an FBX support matrix doc and end-to-end tests to validate editor import flows.

- **New Features**
  - Introduces `renderer/AnimBin` v1 (32-byte header) storing clip name, duration, and per-bone tracks with separate time/value arrays; round-trip read/write with validation.
  - Adds `FbxLoader::LoadAnimations(path, boneNames)` to resolve bones by name and uniformly sample each FBX anim stack at 30 fps via `ufbx_evaluate_transform`; emits one `AnimationClip` per stack.
  - Importer writes `<stem>.anim.bin` only when clips exist, adds it to `producedFiles`, and surfaces `FbxAnimationWriteFailed` warnings without failing the mesh import.
  - Documents capabilities and limits in `docs/architecture/fbx-import-support-matrix.md`, and adds E2E editor tests (modal, drag-drop, producedFiles) covering FBX import paths. 

- **Refactors**
  - Sonar cleanups: typed read/write helpers, `std::array` for POD buffers, `auto`/if-init statements, and `std::format` for version errors.
  - `FbxLoader` map uses a transparent hasher and `try_emplace` for efficient node-name lookups.

<sup>Written for commit 4ddf61cebfcfb768dcd3bacfc0d6d066a641c656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

