### PR TITLE
test(editor): bundled end-to-end FBX import test sweep (HORO-104, HORO-105, HORO-110)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,7 @@ This directory documents the current engine architecture, calls out temporary ex
 - [ownership-lifecycle.md](./ownership-lifecycle.md)
 - [error-result-model.md](./error-result-model.md)
 - [threading-and-mutation.md](./threading-and-mutation.md)
+- [fbx-import-support-matrix.md](./fbx-import-support-matrix.md)
 
 ## Reviewer Rules
 

--- a/docs/architecture/fbx-import-support-matrix.md
+++ b/docs/architecture/fbx-import-support-matrix.md
@@ -1,0 +1,141 @@
+# FBX import — support matrix and limitations
+
+This document describes the FBX import pipeline shipped under the HORO-89 epic.
+It captures what is currently supported, what is intentionally out of scope,
+and how to read the diagnostics emitted by the importer.
+
+> **Status:** import-side complete. Runtime-side consumption of the
+> `.skinned.bin` and `.anim.bin` artefacts (ECS animation system reading
+> animations, full skinned render path through the new manifest) is a separate
+> follow-up tracked under the cook/package work.
+
+## Pipeline at a glance
+
+```
+.fbx source file
+       │
+       ▼
+   FbxAssetImporter           (ui/editor/AssetImporterRegistry.cpp)
+       │
+       ├── FbxLoader (renderer/FbxLoader.h)
+       │       └── ufbx (vendor/ufbx, MIT, v0.21.3)
+       │
+       ▼
+managed assets/<guid>/
+       ├── <stem>.mesh.bin       (static path, HoroMeshBin v1)
+       ├── <stem>.skinned.bin    (skinned path, HoroSkinnedBin v1)
+       ├── <stem>.anim.bin       (skeletal + animation only)
+       ├── <copied textures>     (external + embedded)
+       └── asset.meta.json       (metadata sidecar)
+```
+
+The importer auto-detects whether the FBX has a skin deformer and dispatches
+to the correct path. Static and skinned imports never produce both
+`.mesh.bin` and `.skinned.bin` for the same asset.
+
+## Vendored library
+
+| Library | Version | License | Purpose                                              |
+|---------|---------|---------|------------------------------------------------------|
+| ufbx    | v0.21.3 | MIT     | Single-source FBX parser; no external dependencies. |
+
+Library lives under `vendor/ufbx/` and is private-linked into `HoroEngine`.
+ufbx symbols are intentionally invisible on the public engine surface.
+
+## What is supported
+
+| Capability                       | Supported | Notes                                                                                         |
+|----------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| Static-mesh extraction           | ✅        | Concatenates all renderable meshes; missing normals are auto-generated; UV defaults to (0, 0).|
+| Multi-mesh files                 | ✅        | Combined into a single output mesh.                                                          |
+| Right-handed Y-up axes           | ✅        | ufbx target axes set to RHS Y-up; one-time conversion at load.                               |
+| Diffuse / albedo channel         | ✅        | First diffuse-flagged texture drives `AssetDef::albedoMap`.                                  |
+| Embedded textures                | ✅        | Bytes from `scene->videos[].content` written into managed storage; magic-byte sniff for missing extensions. |
+| External texture resolution      | ✅        | Searches absolute / sibling / `textures/` / sourceDir candidates.                            |
+| Skeletal mesh (skin deformer)    | ✅        | Top-4 bone influences per vertex, weights renormalised to 1.0; bones topologically sorted.   |
+| Bind-pose skeleton               | ✅        | `inverseBindMatrix` taken from each cluster's `geometry_to_bone`.                            |
+| Animation clips                  | ✅        | One `AnimationClip` per ufbx anim_stack; uniform 30 fps sampling via `ufbx_evaluate_transform`.|
+| Per-bone TRS tracks              | ✅        | Position / rotation / scale stored as separate time arrays; rotations as quaternions.        |
+| Diagnostics taxonomy             | ✅        | Typed `DiagnosticCodes::Fbx*` constants, persisted in metadata.                              |
+| Source dependency tracking       | ✅        | FBX file + every resolved external texture path recorded as `Source`.                        |
+| Reimport propagation             | ✅        | Driven by `AssetImportService::ReimportAssetWithDependents`.                                 |
+| Editor file-drop                 | ✅        | OS file-drop dispatcher accepts both `.obj` and `.fbx`.                                      |
+| Editor "Import Asset" modal      | ✅        | `EditorImportAssetModal`; multi-format chooser via `AssetImporterRegistry`.                  |
+| Thumbnail preview (static)       | ✅        | `EditorAssetThumbnailPreview` reads `.mesh.bin` via `MeshBin::ReadStaticMesh`.               |
+
+## Known limitations / out of scope
+
+| Limitation                                  | Workaround / follow-up                                                                                                            |
+|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| Up to 4 bone influences per vertex           | Standard four-bone skinning; smallest weights are dropped, surviving weights renormalised. Lift in a future revision when needed. |
+| Animation tangent / curve shapes             | Uniform 30 fps sampling is the deliberate trade-off (smaller runtime + simpler engine sampler). Bump `kAnimBinVersion` if a tangent variant becomes necessary. |
+| PBR base / normal / metallic split           | Importer captures all `scene->textures` but currently only the first diffuse drives `AssetDef`. Add additional texture slots when the asset model grows. |
+| Thumbnail preview for skinned meshes         | `.mesh.bin` thumbnail support is in; `.skinned.bin` thumbnail rendering follows the runtime work.                                |
+| Runtime-side `.skinned.bin` / `.anim.bin`    | `MeshCache` loads `.mesh.bin`. A `SkinnedMeshCache` and ECS-driven animation playback are planned alongside the cook/package work.|
+| Cook / package integration                  | Out of HORO-89 scope; tracked under HORO-24 (Cooked asset cache generation and release artifact packaging).                       |
+
+## On-disk artefact formats
+
+All formats are little-endian and have versioned headers; readers reject
+mismatched magic / version cleanly.
+
+### `<stem>.mesh.bin` — HoroMeshBin v1 (static mesh)
+
+48-byte header followed by `Vertex` records and `uint32_t` indices.
+See `renderer/MeshBin.h` for the full layout.
+
+### `<stem>.skinned.bin` — HoroSkinnedBin v1 (skinned mesh + skeleton)
+
+64-byte header followed by `SkinnedVertex` records, `uint32_t` indices, and
+per-bone records (parent index + 16-float column-major inverse-bind matrix +
+length-prefixed name).
+See `renderer/SkinnedMeshBin.h` for the full layout.
+
+### `<stem>.anim.bin` — HoroAnimBin v1 (animation clips)
+
+32-byte header followed by per-clip records (name, duration, track count) and
+per-track records (`boneIndex` + position / rotation / scale time arrays with
+their value arrays).
+See `renderer/AnimBin.h` for the full layout.
+
+## Diagnostic codes
+
+The importer emits typed diagnostic codes from
+`Horo::Editor::DiagnosticCodes` (header: `ui/editor/AssetImportDiagnosticCodes.h`).
+Codes are part of the public diagnostic contract — never rename or repurpose
+an existing constant.
+
+| Code                                      | Severity | Meaning                                                                  |
+|-------------------------------------------|----------|--------------------------------------------------------------------------|
+| `asset.fbx.unsupported_type`              | Error    | Source file is not `.fbx`.                                                |
+| `asset.fbx.source_missing`                | Error    | Source path does not resolve to a regular file.                          |
+| `asset.fbx.create_directory_failed`       | Error    | Managed asset directory could not be created.                            |
+| `asset.fbx.parse_failed`                  | Error    | ufbx rejected the file (corrupt or unsupported variant).                 |
+| `asset.fbx.no_geometry`                   | Error    | File parsed but contains no triangulable mesh data.                      |
+| `asset.fbx.mesh_write_failed`             | Error    | `.mesh.bin` could not be written to managed storage.                     |
+| `asset.fbx.skeleton_missing`              | Warning/Error | Skin clusters reference bones that could not be linked.             |
+| `asset.fbx.skeleton_write_failed`         | Error    | `.skinned.bin` could not be written.                                     |
+| `asset.fbx.animation_write_failed`        | Warning  | `.anim.bin` could not be written; mesh import still succeeds.            |
+| `asset.fbx.external_texture_missing`      | Warning  | External texture referenced by the FBX could not be resolved on disk.    |
+| `asset.fbx.external_texture_copy_failed`  | Warning  | External texture was located but could not be copied into managed storage. |
+| `asset.fbx.embedded_texture_extract_failed` | Warning | Embedded texture blob could not be written.                              |
+| `asset.fbx.unit_scale_warning`            | Warning  | Reserved for future unit-scale auditing.                                 |
+| `asset.fbx.unsupported_feature_warning`   | Warning  | Reserved for future per-feature gating.                                  |
+
+## Test fixtures
+
+The repository ships small permissive FBX fixtures vendored from the upstream
+ufbx test suite (same MIT license):
+
+| Fixture                                       | Coverage                                       |
+|-----------------------------------------------|------------------------------------------------|
+| `cube_5800_binary.fbx`                        | HORO-94 static mesh, HORO-108 animation extraction (`Take 001`). |
+| `cube_texture_5800_binary.fbx`                | HORO-95/96 — embedded video texture.           |
+| `embedded_textures_7400_binary.fbx`           | HORO-95/96 — multi-channel embedded textures.  |
+| `external_texture_6100_binary.fbx`            | HORO-95 — external reference, no embedded.     |
+| `skinned_7400_binary.fbx`                     | HORO-107 — skinned mesh + skeleton.            |
+
+## Related documents
+
+- [module-boundaries.md](./module-boundaries.md)
+- [ownership-lifecycle.md](./ownership-lifecycle.md)

--- a/tests/test_fbx_import.cpp
+++ b/tests/test_fbx_import.cpp
@@ -1067,3 +1067,134 @@ TEST_CASE("FbxAssetImporter: skinned FBX without animation does NOT produce .ani
                                      return p.ends_with(".anim.bin");
                                    }));
 }
+
+// ===========================================================================
+// HORO-104 + HORO-105 + HORO-110 — bundled FBX import test sweep
+// ===========================================================================
+// HORO-104 (importer fixtures), HORO-105 (editor integration), and HORO-110
+// (skinned + animation regression) were planned as a final bundled test pass.
+// The per-feature PRs in this stack already shipped most of the coverage; this
+// section adds the end-to-end consolidations that tie everything together
+// across the public surface.
+
+#include "ui/editor/components/EditorImportAssetModal.h"
+
+TEST_CASE("E2E: Import Asset modal drives FBX import all the way to producedFiles",
+          "[editor][asset-import][fbx][e2e]") {
+  const std::filesystem::path root =
+      Horo::Tests::SecureTempBase() / "horo_e2e_modal_fbx";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  std::filesystem::create_directories(root / "assets" / "models", ec);
+  WriteFile(root / "CMakePresets.json", "{}");
+  ProjectPathGuard guard(root);
+
+  AssetImporterRegistry registry;
+  EditorImportAssetModal modal;
+
+  // 1. User opens the modal seeded with an FBX path; importer is auto-selected.
+  modal.Open(FixturePath("cube_5800_binary.fbx"), &registry);
+  REQUIRE(modal.IsOpen());
+  REQUIRE(modal.DraftForTest().importerId == "builtin.fbx_static_mesh");
+  REQUIRE(modal.DraftForTest().assetId == "cube_5800_binary");
+
+  // 2. User clicks Import → caller drives the actual import via AssetImportService.
+  modal.RequestImportForTest();
+  REQUIRE(modal.HasPendingRequest());
+  const ImportAssetRequest req = modal.ConsumePendingRequest();
+
+  AssetImportService service;
+  const AssetImportResult result = service.ImportAssetFromSource(
+      req.sourcePath, req.assetId, "guid_e2e_cube",
+      req.displayName.empty() ? req.assetId : req.displayName);
+  REQUIRE(result.ok);
+
+  // 3. Caller pushes the outcome back into the modal; clean import auto-closes it.
+  ImportAssetOutcome outcome;
+  outcome.ok = result.ok;
+  outcome.error = result.error;
+  outcome.assetMesh = result.asset.mesh;
+  outcome.assetAlbedoMap = result.asset.albedoMap;
+  outcome.diagnostics = result.diagnostics;
+  modal.SetLastResult(outcome);
+  CHECK_FALSE(modal.IsOpen());
+
+  // 4. The produced .mesh.bin is on disk and loadable via MeshCache.
+  const std::filesystem::path meshAbs = root / result.asset.mesh;
+  REQUIRE(std::filesystem::is_regular_file(meshAbs));
+  MeshCache cache;
+  const std::shared_ptr<Mesh> mesh = cache.Get(meshAbs.string());
+  REQUIRE(mesh != nullptr);
+  REQUIRE(mesh->GetIndexCount() > 0);
+  REQUIRE_FALSE(mesh->GetVertices().empty());
+}
+
+TEST_CASE("E2E: skinned + animated FBX yields .skinned.bin and (when present) .anim.bin",
+          "[editor][asset-import][fbx][skeletal][animation][e2e]") {
+  // Pin the regression: the skinned fixture has no anim_stacks, so the import
+  // must produce .skinned.bin but not a .anim.bin. This confirms HORO-107 +
+  // HORO-108 cooperate without false positives.
+  const std::filesystem::path root =
+      Horo::Tests::SecureTempBase() / "horo_e2e_skinned_no_anim";
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  std::filesystem::create_directories(root / "assets" / "models", ec);
+  WriteFile(root / "CMakePresets.json", "{}");
+  ProjectPathGuard guard(root);
+
+  AssetImportService service;
+  const std::string source = FixturePath("skinned_7400_binary.fbx");
+  const AssetImportResult result = service.ImportAssetFromSource(
+      source, "skinned_e2e", "guid_skinned_e2e", "Skinned E2E", {});
+  REQUIRE(result.ok);
+  CHECK(result.asset.mesh.ends_with(".skinned.bin"));
+
+  AssetMetadata metadata;
+  std::string metaError;
+  REQUIRE(LoadAssetMetadata("guid_skinned_e2e", &metadata, &metaError));
+
+  bool sawSkinnedBin = false;
+  bool sawAnimBin = false;
+  for (const std::string &p: metadata.producedFiles) {
+    if (p.ends_with(".skinned.bin")) sawSkinnedBin = true;
+    if (p.ends_with(".anim.bin")) sawAnimBin = true;
+  }
+  CHECK(sawSkinnedBin);
+  CHECK_FALSE(sawAnimBin); // fixture has no anim_stacks
+}
+
+TEST_CASE("E2E: drag-drop predicate accepts both .obj and .fbx",
+          "[editor][asset-import][fbx][drag-drop][e2e]") {
+  // ProcessPendingMeshDrops dispatches by IsObjFilePath || IsFbxFilePath.
+  // Pin both predicates here so a future widening that re-introduces an
+  // .fbx-only or .obj-only path breaks this test loudly.
+  REQUIRE(IsObjFilePath("/x/y/cube.obj"));
+  REQUIRE(IsFbxFilePath("/x/y/cube.fbx"));
+  REQUIRE_FALSE(IsObjFilePath("/x/y/cube.fbx"));
+  REQUIRE_FALSE(IsFbxFilePath("/x/y/cube.obj"));
+}
+
+TEST_CASE("E2E: every vendored FBX fixture loads without parse error",
+          "[fbx][loader][e2e]") {
+  // Coverage map for the fixtures vendored across this stack:
+  // - cube_5800_binary           HORO-94 + HORO-108 (animation extraction).
+  // - cube_texture_5800_binary   HORO-95/96 (embedded video texture).
+  // - embedded_textures_7400     HORO-95/96 (multi-channel embedded textures).
+  // - external_texture_6100      HORO-95   (external reference, no embedded).
+  // - skinned_7400_binary        HORO-107  (skinned mesh + skeleton).
+  const std::vector<std::string> fixtures = {
+      "cube_5800_binary.fbx",
+      "cube_texture_5800_binary.fbx",
+      "embedded_textures_7400_binary.fbx",
+      "external_texture_6100_binary.fbx",
+      "skinned_7400_binary.fbx",
+  };
+  for (const std::string &f: fixtures) {
+    INFO("fixture: " << f);
+    const std::string path = FixturePath(f);
+    REQUIRE(std::filesystem::exists(path));
+    const FbxLoader::FbxLoadResult result = FbxLoader::LoadStaticMesh(path);
+    REQUIRE(result.ok);
+    CHECK(result.error.empty());
+  }
+}


### PR DESCRIPTION
Bundled final test pass for HORO-89. Adds four end-to-end tests that consolidate the per-feature coverage shipped across HORO-91..HORO-108. See commit message for full per-ticket coverage map.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four end-to-end tests that pin FBX import behavior across the editor and loader, and publishes the architecture doc covering the FBX import support matrix and limitations (HORO-106).
Covers modal-driven import (auto-selects `builtin.fbx_static_mesh`, auto-closes on success, produced `.mesh.bin` loads via `MeshCache`), skinned fixture with no anim stacks (`.skinned.bin` yes, `.anim.bin` no), drag‑drop predicate parity (`.obj`/`.fbx`), and a sweep verifying all vendored FBX fixtures load via `FbxLoader::LoadStaticMesh` without parse errors; closes HORO-104, HORO-105, HORO-110.

<sup>Written for commit 9520bef3a07c34f961f57a64e033dedc112c21a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

